### PR TITLE
feat: implement BinaryRow deserialization for partition bytes

### DIFF
--- a/crates/paimon/src/spec/data_file.rs
+++ b/crates/paimon/src/spec/data_file.rs
@@ -58,7 +58,7 @@ pub struct BinaryRow {
 
     /// Raw binary data backing this row. Empty when constructed via `new()`.
     /// Populated via `from_bytes()` for partition data from manifest entries.
-    #[serde(skip)]
+    #[serde(with = "serde_bytes")]
     data: Vec<u8>,
 }
 
@@ -524,13 +524,29 @@ mod tests {
     }
 
     #[test]
-    fn test_serde_roundtrip_backward_compat() {
-        // Verify BinaryRow::new(0) serde roundtrip is stable.
+    fn test_serde_roundtrip_empty() {
+        // Verify empty BinaryRow serde roundtrip is stable.
         let row = BinaryRow::new(0);
         let json = serde_json::to_string(&row).unwrap();
         let deserialized: BinaryRow = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.arity(), 0);
         assert!(deserialized.is_empty());
+    }
+
+    #[test]
+    fn test_serde_roundtrip_populated() {
+        // Verify a populated BinaryRow roundtrips correctly with data intact.
+        let mut builder = BinaryRowBuilder::new(2);
+        builder.write_int(0, 42);
+        builder.write_string(1, "hello");
+        let row = builder.build();
+
+        let json = serde_json::to_string(&row).unwrap();
+        let deserialized: BinaryRow = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.arity(), row.arity());
+        assert_eq!(deserialized.data(), row.data());
+        assert_eq!(deserialized.get_int(0), 42);
+        assert_eq!(deserialized.get_string(1), "hello");
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #126 

Implement `BinaryRow` deserialization primitives so partition binary bytes from Paimon manifests can be decoded in Rust.

This PR focuses on the `BinaryRow` capability itself only. Wiring manifest `_PARTITION` bytes into `TableScan` / `TableRead` is intentionally left to #131, and partition path generation is handled separately in #127.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

 This change adds `BinaryRow` decoding APIs but does not change the external storage format.

  The implementation follows Java Paimon's existing `BinaryRow` binary layout, including null-bit layout and inline / variable-length encoding semantics.

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
