### PR TITLE
doc: add README for published crates

### DIFF
--- a/crates/integrations/datafusion/Cargo.toml
+++ b/crates/integrations/datafusion/Cargo.toml
@@ -20,7 +20,9 @@ name = "paimon-datafusion"
 edition.workspace = true
 version.workspace = true
 license.workspace = true
-description = "Apache Paimon DataFusion Integration (read-only)"
+homepage = "https://paimon.apache.org/docs/rust/datafusion/"
+documentation = "https://docs.rs/paimon-datafusion"
+description = "Apache Paimon DataFusion Integration"
 categories = ["database"]
 keywords = ["paimon", "datafusion", "integrations"]
 
@@ -32,5 +34,4 @@ paimon = { path = "../../paimon" }
 futures = "0.3"
 
 [dev-dependencies]
-serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/integrations/datafusion/README.md
+++ b/crates/integrations/datafusion/README.md
@@ -1,0 +1,27 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+# Apache Paimon DataFusion Integration
+
+[![crates.io](https://img.shields.io/crates/v/paimon-datafusion.svg)](https://crates.io/crates/paimon-datafusion)
+[![docs.rs](https://img.shields.io/docsrs/paimon-datafusion.svg)](https://docs.rs/paimon-datafusion/latest/paimon_datafusion/)
+
+This crate contains the integration of [Apache DataFusion](https://datafusion.apache.org/) and [Apache Paimon](https://paimon.apache.org/).
+
+See the [documentation](https://paimon.apache.org/docs/rust/datafusion/) for getting started guide and more details.

--- a/crates/paimon/Cargo.toml
+++ b/crates/paimon/Cargo.toml
@@ -21,6 +21,7 @@ description = "The rust implementation of Apache Paimon"
 documentation = "https://docs.rs/paimon"
 name = "paimon"
 
+homepage.workspace = true
 repository.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/paimon/README.md
+++ b/crates/paimon/README.md
@@ -1,0 +1,27 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+# Apache Paimon Rust
+
+[![crates.io](https://img.shields.io/crates/v/paimon.svg)](https://crates.io/crates/paimon)
+[![docs.rs](https://img.shields.io/docsrs/paimon.svg)](https://docs.rs/paimon/latest/paimon/)
+
+This crate contains the official Native Rust implementation of [Apache Paimon](https://paimon.apache.org/).
+
+See the [documentation](https://paimon.apache.org/docs/rust/) for getting started guide and more details.


### PR DESCRIPTION
### Purpose

Linked issue: N/A (documentation-only change)

Improve the published crate pages for `paimon` and `paimon-datafusion` by adding crate-specific README files and completing package metadata.

This makes it easier for users to understand the purpose of each crate, find the right documentation, and preview the published presentation before releasing to crates.io.

### Brief change log

- add `README.md` for `crates/paimon` and `crates/integrations/datafusion`
- add `homepage` / `documentation` metadata for the published crates
- remove the unused `serde_json` dependency from `paimon-datafusion`
- publish preview builds to the staging crates registry to verify rendering and package metadata:
  - `paimon`: https://staging.crates.io/crates/paimon
  - `paimon-datafusion`: https://staging.crates.io/crates/paimon-datafusion

### Tests

- `cargo test -p paimon --lib --quiet`

### API and Format

No API or storage format changes.

### Documentation

Yes. This PR adds crate README content and improves crate metadata for published package pages.
