### PR TITLE
Remove main branch protect

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,16 +31,12 @@ github:
   enabled_merge_buttons:
     squash: true
     merge: false
-    rebase: false
+    rebase: true
   features:
     issues: true
     discussions: true
     wiki: false
     projects: false
-  protected_branches:
-    main:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
     gh-pages:
       whatever: Just a placeholder to make it take effects
   collaborators:


### PR DESCRIPTION
Every commit will send a email to private:
Protected Branches for paimon-rust.git has been updated

Maybe we don't need to use protect branch?