### PR TITLE
ci: add release pipeline for go binding

### DIFF
--- a/.github/workflows/release-go-binding.yml
+++ b/.github/workflows/release-go-binding.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ needs.validate.outputs.source_sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ needs.validate.outputs.source_sha }}
 
       - name: Download packaged libraries
         uses: actions/download-artifact@v4

--- a/bindings/go/RELEASE.md
+++ b/bindings/go/RELEASE.md
@@ -99,7 +99,6 @@ submodule tag to contain the embedded artifacts required by Go module consumers.
 - Confirm the release contains all four compressed shared-library assets.
 - Confirm the tag resolves to a commit that contains:
   - `bindings/go/go.mod`
-  - `bindings/go/README.md`
   - `bindings/go/RELEASE.md`
   - the four `libpaimon_c.*.zst` files
 - Record which Rust release tag or baseline commit this Go binding release was


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

  Linked issue: close #136 

  Support publishing the Go binding as a proper Go submodule release so users can install it directly via
  github.com/apache/paimon-rust/bindings/go.

  This change adds a dedicated Go binding release workflow, documents the tagging strategy, and clarifies the release process for
  both RC and GA versions.

  ### Brief change log

  - Add a dedicated GitHub Actions workflow to release the Go binding with submodule tags such as bindings/go/vX.Y.Z and bindings/
    go/vX.Y.Z-rc.N.
  - Add source_ref input to the workflow so each Go binding release is explicitly tied to a reviewed Rust release baseline.
  - Build and package embedded paimon-c shared libraries for:
      - linux/amd64
      - linux/arm64
      - darwin/amd64
      - darwin/arm64
  - Add a detailed release checklist in bindings/go/RELEASE.md, including:
      - tagging strategy
      - RC/GA version conventions
      - release validation steps
      - baseline tracking guidance

  ### Tests
N/A

  ### API and Format
N/A

  ### Documentation
  - Add bindings/go/RELEASE.md to document the release checklist and tagging strategy.
