### PR TITLE
docs: Add ASF related files

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,6 +43,8 @@ github:
         required_approving_review_count: 1
     gh-pages:
       whatever: Just a placeholder to make it take effects
+  collaborators:
+    - Xuanwo
 
 notifications:
   commits: commits@paimon.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See: https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
+
+github:
+  description: "Apache Paimon Rust The rust implementation of Apache Paimon."
+  homepage: https://paimon.apache.org/
+  labels:
+    - rust
+    - paimon
+    - streaming-datalake
+    - real-time-analytics
+    - data-ingestion
+    - big-data
+    - table-store
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: false
+  features:
+    issues: true
+    discussions: true
+    wiki: false
+    projects: false
+  protected_branches:
+    main:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+    gh-pages:
+      whatever: Just a placeholder to make it take effects
+
+notifications:
+  commits: commits@paimon.apache.org
+  issues: issues@paimon.apache.org
+  pullrequests: issues@paimon.apache.org

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11
+          - macos-latest
           - windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11
+          - macos-latest
           - windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Apache Paimon Rust
+Copyright 2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [Latest Version]: https://img.shields.io/crates/v/paimon.svg
 [crates.io]: https://crates.io/crates/paimon
 
-The rust impelmation of Apache Paimon. 
+The rust implementation of Apache Paimon. 
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Check out the [CONTRIBUTING.md](./CONTRIBUTING.md) guide for more details on get
 
 ## Getting help
 
-Submit [issues](https://github.com/apache/paimon/issues/new/choose) for bug report or asking questions in [discussion](https://github.com/apache/paimon/discussions/new?category=q-a).
+Submit [issues](https://github.com/apache/paimon-rust/issues/new/choose) for bug report or asking questions in [discussion](https://github.com/apache/paimon-rust/discussions/new?category=q-a).
 
 #### License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apache Paimon Rust &emsp; [![Build Status]][actions] [![Latest Version]][crates.io]
 
 [Build Status]: https://img.shields.io/github/actions/workflow/status/apache/paimon/ci.yml
-[actions]: https://github.com/apache/paimon/actions?query=branch%3Amain
+[actions]: https://github.com/apache-rust/paimon/actions?query=branch%3Amain
 [Latest Version]: https://img.shields.io/crates/v/paimon.svg
 [crates.io]: https://crates.io/crates/paimon
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apache Paimon Rust &emsp; [![Build Status]][actions] [![Latest Version]][crates.io]
 
-[Build Status]: https://img.shields.io/github/actions/workflow/status/apache/paimon/ci.yml
+[Build Status]: https://img.shields.io/github/actions/workflow/status/apache-rust/paimon/ci.yml
 [actions]: https://github.com/apache-rust/paimon/actions?query=branch%3Amain
 [Latest Version]: https://img.shields.io/crates/v/paimon.svg
 [crates.io]: https://crates.io/crates/paimon

--- a/copyright.txt
+++ b/copyright.txt
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */


### PR DESCRIPTION
This PR will add asf related files.

In the asf.yaml, I have the following settings:

- Only allow squash merge.
- enable issues and discussions
- Add protected branches for main
- Add myself as collaborator (for helping manage issues)
- Add notifications the same like `paimon` repo.