### PR TITLE
fix: remove invalid gh-pages key from .asf.yaml and add CI validation

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,8 +37,6 @@ github:
     discussions: true
     wiki: false
     projects: false
-    gh-pages:
-      whatever: Just a placeholder to make it take effects
   protected_branches:
     main:
       required_pull_request_reviews:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate .asf.yaml
+        run: python3 scripts/validate_asf_yaml.py
+
       - name: Check License Header
         uses: apache/skywalking-eyes/header@v0.6.0
 

--- a/scripts/validate_asf_yaml.py
+++ b/scripts/validate_asf_yaml.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Validate .asf.yaml against known ASF infrastructure schema.
+
+Reference: https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
+"""
+
+import sys
+import yaml
+
+ASF_YAML_PATH = ".asf.yaml"
+
+# Known top-level keys in .asf.yaml
+VALID_TOP_LEVEL_KEYS = {
+    "github",
+    "notifications",
+    "staging",
+    "publish",
+    "pelican",
+}
+
+# Known keys under 'github'
+VALID_GITHUB_KEYS = {
+    "description",
+    "homepage",
+    "labels",
+    "features",
+    "enabled_merge_buttons",
+    "protected_branches",
+    "collaborators",
+    "autolinks",
+    "environments",
+    "dependabot_alerts",
+    "dependabot_updates",
+    "code_scanning",
+    "del_branch_on_merge",
+    "ghp_branch",
+    "ghp_path",
+}
+
+# Known keys under 'github.features'
+VALID_FEATURES_KEYS = {
+    "issues",
+    "discussions",
+    "wiki",
+    "projects",
+}
+
+# Known keys under 'github.enabled_merge_buttons'
+VALID_MERGE_BUTTON_KEYS = {
+    "squash",
+    "merge",
+    "rebase",
+}
+
+# Known keys under 'notifications'
+VALID_NOTIFICATIONS_KEYS = {
+    "commits",
+    "issues",
+    "pullrequests",
+    "jira_options",
+    "jobs",
+    "discussions",
+}
+
+
+def validate():
+    errors = []
+
+    try:
+        with open(ASF_YAML_PATH, "r") as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"SKIP: {ASF_YAML_PATH} not found")
+        return 0
+    except yaml.YAMLError as e:
+        print(f"ERROR: Invalid YAML syntax in {ASF_YAML_PATH}: {e}")
+        return 1
+
+    if not isinstance(data, dict):
+        print(f"ERROR: {ASF_YAML_PATH} root must be a mapping")
+        return 1
+
+    # Check top-level keys
+    for key in data:
+        if key not in VALID_TOP_LEVEL_KEYS:
+            errors.append(f"unexpected top-level key '{key}'")
+
+    github = data.get("github")
+    if isinstance(github, dict):
+        for key in github:
+            if key not in VALID_GITHUB_KEYS:
+                errors.append(f"unexpected key 'github.{key}'")
+
+        features = github.get("features")
+        if isinstance(features, dict):
+            for key in features:
+                if key not in VALID_FEATURES_KEYS:
+                    errors.append(
+                        f"unexpected key 'github.features.{key}' "
+                        f"(allowed: {', '.join(sorted(VALID_FEATURES_KEYS))})"
+                    )
+                elif not isinstance(features[key], bool):
+                    errors.append(
+                        f"'github.features.{key}' must be a boolean, "
+                        f"got {type(features[key]).__name__}"
+                    )
+
+        merge_buttons = github.get("enabled_merge_buttons")
+        if isinstance(merge_buttons, dict):
+            for key in merge_buttons:
+                if key not in VALID_MERGE_BUTTON_KEYS:
+                    errors.append(
+                        f"unexpected key 'github.enabled_merge_buttons.{key}' "
+                        f"(allowed: {', '.join(sorted(VALID_MERGE_BUTTON_KEYS))})"
+                    )
+
+    notifications = data.get("notifications")
+    if isinstance(notifications, dict):
+        for key in notifications:
+            if key not in VALID_NOTIFICATIONS_KEYS:
+                errors.append(f"unexpected key 'notifications.{key}'")
+
+    if errors:
+        print(f"ERROR: {ASF_YAML_PATH} validation failed:")
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+
+    print(f"OK: {ASF_YAML_PATH} is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(validate())


### PR DESCRIPTION
The gh-pages key under github.features is not in the ASF .asf.yaml schema, causing ASF infra errors after merge. Add a validation script to catch such issues in CI before merge.

<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
