### PR TITLE
chore(provision): make Spark integration test provisioning idempotent

### DIFF
--- a/dev/spark/provision.py
+++ b/dev/spark/provision.py
@@ -20,11 +20,49 @@
 # Provisions Paimon tables into the warehouse (file:/tmp/paimon-warehouse)
 # for paimon-rust integration tests to read.
 
+import shutil
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
 from pyspark.sql import SparkSession
+
+
+def _warehouse_path_from_spark_conf(spark: SparkSession) -> Path:
+    warehouse_uri = spark.conf.get("spark.sql.catalog.paimon.warehouse")
+    parsed = urlparse(warehouse_uri)
+
+    if parsed.scheme not in ("", "file"):
+        raise ValueError(
+            f"Unsupported Paimon warehouse URI scheme {parsed.scheme!r}: {warehouse_uri}"
+        )
+
+    if parsed.netloc not in ("", "localhost"):
+        raise ValueError(
+            f"Unsupported remote Paimon warehouse location {parsed.netloc!r}: {warehouse_uri}"
+        )
+
+    warehouse_path = Path(unquote(parsed.path if parsed.scheme else warehouse_uri))
+    if not warehouse_path.is_absolute() or str(warehouse_path) == "/":
+        raise ValueError(f"Refusing to clear unsafe warehouse path: {warehouse_path}")
+
+    return warehouse_path
+
+
+def _reset_warehouse_dir(warehouse_path: Path) -> None:
+    warehouse_path.mkdir(parents=True, exist_ok=True)
+
+    for child in warehouse_path.iterdir():
+        if child.is_symlink() or child.is_file():
+            child.unlink()
+        else:
+            shutil.rmtree(child)
 
 
 def main():
     spark = SparkSession.builder.getOrCreate()
+
+    warehouse_path = _warehouse_path_from_spark_conf(spark)
+    _reset_warehouse_dir(warehouse_path)
 
     # Use Paimon catalog (configured in spark-defaults.conf with warehouse file:/tmp/paimon-warehouse)
     spark.sql("USE paimon.default")


### PR DESCRIPTION
### Purpose

Make Spark-based integration test fixture provisioning idempotent.

`dev/spark/provision.py` previously used `CREATE TABLE IF NOT EXISTS` together with unconditional `INSERT INTO` statements. Re-running provisioning against the same warehouse caused append/log tables to accumulate duplicate rows, which made the test fixture non-deterministic and broke integration tests.

### Brief change log

- Resolve the configured Paimon warehouse path from Spark config
- Clear the existing warehouse contents before provisioning test fixtures
- Keep the existing table definitions and fixture data unchanged
- Preserve the current reader behavior and test expectations while making repeated provisioning deterministic

This approach fits the current repository architecture because the integration tests assert exact fixture contents, while append tables are read as appended data rather than deduplicated business rows. Resetting the whole warehouse before provisioning is the most reliable way to keep the fixture stable across append tables, DV PK tables, and data evolution tables.

### Tests

Verified idempotent provisioning by running fixture setup twice against the same warehouse, then running:

- `cargo test -p paimon-integration-tests --test read_tables`
- `cargo test -p paimon-datafusion --test read_tables`

### API and Format

### Documentation
