### PR TITLE
ci: add python release pipeline

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -20,8 +20,7 @@
 # Trigger: push a version tag (e.g. v0.1.0, v0.1.0-rc1).
 # Pre-release tags (containing '-') only run dry-run checks without publishing.
 #
-# Auth: set repo variable CARGO_USE_TOKEN_AUTH = 'true' and add secret CARGO_REGISTRY_TOKEN
-# for token-based auth. Otherwise, Trusted Publishing (OIDC) is used.
+# Token auth: add secret CARGO_REGISTRY_TOKEN for crates.io publishing.
 
 name: Release Rust
 
@@ -37,7 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     strategy:
       # Publish crates sequentially to respect dependency order
       max-parallel: 1
@@ -55,15 +53,8 @@ jobs:
       - name: Dry run
         run: cargo publish -p ${{ matrix.package }} --all-features --dry-run
 
-      - name: Get crates.io token (OIDC)
-        if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') && vars.CARGO_USE_TOKEN_AUTH != 'true'
-        uses: rust-lang/crates-io-auth-action@v1
-        id: auth
-        with:
-          token-type: publish
-
       - name: Publish ${{ matrix.package }} to crates.io
         if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-')
         run: cargo publish -p ${{ matrix.package }} --all-features
         env:
-          CARGO_REGISTRY_TOKEN: "${{ vars.CARGO_USE_TOKEN_AUTH == 'true' && secrets.CARGO_REGISTRY_TOKEN || steps.auth.outputs.token }}"
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release_python_binding.yml
+++ b/.github/workflows/release_python_binding.yml
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Publish the paimon Python binding to PyPI.
+# Trigger: push tag only (e.g. v0.1.0).
+# Pre-release tags (containing '-') publish to TestPyPI; release tags publish to PyPI.
+#
+# Token auth: add secrets PYPI_API_TOKEN / TEST_PYPI_API_TOKEN for publishing.
+
+name: Release Python Binding
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          working-directory: bindings/python
+          command: sdist
+          args: -o dist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: bindings/python/dist
+
+  wheels:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - { os: windows-latest }
+          - { os: macos-15-intel, target: "x86_64-apple-darwin" }
+          - { os: macos-latest, target: "aarch64-apple-darwin" }
+          - { os: ubuntu-latest, target: "x86_64" }
+          - { os: ubuntu-latest, target: "aarch64", manylinux: "manylinux_2_28" }
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          working-directory: bindings/python
+          target: ${{ matrix.target }}
+          command: build
+          args: --release -o dist
+          manylinux: ${{ matrix.manylinux || 'auto' }}
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.target || 'native' }}
+          path: bindings/python/dist
+
+  release:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: [sdist, wheels]
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: bindings/python/dist
+
+      - name: Publish to TestPyPI
+        if: contains(github.ref, '-')
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          packages-dir: bindings/python/dist
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+
+      - name: Publish to PyPI
+        if: ${{ !contains(github.ref, '-') }}
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        with:
+          skip-existing: true
+          packages-dir: bindings/python/dist
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### Purpose

Linked issue: close #211

Add a dedicated GitHub Actions release workflow for the Python binding so tagged releases can publish pre-release artifacts to TestPyPI and stable artifacts to PyPI.

### Brief change log

- add `.github/workflows/release_python_binding.yml` to build sdist and platform wheels for `bindings/python`;
- publish release candidates to TestPyPI and stable tags to PyPI based on the pushed tag name;
- upload build artifacts between jobs before the publish step;
- simplify `.github/workflows/release-rust.yml` to use `CARGO_REGISTRY_TOKEN` directly for crates.io publishing.

### Tests

- validated workflow YAML syntax with `ruby -e 'require "yaml"; YAML.load_file(...)'` for the touched workflow files
- did not run `cargo test`; this change only updates GitHub Actions release workflows

### API and Format

No API or storage format changes.

### Documentation

No additional documentation updates are required.
