### PR TITLE
feat(table): support column projection in ReadBuilder

### DIFF
--- a/crates/integration_tests/tests/read_tables.rs
+++ b/crates/integration_tests/tests/read_tables.rs
@@ -28,15 +28,19 @@ fn get_test_warehouse() -> String {
 }
 
 async fn scan_and_read(table_name: &str) -> (Plan, Vec<RecordBatch>) {
-    let warehouse = get_test_warehouse();
-    let catalog = FileSystemCatalog::new(warehouse).expect("Failed to create catalog");
-    let identifier = Identifier::new("default", table_name);
-    let table = catalog
-        .get_table(&identifier)
-        .await
-        .expect("Failed to get table");
+    scan_and_read_with_projection(table_name, None).await
+}
 
-    let read_builder = table.new_read_builder();
+async fn scan_and_read_with_projection(
+    table_name: &str,
+    projection: Option<&[&str]>,
+) -> (Plan, Vec<RecordBatch>) {
+    let table = get_test_table(table_name).await;
+
+    let mut read_builder = table.new_read_builder();
+    if let Some(cols) = projection {
+        read_builder.with_projection(cols);
+    }
     let scan = read_builder.new_scan();
     let plan = scan.plan().await.expect("Failed to plan scan");
 
@@ -306,38 +310,10 @@ async fn get_test_table(table_name: &str) -> paimon::Table {
 
 #[tokio::test]
 async fn test_read_with_column_projection() {
-    let table = get_test_table("partitioned_log_table").await;
+    let (_, batches) =
+        scan_and_read_with_projection("partitioned_log_table", Some(&["name", "id"])).await;
 
-    let plan = table
-        .new_read_builder()
-        .new_scan()
-        .plan()
-        .await
-        .expect("Failed to plan scan");
-
-    // Input order ["name", "id"] — output must preserve this order (not schema order).
-    let read = table
-        .new_read_builder()
-        .with_projection(&["name", "id"])
-        .new_read()
-        .expect("Failed to create projected read");
-
-    let field_names: Vec<&str> = read.read_type().iter().map(|f| f.name()).collect();
-    assert_eq!(
-        field_names,
-        vec!["name", "id"],
-        "read_type should preserve caller-specified order"
-    );
-
-    let stream = read
-        .to_arrow(plan.splits())
-        .expect("Failed to create arrow stream");
-    let batches: Vec<RecordBatch> = stream
-        .try_collect()
-        .await
-        .expect("Failed to collect batches");
-    assert!(!batches.is_empty());
-
+    // Verify that output schema preserves caller-specified column order.
     for batch in &batches {
         let schema = batch.schema();
         let batch_field_names: Vec<&str> =
@@ -366,9 +342,9 @@ async fn test_read_with_column_projection() {
 async fn test_read_projection_empty() {
     let table = get_test_table("simple_log_table").await;
 
-    let read = table
-        .new_read_builder()
-        .with_projection(&[])
+    let mut read_builder = table.new_read_builder();
+    read_builder.with_projection(&[]);
+    let read = read_builder
         .new_read()
         .expect("Empty projection should succeed");
 
@@ -407,9 +383,9 @@ async fn test_read_projection_empty() {
 async fn test_read_projection_unknown_column() {
     let table = get_test_table("simple_log_table").await;
 
-    let err = table
-        .new_read_builder()
-        .with_projection(&["id", "nonexistent_column"])
+    let mut read_builder = table.new_read_builder();
+    read_builder.with_projection(&["id", "nonexistent_column"]);
+    let err = read_builder
         .new_read()
         .expect_err("Unknown columns should fail");
 
@@ -429,9 +405,9 @@ async fn test_read_projection_unknown_column() {
 async fn test_read_projection_all_invalid() {
     let table = get_test_table("simple_log_table").await;
 
-    let err = table
-        .new_read_builder()
-        .with_projection(&["nonexistent_a", "nonexistent_b"])
+    let mut read_builder = table.new_read_builder();
+    read_builder.with_projection(&["nonexistent_a", "nonexistent_b"]);
+    let err = read_builder
         .new_read()
         .expect_err("All-invalid projection should fail");
 
@@ -451,9 +427,9 @@ async fn test_read_projection_all_invalid() {
 async fn test_read_projection_duplicate_column() {
     let table = get_test_table("simple_log_table").await;
 
-    let err = table
-        .new_read_builder()
-        .with_projection(&["id", "id"])
+    let mut read_builder = table.new_read_builder();
+    read_builder.with_projection(&["id", "id"]);
+    let err = read_builder
         .new_read()
         .expect_err("Duplicate projection should fail");
 

--- a/crates/paimon/src/arrow/reader.rs
+++ b/crates/paimon/src/arrow/reader.rs
@@ -133,11 +133,13 @@ impl ArrowReader {
                         ParquetRecordBatchStreamBuilder::new(arrow_file_reader)
                             .await?;
                     // ProjectionMask preserves parquet-schema order; read_type order is restored below.
-                    let parquet_schema = batch_stream_builder.parquet_schema().clone();
-                    let mask = ProjectionMask::columns(
-                        &parquet_schema,
-                        projected_column_names.iter().map(String::as_str),
-                    );
+                    let mask = {
+                        let parquet_schema = batch_stream_builder.parquet_schema();
+                        ProjectionMask::columns(
+                            parquet_schema,
+                            projected_column_names.iter().map(String::as_str),
+                        )
+                    };
                     batch_stream_builder = batch_stream_builder.with_projection(mask);
 
                     if let Some(dv) = dv {
@@ -163,8 +165,8 @@ impl ArrowReader {
                                 batch.schema().index_of(name).map_err(|_| {
                                     Error::UnexpectedError {
                                         message: format!(
-                                            "Projected column '{}' not found in Parquet batch schema",
-                                            name
+                                            "Projected column '{}' not found in Parquet batch schema of file {}",
+                                            name, path_to_read
                                         ),
                                         source: None,
                                     }

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -48,7 +48,7 @@ impl<'a> ReadBuilder<'a> {
     /// Set column projection by name. Output order follows the caller-specified order.
     /// Unknown or duplicate names cause `new_read()` to fail; an empty list is a valid
     /// zero-column projection.
-    pub fn with_projection(mut self, columns: &[&str]) -> Self {
+    pub fn with_projection(&mut self, columns: &[&str]) -> &mut Self {
         self.projected_fields = Some(columns.iter().map(|c| (*c).to_string()).collect());
         self
     }


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #146 

Add column projection support to `ReadBuilder`, allowing users to specify which columns to read from Parquet data files. This reduces unnecessary I/O for wide tables, especially on remote storage (S3/OSS), by leveraging the existing `ProjectionMask` in the Parquet reader layer.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

- **`crates/paimon/src/table/read_builder.rs`**
  - Add `ReadBuilder::with_projection(&[&str])` — accepts column names, stores them for deferred resolution.
  - Add `resolve_projected_fields` — resolves names to `DataField`s in caller-specified order; rejects unknown columns (`ColumnNotExist`) and duplicates (`ConfigInvalid`).
  - Change `TableRead::read_type` from `&[DataField]` to `Vec<DataField>` to support projected subsets.

- **`crates/paimon/src/arrow/reader.rs`**
  - Always apply `ProjectionMask` to clip Parquet schema to `read_type` columns (previously only applied conditionally).
  - Add column reorder step after Parquet read to guarantee `RecordBatch` schema matches `read_type` order (Parquet `ProjectionMask` returns columns in file-schema order, not projection order).
  - Use fail-fast error propagation instead of silent fallback when projected columns are missing from batch schema.

### Tests

<!-- List unit tests or integration cases to verify this change -->

- `cargo test -p paimon-integration-tests test_read_with_column_projection`
- `cargo test -p paimon-integration-tests test_read_projection_empty`
- `cargo test -p paimon-integration-tests test_read_projection_unknown_column`
- `cargo test -p paimon-integration-tests test_read_projection_all_invalid`
- `cargo test -p paimon-integration-tests test_read_projection_duplicate_column`

### API and Format

<!-- Does this change affect API or storage format -->

- New public API: `ReadBuilder::with_projection(&[&str]) -> Self`
- `TableRead::read_type()` return type changed from `&[DataField]` (borrowed from table schema) to `&[DataField]` (borrowed from owned `Vec<DataField>`). No breaking change for callers.
- No storage format changes.

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
