### PR TITLE
chore: remove obsolete allow(dead_code) annotations

### DIFF
--- a/bindings/c/src/error.rs
+++ b/bindings/c/src/error.rs
@@ -21,7 +21,6 @@ use crate::types::paimon_bytes;
 
 /// Error codes for paimon C API.
 #[repr(i32)]
-#[allow(dead_code)]
 pub enum PaimonErrorCode {
     Unexpected = 0,
     Unsupported = 1,

--- a/crates/paimon/src/catalog/filesystem.rs
+++ b/crates/paimon/src/catalog/filesystem.rs
@@ -67,7 +67,6 @@ pub struct FileSystemCatalog {
     warehouse: String,
 }
 
-#[allow(dead_code)]
 impl FileSystemCatalog {
     /// Create a new filesystem catalog from configuration options.
     ///

--- a/crates/paimon/src/catalog/mod.rs
+++ b/crates/paimon/src/catalog/mod.rs
@@ -35,23 +35,18 @@ pub use rest::*;
 use serde::{Deserialize, Serialize};
 
 /// Splitter for system table names (e.g. `table$snapshots`).
-#[allow(dead_code)]
 pub const SYSTEM_TABLE_SPLITTER: &str = "$";
 /// Prefix for branch in object name (e.g. `table$branch_foo`).
-#[allow(dead_code)]
 pub const SYSTEM_BRANCH_PREFIX: &str = "branch_";
 /// Default main branch name.
-#[allow(dead_code)]
 pub const DEFAULT_MAIN_BRANCH: &str = "main";
 /// Database value when the database is not known; [`Identifier::full_name`] returns only the object.
 pub const UNKNOWN_DATABASE: &str = "unknown";
 /// Database property key for custom location. Not allowed for filesystem catalog.
 /// See [Catalog.DB_LOCATION_PROP](https://github.com/apache/paimon/blob/release-1.3/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java).
-#[allow(dead_code)] // Public API - allow unused until used by external code
 pub const DB_LOCATION_PROP: &str = "location";
 /// Suffix for database directory names in the filesystem (e.g. `mydb.db`).
 /// See [Catalog.DB_SUFFIX](https://github.com/apache/paimon/blob/release-1.3/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java).
-#[allow(dead_code)] // Public API - allow unused until used by external code
 pub const DB_SUFFIX: &str = ".db";
 
 // ======================= Identifier ===============================
@@ -70,7 +65,6 @@ pub struct Identifier {
     object: String,
 }
 
-#[allow(dead_code)]
 impl Identifier {
     /// Create an identifier from database and object name.
     pub fn new(database: impl Into<String>, object: impl Into<String>) -> Self {
@@ -128,7 +122,6 @@ use crate::Result;
 ///
 /// Corresponds to [org.apache.paimon.catalog.Catalog](https://github.com/apache/paimon/blob/release-1.3/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java).
 #[async_trait]
-#[allow(dead_code)]
 pub trait Catalog: Send + Sync {
     // ======================= database methods ===============================
 

--- a/crates/paimon/src/deletion_vector/core.rs
+++ b/crates/paimon/src/deletion_vector/core.rs
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-#![allow(dead_code)]
 
 use roaring::RoaringBitmap;
 use std::sync::Arc;
@@ -50,18 +49,6 @@ impl DeletionVector {
         }
     }
 
-    /// Check if a row at the given position is deleted
-    pub fn is_deleted(&self, row_position: u64) -> crate::Result<bool> {
-        // RoaringBitmap32 in Java supports up to 2^31-1, so we check i32 range
-        if row_position > i32::MAX as u64 {
-            return Err(crate::Error::UnexpectedError {
-                message: format!("The file has too many rows, RoaringBitmap32 only supports files with row count not exceeding {}.", i32::MAX),
-                source: None,
-            });
-        }
-        Ok(self.bitmap.contains(row_position as u32))
-    }
-
     /// Returns an iterator over deleted positions that supports [DeletionVectorIterator::advance_to].
     /// Required for efficient row selection building when skipping row groups (avoid re-scanning
     /// deletes in skipped ranges).
@@ -74,18 +61,14 @@ impl DeletionVector {
         DeletionVectorIterator::new(self.bitmap.iter().map(u64::from).collect())
     }
 
-    /// Get the number of deleted rows (cardinality)
-    pub fn deleted_count(&self) -> u64 {
-        self.bitmap.len()
-    }
-
     /// Check if the deletion vector is empty (no deleted rows)
     pub fn is_empty(&self) -> bool {
         self.bitmap.is_empty()
     }
 
     /// Get the underlying bitmap (read-only)
-    pub fn bitmap(&self) -> &RoaringBitmap {
+    #[cfg(test)]
+    fn bitmap(&self) -> &RoaringBitmap {
         &self.bitmap
     }
 
@@ -225,9 +208,5 @@ mod tests {
 
         let expected_bitmap = RoaringBitmap::from_iter([1u32, 2u32]);
         assert_eq!(dv.bitmap(), &expected_bitmap, "bitmap should be [1, 2]");
-        assert_eq!(dv.deleted_count(), 2);
-        assert!(dv.is_deleted(1).unwrap());
-        assert!(dv.is_deleted(2).unwrap());
-        assert!(!dv.is_deleted(0).unwrap());
     }
 }

--- a/crates/paimon/src/deletion_vector/factory.rs
+++ b/crates/paimon/src/deletion_vector/factory.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![allow(dead_code)]
-
 use crate::deletion_vector::core::DeletionVector;
 use crate::io::{FileIO, FileRead};
 use crate::spec::DataFileMeta;

--- a/crates/paimon/src/spec/data_file.rs
+++ b/crates/paimon/src/spec/data_file.rs
@@ -428,7 +428,6 @@ impl Display for DataFileMeta {
     }
 }
 
-#[allow(dead_code)]
 impl DataFileMeta {
     /// Returns the row ID range `[first_row_id, first_row_id + row_count - 1]` if `first_row_id` is set.
     pub fn row_id_range(&self) -> Option<(i64, i64)> {

--- a/crates/paimon/src/spec/index_manifest.rs
+++ b/crates/paimon/src/spec/index_manifest.rs
@@ -28,7 +28,6 @@ use crate::Result;
 /// Manifest entry for index file.
 ///
 /// Impl Reference: <https://github.com/apache/paimon/blob/release-0.8.2/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java>
-#[allow(dead_code)] // Part of spec; used when index manifest is implemented.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IndexManifestEntry {
     #[serde(rename = "_KIND")]

--- a/crates/paimon/src/spec/manifest.rs
+++ b/crates/paimon/src/spec/manifest.rs
@@ -30,7 +30,6 @@ use crate::Result;
 /// Impl Reference: <https://github.com/apache/paimon/blob/release-1.3/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java>
 pub struct Manifest;
 
-#[allow(dead_code)]
 impl Manifest {
     /// Read manifest entries from a file.
     ///

--- a/crates/paimon/src/spec/objects_file.rs
+++ b/crates/paimon/src/spec/objects_file.rs
@@ -19,7 +19,6 @@ use serde::de::DeserializeOwned;
 use serde_avro_fast::object_container_file_encoding::Reader;
 use snafu::ResultExt;
 
-#[allow(dead_code)]
 pub fn from_avro_bytes<T: DeserializeOwned>(bytes: &[u8]) -> crate::Result<Vec<T>> {
     let mut reader = Reader::from_slice(bytes)
         .whatever_context::<_, crate::Error>("read avro object container")?;

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -50,7 +50,6 @@ pub struct Table {
     schema_manager: SchemaManager,
 }
 
-#[allow(dead_code)]
 impl Table {
     /// Create a new table.
     pub fn new(

--- a/crates/paimon/src/table/source.rs
+++ b/crates/paimon/src/table/source.rs
@@ -19,8 +19,6 @@
 //!
 //! Reference: [org.apache.paimon.table.source](https://github.com/apache/paimon/blob/master/paimon-core/src/main/java/org/apache/paimon/table/source/).
 
-#![allow(dead_code)]
-
 use crate::spec::{BinaryRow, DataFileMeta};
 use crate::table::table_scan::group_by_overlapping_row_id;
 use serde::{Deserialize, Serialize};

--- a/crates/paimon/tests/mock_server.rs
+++ b/crates/paimon/tests/mock_server.rs
@@ -53,8 +53,7 @@ struct MockState {
 #[derive(Clone)]
 pub struct RESTServer {
     warehouse: String,
-    #[allow(dead_code)]
-    data_path: String,
+    _data_path: String,
     config: ConfigResponse,
     inner: Arc<Mutex<MockState>>,
     resource_paths: ResourcePaths,
@@ -62,11 +61,12 @@ pub struct RESTServer {
     server_handle: Option<Arc<JoinHandle<()>>>,
 }
 
+#[allow(dead_code)]
 impl RESTServer {
     /// Create a new RESTServer with initial databases.
     pub fn new(
         warehouse: String,
-        data_path: String,
+        _data_path: String,
         config: ConfigResponse,
         initial_dbs: Vec<String>,
     ) -> Self {
@@ -88,7 +88,7 @@ impl RESTServer {
             .collect();
 
         RESTServer {
-            data_path,
+            _data_path,
             config,
             warehouse,
             inner: Arc::new(Mutex::new(MockState {
@@ -521,7 +521,6 @@ impl RESTServer {
     }
     // ====================== Server Control ====================
     /// Add a database to the server state.
-    #[allow(dead_code)]
     pub fn add_database(&self, name: &str) {
         let mut s = self.inner.lock().unwrap();
         s.databases.entry(name.to_string()).or_insert_with(|| {
@@ -535,14 +534,12 @@ impl RESTServer {
         });
     }
     /// Add a no-permission database to the server state.
-    #[allow(dead_code)]
     pub fn add_no_permission_database(&self, name: &str) {
         let mut s = self.inner.lock().unwrap();
         s.no_permission_databases.insert(name.to_string());
     }
 
     /// Add a table to the server state.
-    #[allow(dead_code)]
     pub fn add_table(&self, database: &str, table: &str) {
         let mut s = self.inner.lock().unwrap();
         s.databases.entry(database.to_string()).or_insert_with(|| {
@@ -574,7 +571,6 @@ impl RESTServer {
     ///
     /// This is needed for `RESTCatalog::get_table` which requires
     /// the response to contain `schema` and `path`.
-    #[allow(dead_code)]
     pub fn add_table_with_schema(
         &self,
         database: &str,
@@ -609,7 +605,6 @@ impl RESTServer {
     }
 
     /// Add a no-permission table to the server state.
-    #[allow(dead_code)]
     pub fn add_no_permission_table(&self, database: &str, table: &str) {
         let mut s = self.inner.lock().unwrap();
         s.no_permission_tables.insert(format!("{database}.{table}"));
@@ -619,7 +614,6 @@ impl RESTServer {
         self.addr.map(|a| format!("http://{a}"))
     }
     /// Get the warehouse path.
-    #[allow(dead_code)]
     pub fn warehouse(&self) -> &str {
         &self.warehouse
     }
@@ -629,13 +623,11 @@ impl RESTServer {
         &self.resource_paths
     }
     /// Get the server address.
-    #[allow(dead_code)]
     pub fn addr(&self) -> Option<SocketAddr> {
         self.addr
     }
 
     /// Set ECS metadata role name and token for token loader testing.
-    #[allow(dead_code)]
     pub fn set_ecs_metadata(&self, role_name: &str, token: serde_json::Value) {
         let mut s = self.inner.lock().unwrap();
         s.ecs_role_name = Some(role_name.to_string());


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

This PR removes allow(dead_code) annotations that were introduced earlier during implementation to temporarily suppress warnings for code that had not yet been wired up.

As the related code paths are now being used, these annotations are no longer necessary. Cleaning them up makes the codebase tidier and helps keep warning suppression limited to cases where it is actually needed.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
