### PR TITLE
fix: Adjust required_approving_review_count to zero

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,6 +39,10 @@ github:
     projects: false
     gh-pages:
       whatever: Just a placeholder to make it take effects
+  protected_branches:
+    main:
+      required_pull_request_reviews:
+        required_approving_review_count: 0
   collaborators:
     - Xuanwo
 


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
The `required_approving_review_count` is 1 makes merging cumbersome, as two committers must participate in order to merge the code.

Like other Apache Paimon repositories, we don't need to set this parameter to 1.

Previous modification did not work. #8 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
