### PR TITLE
ci: trigger go release pipeline on release tag push

### DIFF
--- a/.github/workflows/release-go-binding.yml
+++ b/.github/workflows/release-go-binding.yml
@@ -18,14 +18,20 @@
 name: Release Go Binding
 
 on:
+  push:
+    tags:
+      # Trigger this workflow when tag follows the versioning format: v<major>.<minor>.<patch> OR v<major>.<minor>.<patch>-rc<release_candidate>
+      # Example valid tags: v0.4.0, v0.4.0-rc1
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
   workflow_dispatch:
     inputs:
       version:
-        description: Release version, for example v0.1.0 or v0.1.0-rc.1
+        description: Release version, for example v0.1.0 or v0.1.0-rc1
         required: true
         type: string
       source_ref:
-        description: Rust release baseline ref, for example main, v0.1.0-rc.1, or a commit SHA
+        description: Rust release baseline ref, for example main, v0.1.0-rc1, or a commit SHA
         required: true
         type: string
 
@@ -36,20 +42,33 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     outputs:
+      version: ${{ steps.meta.outputs.version }}
+      source_ref: ${{ steps.meta.outputs.source_ref }}
       tag: ${{ steps.meta.outputs.tag }}
       source_sha: ${{ steps.meta.outputs.source_sha }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ inputs.source_ref || github.sha }}
 
       - name: Validate release version and tag
         id: meta
         shell: bash
         run: |
-          version='${{ inputs.version }}'
-          source_ref='${{ inputs.source_ref }}'
+          event_name='${{ github.event_name }}'
+          version=''
+          source_ref=''
+
+          if [[ "$event_name" == "workflow_dispatch" ]]; then
+            version='${{ inputs.version }}'
+            source_ref='${{ inputs.source_ref }}'
+          else
+            tag_name='${{ github.ref_name }}'
+            source_ref='${{ github.sha }}'
+            version="$tag_name"
+          fi
+
           if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
             echo "invalid version: $version; expected vX.Y.Z or vX.Y.Z-rc.N" >&2
             exit 1
@@ -71,6 +90,8 @@ jobs:
           fi
 
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
           echo "source_sha=$(git rev-parse "$source_ref^{commit}")" >> "$GITHUB_OUTPUT"
 
   build:
@@ -158,8 +179,8 @@ jobs:
       - name: Create release tag commit
         env:
           TAG: ${{ needs.validate.outputs.tag }}
-          VERSION: ${{ inputs.version }}
-          SOURCE_REF: ${{ inputs.source_ref }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          SOURCE_REF: ${{ needs.validate.outputs.source_ref }}
           SOURCE_SHA: ${{ needs.validate.outputs.source_sha }}
         shell: bash
         run: |


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #165 

Enable Go binding release pipeline to run automatically on version tags, while preserving manual release capability.

<!-- What is the purpose of the change -->

### Brief change log

- Update `.github/workflows/release-go-binding.yml` trigger from release/rc branches to version-like tags:
  - `on.push.tags: ["v*"]`
- Keep `workflow_dispatch` as a manual fallback path.
- Adjust validation logic for non-dispatch events:
  - derive `version` from pushed tag name (`github.ref_name`)
  - derive `source_ref` from `github.sha`
- Make checkout ref safe for both trigger types:
  - `ref: ${{ inputs.source_ref || github.sha }}`
- Keep existing release validation and artifact publishing flow unchanged.

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests
Already verify it in my own fork. 

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
