### PR TITLE
feat(blob): add create-time schema contract checks

### DIFF
--- a/crates/paimon/src/spec/schema.rs
+++ b/crates/paimon/src/spec/schema.rs
@@ -237,6 +237,7 @@ impl Schema {
         let primary_keys = Self::normalize_primary_keys(&primary_keys, &mut options)?;
         let partition_keys = Self::normalize_partition_keys(&partition_keys, &mut options)?;
         let fields = Self::normalize_fields(&fields, &partition_keys, &primary_keys)?;
+        Self::validate_blob_fields(&fields, &partition_keys, &options)?;
 
         Ok(Self {
             fields,
@@ -389,6 +390,54 @@ impl Schema {
             });
         }
         Ok(())
+    }
+
+    fn validate_blob_fields(
+        fields: &[DataField],
+        partition_keys: &[String],
+        options: &HashMap<String, String>,
+    ) -> crate::Result<()> {
+        let blob_field_names = Self::top_level_blob_field_names(fields);
+        if blob_field_names.is_empty() {
+            return Ok(());
+        }
+
+        let core_options = CoreOptions::new(options);
+        if !core_options.data_evolution_enabled() {
+            return Err(crate::Error::ConfigInvalid {
+                message: "Data evolution config must enabled for table with BLOB type column."
+                    .to_string(),
+            });
+        }
+
+        if fields.len() == blob_field_names.len() {
+            return Err(crate::Error::ConfigInvalid {
+                message: "Table with BLOB type column must have other normal columns.".to_string(),
+            });
+        }
+
+        let partition_key_set: HashSet<&str> = partition_keys.iter().map(String::as_str).collect();
+        if blob_field_names
+            .iter()
+            .any(|name| partition_key_set.contains(name))
+        {
+            return Err(crate::Error::ConfigInvalid {
+                message: "The BLOB type column can not be part of partition keys.".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Returns top-level Blob field names for create-time Blob contract checks.
+    fn top_level_blob_field_names(fields: &[DataField]) -> Vec<&str> {
+        fields
+            .iter()
+            .filter_map(|field| match field.data_type() {
+                DataType::Blob(_) => Some(field.name()),
+                _ => None,
+            })
+            .collect()
     }
 
     /// Returns the set of names that appear more than once.
@@ -572,7 +621,7 @@ impl Default for SchemaBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::spec::IntType;
+    use crate::spec::{BlobType, IntType};
 
     use super::*;
 
@@ -743,6 +792,62 @@ mod tests {
             .unwrap();
         assert_eq!(schema.partition_keys(), &["a"]);
         assert_eq!(schema.primary_keys(), &["a", "b"]);
+    }
+
+    #[test]
+    fn test_blob_schema_validation_requires_data_evolution() {
+        let err = Schema::builder()
+            .column("id", DataType::Int(IntType::new()))
+            .column("payload", DataType::Blob(BlobType::new()))
+            .build()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, crate::Error::ConfigInvalid { message } if message.contains("Data evolution config must enabled")),
+            "blob columns should require data-evolution.enabled"
+        );
+    }
+
+    #[test]
+    fn test_blob_schema_validation_rejects_all_blob_columns() {
+        let err = Schema::builder()
+            .column("payload", DataType::Blob(BlobType::new()))
+            .option("data-evolution.enabled", "true")
+            .build()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, crate::Error::ConfigInvalid { message } if message.contains("must have other normal columns")),
+            "blob-only tables should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_blob_schema_validation_rejects_blob_partition_keys() {
+        let err = Schema::builder()
+            .column("id", DataType::Int(IntType::new()))
+            .column("payload", DataType::Blob(BlobType::new()))
+            .partition_keys(["payload"])
+            .option("data-evolution.enabled", "true")
+            .build()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, crate::Error::ConfigInvalid { message } if message.contains("can not be part of partition keys")),
+            "blob columns should be rejected as partition keys during schema validation"
+        );
+    }
+
+    #[test]
+    fn test_blob_schema_validation_accepts_valid_blob_table() {
+        let schema = Schema::builder()
+            .column("id", DataType::Int(IntType::new()))
+            .column("payload", DataType::Blob(BlobType::new()))
+            .option("data-evolution.enabled", "true")
+            .build()
+            .unwrap();
+
+        assert_eq!(schema.fields().len(), 2);
     }
 
     #[test]

--- a/crates/paimon/src/table/table_write.rs
+++ b/crates/paimon/src/table/table_write.rs
@@ -379,6 +379,7 @@ mod tests {
         let schema = Schema::builder()
             .column("id", DataType::Int(IntType::new()))
             .column("payload", DataType::Blob(BlobType::new()))
+            .option("data-evolution.enabled", "true")
             .build()
             .unwrap();
         TableSchema::new(0, &schema)


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

Linked issue: part of #228

This PR hardens the create-time schema contract for `BLOB` columns.

After `BlobType` groundwork landed, Rust still relied on scattered runtime rejections for some invalid table shapes. This change moves the basic table-creation checks to schema construction so invalid  `BLOB` table definitions fail earlier and more consistently.

This PR is intentionally limited to create-time validation. It does not add `.blob` file-format dispatch or read path support.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - add create-time `BLOB` validation in `Schema::new()`
  - require `data-evolution.enabled = true` when top-level `BLOB` columns exist
  - reject tables whose top-level columns are all `BLOB`
  - reject top-level `BLOB` columns in partition keys
  - add schema-level tests for the accepted and rejected cases
  - update the existing `table_write` test fixture to satisfy the new schema contract

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
