### PR TITLE
feat: add dynamic bucket assignment for primary-key tables

### DIFF
--- a/crates/integrations/datafusion/src/physical_plan/scan.rs
+++ b/crates/integrations/datafusion/src/physical_plan/scan.rs
@@ -337,7 +337,6 @@ mod tests {
             .with_bucket_path(local_file_path(&bucket_dir))
             .with_total_buckets(1)
             .with_data_files(vec![test_data_file("data.parquet", 4, file_size)])
-            .with_raw_convertible(true)
             .build()
             .unwrap();
 

--- a/crates/integrations/datafusion/src/physical_plan/sink.rs
+++ b/crates/integrations/datafusion/src/physical_plan/sink.rs
@@ -80,7 +80,10 @@ impl DataSink for PaimonDataSink {
         mut data: SendableRecordBatchStream,
         _context: &Arc<TaskContext>,
     ) -> DFResult<u64> {
-        let wb = self.table.new_write_builder();
+        let mut wb = self.table.new_write_builder();
+        if self.overwrite {
+            wb = wb.with_overwrite();
+        }
         let mut tw = wb.new_write().map_err(to_datafusion_error)?;
         let mut row_count = 0u64;
 

--- a/crates/integrations/datafusion/tests/common/mod.rs
+++ b/crates/integrations/datafusion/tests/common/mod.rs
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Shared test helpers for DataFusion integration tests.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Int32Array, StringArray};
+use datafusion::prelude::SessionContext;
+use paimon::{CatalogOptions, FileSystemCatalog, Options};
+use paimon_datafusion::{PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler};
+use tempfile::TempDir;
+
+pub fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let warehouse = format!("file://{}", temp_dir.path().display());
+    let mut options = Options::new();
+    options.set(CatalogOptions::WAREHOUSE, warehouse);
+    let catalog = FileSystemCatalog::new(options).expect("Failed to create catalog");
+    (temp_dir, Arc::new(catalog))
+}
+
+pub fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
+    let ctx = SessionContext::new();
+    ctx.register_catalog(
+        "paimon",
+        Arc::new(PaimonCatalogProvider::new(catalog.clone())),
+    );
+    ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
+        .expect("Failed to register relation planner");
+    PaimonSqlHandler::new(ctx, catalog, "paimon")
+}
+
+pub async fn setup_handler() -> (TempDir, PaimonSqlHandler) {
+    let (tmp, catalog) = create_test_env();
+    let handler = create_handler(catalog);
+    handler
+        .sql("CREATE SCHEMA paimon.test_db")
+        .await
+        .expect("CREATE SCHEMA failed");
+    (tmp, handler)
+}
+
+pub async fn collect_id_name(handler: &PaimonSqlHandler, sql: &str) -> Vec<(i32, String)> {
+    let batches = handler.sql(sql).await.unwrap().collect().await.unwrap();
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let ids = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .expect("id column");
+        let names = batch
+            .column_by_name("name")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .expect("name column");
+        for i in 0..batch.num_rows() {
+            rows.push((ids.value(i), names.value(i).to_string()));
+        }
+    }
+    rows.sort_by_key(|(id, _)| *id);
+    rows
+}
+
+pub async fn collect_id_value(handler: &PaimonSqlHandler, sql: &str) -> Vec<(i32, i32)> {
+    let batches = handler.sql(sql).await.unwrap().collect().await.unwrap();
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let ids = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .expect("id column");
+        let vals = batch
+            .column_by_name("value")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .expect("value column");
+        for i in 0..batch.num_rows() {
+            rows.push((ids.value(i), vals.value(i)));
+        }
+    }
+    rows.sort_by_key(|(id, _)| *id);
+    rows
+}
+
+#[allow(dead_code)]
+pub async fn row_count(handler: &PaimonSqlHandler, sql: &str) -> usize {
+    let batches = handler.sql(sql).await.unwrap().collect().await.unwrap();
+    batches.iter().map(|b| b.num_rows()).sum()
+}

--- a/crates/integrations/datafusion/tests/cross_partition_tables.rs
+++ b/crates/integrations/datafusion/tests/cross_partition_tables.rs
@@ -537,3 +537,118 @@ async fn test_cross_partition_first_row_skip() {
     // id=1 keeps original value 10, id=2 unchanged, id=3 is new
     assert_eq!(rows, vec![(1, 10), (2, 20), (3, 30)]);
 }
+
+/// Regression: partial PK/partition overlap — `PARTITIONED BY (pt1, pt2) + PK (pt1, id)`.
+/// pt2 is NOT in PK, so cross-partition mode must be triggered.
+/// When same id is written under different pt2, old partition should get a DELETE.
+#[tokio::test]
+async fn test_cross_partition_partial_pk_partition_overlap() {
+    let (_tmp, handler) = setup_handler().await;
+
+    // PK = (pt1, id), partition = (pt1, pt2) — pt2 is NOT in PK → cross-partition
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_cross_partial (
+                pt1 STRING, pt2 STRING, id INT NOT NULL, value INT,
+                PRIMARY KEY (pt1, id)
+            ) PARTITIONED BY (pt1 STRING, pt2 STRING)",
+        )
+        .await
+        .unwrap();
+
+    // Commit 1: id=1 in (pt1='a', pt2='x')
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_partial VALUES \
+             ('a', 'x', 1, 10), ('a', 'x', 2, 20)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_cross_partial ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows, vec![(1, 10), (2, 20)]);
+
+    // Commit 2: id=1 moves to (pt1='a', pt2='y') — different pt2
+    handler
+        .sql("INSERT INTO paimon.test_db.t_cross_partial VALUES ('a', 'y', 1, 100)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // After dedup, id=1 should have value=100 and only appear once
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_cross_partial ORDER BY id",
+    )
+    .await;
+    assert_eq!(
+        rows,
+        vec![(1, 100), (2, 20)],
+        "id=1 should be deduplicated across pt2 partitions"
+    );
+}
+
+/// Regression: _VALUE_KIND schema stability across batches in cross-partition mode.
+/// A cross-partition writer must always include _VALUE_KIND in the Arrow schema,
+/// even when the current batch has no cross-partition migrations. Otherwise,
+/// KeyValueFileWriter's concat_batches fails with a schema mismatch when a later
+/// batch introduces deletes.
+///
+/// This test writes two commits to the same cross-partition table:
+/// 1. First commit: all new keys (no migration → no deletes)
+/// 2. Second commit: migrates keys (produces deletes)
+/// Both must succeed without schema errors.
+#[tokio::test]
+async fn test_cross_partition_value_kind_schema_stability() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_cross_vk (
+                dt STRING, id INT NOT NULL, value INT,
+                PRIMARY KEY (id)
+            ) PARTITIONED BY (dt STRING)",
+        )
+        .await
+        .unwrap();
+
+    // Commit 1: all new keys, no migration — _VALUE_KIND must still be added
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_vk VALUES \
+             ('a', 1, 10), ('a', 2, 20), ('b', 3, 30)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Commit 2: id=1 migrates from "a" to "b" — produces DELETE in "a"
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_vk VALUES \
+             ('b', 1, 100), ('a', 2, 200)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_cross_vk ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows, vec![(1, 100), (2, 200), (3, 30)]);
+}

--- a/crates/integrations/datafusion/tests/cross_partition_tables.rs
+++ b/crates/integrations/datafusion/tests/cross_partition_tables.rs
@@ -1,0 +1,539 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! E2E integration tests for cross-partition update PK tables via DataFusion SQL.
+//!
+//! Cross-partition mode: PK does NOT include partition fields, bucket=-1 (dynamic).
+//! A record's partition can change over time, requiring DELETE in old partition
+//! and ADD in new partition.
+
+mod common;
+
+use common::{collect_id_name, collect_id_value, create_handler, create_test_env, setup_handler};
+use datafusion::arrow::array::Int32Array;
+use paimon::catalog::Identifier;
+use paimon::Catalog;
+
+/// Cross-partition update: PK does NOT include partition field.
+/// A record's partition can change — old partition gets a DELETE, new partition gets an ADD.
+#[tokio::test]
+async fn test_cross_partition_update_basic() {
+    let (_tmp, handler) = setup_handler().await;
+
+    // PK is only "id", partition is "dt" — PK does NOT include partition field
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_cross_pt (
+                dt STRING, id INT NOT NULL, value INT,
+                PRIMARY KEY (id)
+            ) PARTITIONED BY (dt STRING)",
+        )
+        .await
+        .unwrap();
+
+    // First commit: id=1,2 in partition "2024-01-01"
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_pt VALUES \
+             ('2024-01-01', 1, 10), ('2024-01-01', 2, 20)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_cross_pt ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows, vec![(1, 10), (2, 20)]);
+
+    // Second commit: id=1 moves to partition "2024-01-02"
+    handler
+        .sql("INSERT INTO paimon.test_db.t_cross_pt VALUES ('2024-01-02', 1, 100)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Read back — id=1 should have value=100, id=2 unchanged
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_cross_pt ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows, vec![(1, 100), (2, 20)]);
+}
+
+/// Cross-partition: multiple records moving between partitions in one commit.
+#[tokio::test]
+async fn test_cross_partition_update_multiple_keys() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_cross_multi (
+                dt STRING, id INT NOT NULL, name STRING,
+                PRIMARY KEY (id)
+            ) PARTITIONED BY (dt STRING)",
+        )
+        .await
+        .unwrap();
+
+    // First commit: 3 records in partition "a"
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_multi VALUES \
+             ('a', 1, 'alice'), ('a', 2, 'bob'), ('a', 3, 'carol')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Second commit: id=1 moves to "b", id=2 moves to "c", id=3 stays in "a" with update
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_multi VALUES \
+             ('b', 1, 'alice-v2'), ('c', 2, 'bob-v2'), ('a', 3, 'carol-v2')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let rows = collect_id_name(
+        &handler,
+        "SELECT id, name FROM paimon.test_db.t_cross_multi ORDER BY id",
+    )
+    .await;
+
+    assert_eq!(
+        rows,
+        vec![
+            (1, "alice-v2".to_string()),
+            (2, "bob-v2".to_string()),
+            (3, "carol-v2".to_string()),
+        ]
+    );
+}
+
+/// Cross-partition: three commits with records bouncing between partitions.
+#[tokio::test]
+async fn test_cross_partition_update_three_commits() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_cross_3c (
+                dt STRING, id INT NOT NULL, value INT,
+                PRIMARY KEY (id)
+            ) PARTITIONED BY (dt STRING)",
+        )
+        .await
+        .unwrap();
+
+    // Commit 1: id=1 in "a", id=2 in "b"
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_3c VALUES \
+             ('a', 1, 10), ('b', 2, 20)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Commit 2: id=1 moves to "b", id=2 moves to "a", add id=3 in "a"
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_3c VALUES \
+             ('b', 1, 100), ('a', 2, 200), ('a', 3, 30)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Commit 3: id=1 moves back to "a", id=3 moves to "b"
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_3c VALUES \
+             ('a', 1, 1000), ('b', 3, 300)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_cross_3c ORDER BY id",
+    )
+    .await;
+
+    assert_eq!(rows, vec![(1, 1000), (2, 200), (3, 300)]);
+}
+
+/// Cross-partition: new records in different partitions (no migration, just new keys).
+#[tokio::test]
+async fn test_cross_partition_new_keys_no_migration() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_cross_new (
+                dt STRING, id INT NOT NULL, value INT,
+                PRIMARY KEY (id)
+            ) PARTITIONED BY (dt STRING)",
+        )
+        .await
+        .unwrap();
+
+    // All new keys in different partitions — no cross-partition migration
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_new VALUES \
+             ('a', 1, 10), ('b', 2, 20), ('c', 3, 30)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_cross_new ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows, vec![(1, 10), (2, 20), (3, 30)]);
+
+    // Add more new keys
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_new VALUES \
+             ('a', 4, 40), ('b', 5, 50)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_cross_new ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows, vec![(1, 10), (2, 20), (3, 30), (4, 40), (5, 50)]);
+}
+
+/// Cross-partition update: verify via scan_all_files that the old partition
+/// receives a data file containing DELETE records (_VALUE_KIND=1) when a record
+/// migrates to a new partition.
+#[tokio::test]
+async fn test_cross_partition_delete_file_in_old_partition() {
+    let (_tmp, catalog) = create_test_env();
+    let handler = create_handler(catalog.clone());
+    handler
+        .sql("CREATE SCHEMA paimon.test_db")
+        .await
+        .expect("CREATE SCHEMA failed");
+
+    // PK = (id), partition = dt — cross-partition mode
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_cross_dv (
+                dt STRING, id INT NOT NULL, value INT,
+                PRIMARY KEY (id)
+            ) PARTITIONED BY (dt STRING)",
+        )
+        .await
+        .unwrap();
+
+    // Commit 1: id=1,2 in partition "a", id=3 in partition "b"
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_dv VALUES \
+             ('a', 1, 10), ('a', 2, 20), ('b', 3, 30)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Verify initial state: 2 data files (one per partition)
+    let table = catalog
+        .get_table(&Identifier::new("test_db", "t_cross_dv"))
+        .await
+        .unwrap();
+    let plan = table
+        .new_read_builder()
+        .new_scan()
+        .with_scan_all_files()
+        .plan()
+        .await
+        .unwrap();
+    let initial_file_count: usize = plan.splits().iter().map(|s| s.data_files().len()).sum();
+    assert_eq!(
+        initial_file_count, 2,
+        "After commit 1: 2 data files (one per partition)"
+    );
+
+    // Commit 2: id=1 moves from partition "a" to partition "c"
+    handler
+        .sql("INSERT INTO paimon.test_db.t_cross_dv VALUES ('c', 1, 100)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Verify via scan_all_files: old partition "a" should have a new file
+    // containing the DELETE record for id=1 (written with _VALUE_KIND=1)
+    let table = catalog
+        .get_table(&Identifier::new("test_db", "t_cross_dv"))
+        .await
+        .unwrap();
+    let plan = table
+        .new_read_builder()
+        .new_scan()
+        .with_scan_all_files()
+        .plan()
+        .await
+        .unwrap();
+
+    // Collect per-partition file counts and row counts
+    let mut partition_file_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    let mut partition_row_counts: std::collections::HashMap<String, Vec<i64>> =
+        std::collections::HashMap::new();
+    for split in plan.splits() {
+        let dt = split.partition().get_string(0).unwrap().to_string();
+        let count = split.data_files().len();
+        *partition_file_counts.entry(dt.clone()).or_insert(0) += count;
+        for file in split.data_files() {
+            partition_row_counts
+                .entry(dt.clone())
+                .or_default()
+                .push(file.row_count);
+        }
+    }
+
+    // Partition "a": original file (2 rows) + DELETE file (1 row for id=1 migrating away)
+    assert_eq!(
+        partition_file_counts.get("a").copied().unwrap_or(0),
+        2,
+        "Partition 'a' should have 2 files (original + delete record)"
+    );
+    // The delete file should have row_count=1 (the DELETE record for id=1)
+    let a_rows = partition_row_counts.get("a").unwrap();
+    assert!(
+        a_rows.contains(&1),
+        "Partition 'a' should have a file with row_count=1 (the DELETE record), got {:?}",
+        a_rows
+    );
+
+    // Partition "b": unchanged, still 1 file
+    assert_eq!(
+        partition_file_counts.get("b").copied().unwrap_or(0),
+        1,
+        "Partition 'b' should still have 1 file (untouched)"
+    );
+
+    // Partition "c": new file for id=1
+    assert_eq!(
+        partition_file_counts.get("c").copied().unwrap_or(0),
+        1,
+        "Partition 'c' should have 1 file (new ADD)"
+    );
+
+    // Final read: dedup should produce correct results
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_cross_dv ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows, vec![(1, 100), (2, 20), (3, 30)]);
+
+    // Commit 3: id=2 also moves from "a" to "b", id=3 stays in "b" with update
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_dv VALUES \
+             ('b', 2, 200), ('b', 3, 300)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Verify partition "a" now has another DELETE file for id=2
+    let table = catalog
+        .get_table(&Identifier::new("test_db", "t_cross_dv"))
+        .await
+        .unwrap();
+    let plan = table
+        .new_read_builder()
+        .new_scan()
+        .with_scan_all_files()
+        .plan()
+        .await
+        .unwrap();
+
+    let mut partition_file_counts_3: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for split in plan.splits() {
+        let dt = split.partition().get_string(0).unwrap().to_string();
+        *partition_file_counts_3.entry(dt).or_insert(0) += split.data_files().len();
+    }
+
+    // Partition "a": original (2 rows) + delete for id=1 + delete for id=2 = 3 files
+    assert_eq!(
+        partition_file_counts_3.get("a").copied().unwrap_or(0),
+        3,
+        "Partition 'a' should have 3 files (original + 2 delete records)"
+    );
+
+    // Partition "b": original (1 row) + new commit (2 rows: id=2 ADD + id=3 update) = 2 files
+    assert_eq!(
+        partition_file_counts_3.get("b").copied().unwrap_or(0),
+        2,
+        "Partition 'b' should have 2 files"
+    );
+
+    // Final read after 3 commits
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_cross_dv ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows, vec![(1, 100), (2, 200), (3, 300)]);
+}
+
+/// Cross-partition + FIRST_ROW: key already in another partition → discard new row.
+#[tokio::test]
+async fn test_cross_partition_first_row_skip() {
+    let (_tmp, catalog) = create_test_env();
+    let handler = create_handler(catalog.clone());
+    handler
+        .sql("CREATE SCHEMA paimon.test_db")
+        .await
+        .expect("CREATE SCHEMA failed");
+
+    // PK is only "id", partition is "dt", merge-engine = first-row
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_cross_fr (
+                dt STRING, id INT NOT NULL, value INT,
+                PRIMARY KEY (id)
+            ) PARTITIONED BY (dt STRING)
+            WITH ('merge-engine' = 'first-row')",
+        )
+        .await
+        .unwrap();
+
+    // Commit 1: id=1,2 in partition "a"
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_fr VALUES \
+             ('a', 1, 10), ('a', 2, 20)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Commit 2: try to move id=1 to partition "b" and insert new id=3 in "b"
+    // FIRST_ROW should discard id=1 (already exists in "a"), but accept id=3
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_cross_fr VALUES \
+             ('b', 1, 100), ('b', 3, 30)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Use scan_all_files to verify (FIRST_ROW skips level-0 in normal reads)
+    let table = catalog
+        .get_table(&Identifier::new("test_db", "t_cross_fr"))
+        .await
+        .unwrap();
+    let rb = table.new_read_builder();
+    let plan = rb.new_scan().with_scan_all_files().plan().await.unwrap();
+
+    // Partition "a" should still have its original file only (no DELETE file)
+    // because FIRST_ROW discards the new row instead of migrating
+    let mut partition_file_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for split in plan.splits() {
+        let dt = split.partition().get_string(0).unwrap().to_string();
+        *partition_file_counts.entry(dt).or_insert(0) += split.data_files().len();
+    }
+    assert_eq!(
+        partition_file_counts.get("a").copied().unwrap_or(0),
+        1,
+        "Partition 'a' should have 1 file (no DELETE generated for FIRST_ROW)"
+    );
+    // Partition "b" should have 1 file with only id=3 (id=1 was skipped)
+    assert_eq!(
+        partition_file_counts.get("b").copied().unwrap_or(0),
+        1,
+        "Partition 'b' should have 1 file (only id=3)"
+    );
+
+    // Verify data via scan_all_files read
+    let read = rb.new_read().unwrap();
+    let batches: Vec<_> = futures::TryStreamExt::try_collect(read.to_arrow(plan.splits()).unwrap())
+        .await
+        .unwrap();
+    let mut rows: Vec<(i32, i32)> = Vec::new();
+    for batch in &batches {
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let vals = batch
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            rows.push((ids.value(i), vals.value(i)));
+        }
+    }
+    rows.sort();
+    // id=1 keeps original value 10, id=2 unchanged, id=3 is new
+    assert_eq!(rows, vec![(1, 10), (2, 20), (3, 30)]);
+}

--- a/crates/integrations/datafusion/tests/dynamic_bucket_tables.rs
+++ b/crates/integrations/datafusion/tests/dynamic_bucket_tables.rs
@@ -1,0 +1,552 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! E2E integration tests for dynamic bucket (bucket=-1) PK tables via DataFusion SQL.
+
+mod common;
+
+use common::{collect_id_name, collect_id_value, create_handler, create_test_env, setup_handler};
+use datafusion::arrow::array::{Int32Array, StringArray};
+use paimon::catalog::Identifier;
+use paimon::spec::{IndexManifest, IndexManifestEntry};
+use paimon::{Catalog, CatalogOptions, FileSystemCatalog, Options, SnapshotManager};
+
+/// PK table with bucket=-1 (dynamic bucket) should write and read correctly.
+#[tokio::test]
+async fn test_pk_dynamic_bucket() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_dyn (
+                id INT NOT NULL, name STRING,
+                PRIMARY KEY (id)
+            )",
+        )
+        .await
+        .unwrap();
+
+    // First insert — no 'bucket' option, defaults to -1 (dynamic bucket)
+    handler
+        .sql("INSERT INTO paimon.test_db.t_dyn VALUES (1, 'alice'), (2, 'bob')")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let rows = collect_id_name(
+        &handler,
+        "SELECT id, name FROM paimon.test_db.t_dyn ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows, vec![(1, "alice".to_string()), (2, "bob".to_string())]);
+
+    // Second insert with overlapping key — dedup should keep latest
+    handler
+        .sql("INSERT INTO paimon.test_db.t_dyn VALUES (2, 'bobby'), (3, 'carol')")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let rows = collect_id_name(
+        &handler,
+        "SELECT id, name FROM paimon.test_db.t_dyn ORDER BY id",
+    )
+    .await;
+    assert_eq!(
+        rows,
+        vec![
+            (1, "alice".to_string()),
+            (2, "bobby".to_string()),
+            (3, "carol".to_string()),
+        ]
+    );
+}
+
+/// Dynamic bucket with partitioned table.
+#[tokio::test]
+async fn test_pk_dynamic_bucket_partitioned() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_dyn_part (
+                dt STRING, id INT NOT NULL, value INT,
+                PRIMARY KEY (dt, id)
+            ) PARTITIONED BY (dt STRING)",
+        )
+        .await
+        .unwrap();
+
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_dyn_part VALUES \
+             ('2024-01-01', 1, 10), ('2024-01-01', 2, 20), \
+             ('2024-01-02', 1, 100), ('2024-01-02', 2, 200)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Update within each partition
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_dyn_part VALUES \
+             ('2024-01-01', 1, 11), ('2024-01-02', 2, 222)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let batches = handler
+        .sql("SELECT dt, id, value FROM paimon.test_db.t_dyn_part ORDER BY dt, id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let dts = batch
+            .column_by_name("dt")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        let ids = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .unwrap();
+        let vals = batch
+            .column_by_name("value")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            rows.push((dts.value(i).to_string(), ids.value(i), vals.value(i)));
+        }
+    }
+    rows.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+
+    assert_eq!(
+        rows,
+        vec![
+            ("2024-01-01".to_string(), 1, 11),
+            ("2024-01-01".to_string(), 2, 20),
+            ("2024-01-02".to_string(), 1, 100),
+            ("2024-01-02".to_string(), 2, 222),
+        ]
+    );
+}
+
+/// Dynamic bucket with three commits — verifies sequence number tracking.
+#[tokio::test]
+async fn test_pk_dynamic_bucket_three_commits() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_dyn3 (
+                id INT NOT NULL, value INT,
+                PRIMARY KEY (id)
+            )",
+        )
+        .await
+        .unwrap();
+
+    handler
+        .sql("INSERT INTO paimon.test_db.t_dyn3 VALUES (1, 10), (2, 20)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    handler
+        .sql("INSERT INTO paimon.test_db.t_dyn3 VALUES (2, 200), (3, 30)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    handler
+        .sql("INSERT INTO paimon.test_db.t_dyn3 VALUES (1, 100), (3, 300), (4, 40)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_dyn3 ORDER BY id",
+    )
+    .await;
+
+    assert_eq!(rows, vec![(1, 100), (2, 200), (3, 300), (4, 40)]);
+}
+
+/// Helper: read HASH index entries from a table's latest snapshot.
+async fn read_hash_index_entries(table: &paimon::Table) -> Vec<IndexManifestEntry> {
+    let sm = SnapshotManager::new(table.file_io().clone(), table.location().to_string());
+    let snapshot = sm
+        .get_latest_snapshot()
+        .await
+        .unwrap()
+        .expect("no snapshot");
+    let index_manifest_name = snapshot.index_manifest().expect("no index manifest");
+    let path = format!("{}/manifest/{}", table.location(), index_manifest_name);
+    let entries = IndexManifest::read(table.file_io(), &path).await.unwrap();
+    entries
+        .into_iter()
+        .filter(|e| e.index_file.index_type == "HASH")
+        .collect()
+}
+
+/// Helper: read raw hash values from a hash index file (flat i32 little-endian).
+async fn read_hash_file(table: &paimon::Table, file_name: &str) -> Vec<i32> {
+    let path = format!("{}/index/{}", table.location(), file_name);
+    let input = table.file_io().new_input(&path).unwrap();
+    let content = input.read().await.unwrap();
+    assert!(content.len() % 4 == 0);
+    (0..content.len() / 4)
+        .map(|i| {
+            let off = i * 4;
+            i32::from_be_bytes([
+                content[off],
+                content[off + 1],
+                content[off + 2],
+                content[off + 3],
+            ])
+        })
+        .collect()
+}
+
+/// Collect all hash values from all HASH index files of a table's latest snapshot.
+async fn collect_all_hashes(table: &paimon::Table) -> Vec<i32> {
+    let entries = read_hash_index_entries(table).await;
+    let mut all_hashes = Vec::new();
+    for entry in &entries {
+        let hashes = read_hash_file(table, &entry.index_file.file_name).await;
+        all_hashes.extend(hashes);
+    }
+    all_hashes.sort();
+    all_hashes
+}
+
+/// INSERT OVERWRITE on an unpartitioned dynamic bucket table should replace
+/// all data and rebuild the HASH index from scratch (old index entries cleared).
+#[tokio::test]
+async fn test_pk_dynamic_bucket_insert_overwrite() {
+    let (_tmp, catalog) = create_test_env();
+    let handler = create_handler(catalog.clone());
+    handler
+        .sql("CREATE SCHEMA paimon.test_db")
+        .await
+        .expect("CREATE SCHEMA failed");
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_dyn_ow (
+                id INT NOT NULL, name STRING,
+                PRIMARY KEY (id)
+            )",
+        )
+        .await
+        .unwrap();
+
+    // Commit 1: insert 3 rows
+    handler
+        .sql("INSERT INTO paimon.test_db.t_dyn_ow VALUES (1, 'alice'), (2, 'bob'), (3, 'carol')")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let table = catalog
+        .get_table(&Identifier::new("test_db", "t_dyn_ow"))
+        .await
+        .unwrap();
+    let hashes_before = collect_all_hashes(&table).await;
+    assert_eq!(hashes_before.len(), 3, "Should have 3 hash entries");
+
+    // INSERT OVERWRITE with only 2 rows — old index entries must be cleared
+    handler
+        .sql("INSERT OVERWRITE paimon.test_db.t_dyn_ow VALUES (10, 'new_a'), (20, 'new_b')")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Verify data
+    let rows = collect_id_name(
+        &handler,
+        "SELECT id, name FROM paimon.test_db.t_dyn_ow ORDER BY id",
+    )
+    .await;
+    assert_eq!(
+        rows,
+        vec![(10, "new_a".to_string()), (20, "new_b".to_string())]
+    );
+
+    // Verify HASH index: should have exactly 2 entries (not 3+2=5)
+    let table = catalog
+        .get_table(&Identifier::new("test_db", "t_dyn_ow"))
+        .await
+        .unwrap();
+    let hashes_after = collect_all_hashes(&table).await;
+    assert_eq!(
+        hashes_after.len(),
+        2,
+        "HASH index should have 2 entries after overwrite, got {}",
+        hashes_after.len()
+    );
+
+    // Old hashes should not be present
+    for h in &hashes_before {
+        assert!(
+            !hashes_after.contains(h),
+            "Old hash {h} should not survive overwrite"
+        );
+    }
+}
+
+/// INSERT OVERWRITE on a partitioned dynamic bucket table should only clear
+/// index entries for the overwritten partition, keeping other partitions intact.
+#[tokio::test]
+async fn test_pk_dynamic_bucket_partitioned_insert_overwrite() {
+    let (_tmp, catalog) = create_test_env();
+    let handler = create_handler(catalog.clone());
+    handler
+        .sql("CREATE SCHEMA paimon.test_db")
+        .await
+        .expect("CREATE SCHEMA failed");
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_dyn_part_ow (
+                dt STRING, id INT NOT NULL, value INT,
+                PRIMARY KEY (dt, id)
+            ) PARTITIONED BY (dt STRING)",
+        )
+        .await
+        .unwrap();
+
+    // Commit 1: two partitions
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_dyn_part_ow VALUES \
+             ('a', 1, 10), ('a', 2, 20), \
+             ('b', 3, 30), ('b', 4, 40)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let table = catalog
+        .get_table(&Identifier::new("test_db", "t_dyn_part_ow"))
+        .await
+        .unwrap();
+    let entries_before = read_hash_index_entries(&table).await;
+    // Should have index entries for both partitions
+    assert!(
+        entries_before.len() >= 2,
+        "Should have index entries for both partitions"
+    );
+
+    // INSERT OVERWRITE partition 'a' with only 1 row
+    handler
+        .sql("INSERT OVERWRITE paimon.test_db.t_dyn_part_ow VALUES ('a', 5, 50)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Verify data: partition 'a' replaced, partition 'b' untouched
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_dyn_part_ow ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows, vec![(3, 30), (4, 40), (5, 50)]);
+
+    // Verify HASH index: partition 'b' entries should survive,
+    // partition 'a' should have exactly 1 entry (not 2+1=3)
+    let table = catalog
+        .get_table(&Identifier::new("test_db", "t_dyn_part_ow"))
+        .await
+        .unwrap();
+    let entries_after = read_hash_index_entries(&table).await;
+
+    // Count entries per partition
+    let mut partition_entry_counts: std::collections::HashMap<Vec<u8>, usize> =
+        std::collections::HashMap::new();
+    for entry in &entries_after {
+        *partition_entry_counts
+            .entry(entry.partition.clone())
+            .or_insert(0) += 1;
+    }
+
+    // Total hash count: partition 'b' had 2 keys, partition 'a' now has 1 key
+    let total_hashes: i64 = entries_after
+        .iter()
+        .map(|e| e.index_file.row_count as i64)
+        .sum();
+    assert_eq!(
+        total_hashes, 3,
+        "Total hash entries should be 3 (2 from 'b' + 1 from 'a'), got {total_hashes}"
+    );
+}
+
+/// Read the Spark-provisioned dynamic_bucket_pk_table, write the same data
+/// into a new dynamic bucket table, and verify the HASH index values are identical.
+///
+/// Spark may distribute rows across multiple buckets due to parallelism, so we
+/// compare the aggregate set of hash values rather than per-bucket entries.
+///
+/// Requires: `make docker-up` + colima copy (see dev/spark/README.md).
+#[tokio::test]
+#[ignore]
+async fn test_read_spark_dynamic_bucket_and_compare_index() {
+    // --- Read from Spark-provisioned table ---
+    let warehouse =
+        std::env::var("PAIMON_TEST_WAREHOUSE").unwrap_or_else(|_| "/tmp/paimon-warehouse".into());
+    let mut opts = Options::new();
+    opts.set(CatalogOptions::WAREHOUSE, &warehouse);
+    let spark_catalog = FileSystemCatalog::new(opts).unwrap();
+    let spark_table = spark_catalog
+        .get_table(&Identifier::new("default", "dynamic_bucket_pk_table"))
+        .await
+        .unwrap();
+
+    // Read all rows from the Spark table
+    let plan = spark_table
+        .new_read_builder()
+        .new_scan()
+        .plan()
+        .await
+        .unwrap();
+    let reader = spark_table.new_read_builder().new_read().unwrap();
+    let stream = reader.to_arrow(plan.splits()).unwrap();
+
+    use arrow_array::RecordBatch;
+    use futures::StreamExt;
+    let batches: Vec<RecordBatch> = stream
+        .map(|r: paimon::Result<RecordBatch>| r.unwrap())
+        .collect()
+        .await;
+    let mut all_rows: Vec<(i32, String)> = Vec::new();
+    for batch in &batches {
+        let ids = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .unwrap();
+        let names = batch
+            .column_by_name("name")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            all_rows.push((ids.value(i), names.value(i).to_string()));
+        }
+    }
+    all_rows.sort_by_key(|(id, _)| *id);
+
+    // Verify Spark data: two commits with overlapping keys
+    assert_eq!(
+        all_rows,
+        vec![
+            (1, "alice".to_string()),
+            (2, "bob-v2".to_string()),
+            (3, "carol-v2".to_string()),
+            (4, "dave".to_string()),
+        ]
+    );
+
+    // --- Write the same data into a new dynamic bucket table ---
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_dyn_cmp (
+                id INT NOT NULL, name STRING,
+                PRIMARY KEY (id)
+            )",
+        )
+        .await
+        .unwrap();
+
+    // Replicate the same two commits as provision.py
+    handler
+        .sql("INSERT INTO paimon.test_db.t_dyn_cmp VALUES (1, 'alice'), (2, 'bob'), (3, 'carol')")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_dyn_cmp VALUES \
+             (2, 'bob-v2'), (3, 'carol-v2'), (4, 'dave')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Verify written data matches
+    let rows = collect_id_name(
+        &handler,
+        "SELECT id, name FROM paimon.test_db.t_dyn_cmp ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows, all_rows);
+
+    // --- Compare HASH index values ---
+    let rust_catalog = {
+        let mut opts = Options::new();
+        opts.set(
+            CatalogOptions::WAREHOUSE,
+            format!("file://{}", _tmp.path().display()),
+        );
+        FileSystemCatalog::new(opts).unwrap()
+    };
+    let rust_table = rust_catalog
+        .get_table(&Identifier::new("test_db", "t_dyn_cmp"))
+        .await
+        .unwrap();
+
+    let spark_hashes = collect_all_hashes(&spark_table).await;
+    let rust_hashes = collect_all_hashes(&rust_table).await;
+
+    assert_eq!(
+        spark_hashes, rust_hashes,
+        "HASH index values mismatch between Spark and Rust tables"
+    );
+}

--- a/crates/integrations/datafusion/tests/pk_tables.rs
+++ b/crates/integrations/datafusion/tests/pk_tables.rs
@@ -1279,3 +1279,107 @@ async fn test_postpone_insert_overwrite() {
         "After OVERWRITE: only 1 new file (old file deleted)"
     );
 }
+
+// ======================= Bucket Keys Regression =======================
+
+/// Regression: partitioned PK fixed-bucket table — query with partition + PK
+/// predicate must return rows. Before the fix, `bucket_keys()` returned full
+/// primary keys (including partition columns), while the read path used
+/// `trimmed_primary_keys()`, causing bucket pruning to target the wrong bucket.
+#[tokio::test]
+async fn test_pk_partitioned_fixed_bucket_predicate_query() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_bk_pred (
+                pt STRING, id INT NOT NULL, value INT,
+                PRIMARY KEY (pt, id)
+            ) PARTITIONED BY (pt STRING)
+            WITH ('bucket' = '2')",
+        )
+        .await
+        .unwrap();
+
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_bk_pred VALUES \
+             ('a', 1, 10), ('a', 2, 20), ('b', 3, 30), ('b', 4, 40)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Query with both partition and PK columns in predicate
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_bk_pred WHERE pt = 'a' AND id = 1",
+    )
+    .await;
+    assert_eq!(rows, vec![(1, 10)], "Predicate query must find the row");
+
+    let rows = collect_id_value(
+        &handler,
+        "SELECT id, value FROM paimon.test_db.t_bk_pred WHERE pt = 'b' AND id = 4",
+    )
+    .await;
+    assert_eq!(rows, vec![(4, 40)], "Predicate query must find the row");
+}
+
+// ======================= DV + Deduplicate Regression =======================
+
+/// Regression: DV-enabled Deduplicate PK table must not error on read.
+/// Before the fix, removing the DV guard caused level-0 files to reach
+/// KeyValueFileReader which rejects deletion-vector files with a hard error.
+/// With the guard restored, level-0 files are skipped in scan (DV mode relies
+/// on compaction to produce higher-level files).
+#[tokio::test]
+async fn test_pk_dv_deduplicate_read_no_error() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_dv_dedup (
+                id INT NOT NULL, value INT,
+                PRIMARY KEY (id)
+            ) WITH ('bucket' = '1', 'deletion-vectors.enabled' = 'true')",
+        )
+        .await
+        .unwrap();
+
+    handler
+        .sql("INSERT INTO paimon.test_db.t_dv_dedup VALUES (1, 10), (2, 20)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Second commit with overlapping key — creates level-0 files
+    handler
+        .sql("INSERT INTO paimon.test_db.t_dv_dedup VALUES (2, 200), (3, 30)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Read must not error. DV mode skips level-0 files, so only compacted
+    // (level > 0) files are visible. Without compaction, all files are level-0
+    // and get skipped — count may be 0, but the read must succeed without error.
+    // Before the fix, this would hard-fail with "KeyValueFileReader does not
+    // support deletion vectors".
+    let result = handler
+        .sql("SELECT * FROM paimon.test_db.t_dv_dedup")
+        .await
+        .unwrap()
+        .collect()
+        .await;
+    assert!(
+        result.is_ok(),
+        "DV + Deduplicate read should not error: {:?}",
+        result.err()
+    );
+}

--- a/crates/integrations/datafusion/tests/pk_tables.rs
+++ b/crates/integrations/datafusion/tests/pk_tables.rs
@@ -20,92 +20,19 @@
 //! Covers: basic write+read, dedup within/across commits, partitioned PK tables,
 //! multi-bucket, column projection, FirstRow merge engine, sequence.field,
 //! INSERT OVERWRITE, filter pushdown, and error cases.
+//!
+//! Dynamic bucket and cross-partition tests are in separate files:
+//! - `dynamic_bucket_tables.rs`
+//! - `cross_partition_tables.rs`
 
-use std::sync::Arc;
+mod common;
 
+use common::{
+    collect_id_name, collect_id_value, create_handler, create_test_env, row_count, setup_handler,
+};
 use datafusion::arrow::array::{Int32Array, StringArray};
-use datafusion::prelude::SessionContext;
 use paimon::catalog::Identifier;
-use paimon::{Catalog, CatalogOptions, FileSystemCatalog, Options};
-use paimon_datafusion::{PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler};
-use tempfile::TempDir;
-
-// ======================= Helpers =======================
-
-fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
-    let temp_dir = TempDir::new().expect("Failed to create temp dir");
-    let warehouse = format!("file://{}", temp_dir.path().display());
-    let mut options = Options::new();
-    options.set(CatalogOptions::WAREHOUSE, warehouse);
-    let catalog = FileSystemCatalog::new(options).expect("Failed to create catalog");
-    (temp_dir, Arc::new(catalog))
-}
-
-fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
-    let ctx = SessionContext::new();
-    ctx.register_catalog(
-        "paimon",
-        Arc::new(PaimonCatalogProvider::new(catalog.clone())),
-    );
-    ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
-        .expect("Failed to register relation planner");
-    PaimonSqlHandler::new(ctx, catalog, "paimon")
-}
-
-async fn setup_handler() -> (TempDir, PaimonSqlHandler) {
-    let (tmp, catalog) = create_test_env();
-    let handler = create_handler(catalog);
-    handler
-        .sql("CREATE SCHEMA paimon.test_db")
-        .await
-        .expect("CREATE SCHEMA failed");
-    (tmp, handler)
-}
-
-async fn collect_id_name(handler: &PaimonSqlHandler, sql: &str) -> Vec<(i32, String)> {
-    let batches = handler.sql(sql).await.unwrap().collect().await.unwrap();
-    let mut rows = Vec::new();
-    for batch in &batches {
-        let ids = batch
-            .column_by_name("id")
-            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
-            .expect("id column");
-        let names = batch
-            .column_by_name("name")
-            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
-            .expect("name column");
-        for i in 0..batch.num_rows() {
-            rows.push((ids.value(i), names.value(i).to_string()));
-        }
-    }
-    rows.sort_by_key(|(id, _)| *id);
-    rows
-}
-
-async fn collect_id_value(handler: &PaimonSqlHandler, sql: &str) -> Vec<(i32, i32)> {
-    let batches = handler.sql(sql).await.unwrap().collect().await.unwrap();
-    let mut rows = Vec::new();
-    for batch in &batches {
-        let ids = batch
-            .column_by_name("id")
-            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
-            .expect("id column");
-        let vals = batch
-            .column_by_name("value")
-            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
-            .expect("value column");
-        for i in 0..batch.num_rows() {
-            rows.push((ids.value(i), vals.value(i)));
-        }
-    }
-    rows.sort_by_key(|(id, _)| *id);
-    rows
-}
-
-async fn row_count(handler: &PaimonSqlHandler, sql: &str) -> usize {
-    let batches = handler.sql(sql).await.unwrap().collect().await.unwrap();
-    batches.iter().map(|b| b.num_rows()).sum()
-}
+use paimon::Catalog;
 
 // ======================= Basic PK Write + Read =======================
 
@@ -942,34 +869,6 @@ async fn test_pk_partitioned_multi_bucket() {
 }
 
 // ======================= Error Cases =======================
-
-/// PK table with bucket=-1 (dynamic bucket) should be rejected.
-#[tokio::test]
-async fn test_pk_reject_dynamic_bucket() {
-    let (_tmp, handler) = setup_handler().await;
-
-    handler
-        .sql(
-            "CREATE TABLE paimon.test_db.t_dyn (
-                id INT NOT NULL, name STRING,
-                PRIMARY KEY (id)
-            )",
-        )
-        .await
-        .unwrap();
-
-    // bucket defaults to -1, PK write should fail
-    let result = handler
-        .sql("INSERT INTO paimon.test_db.t_dyn VALUES (1, 'alice')")
-        .await;
-
-    // The error may come from sql() or collect()
-    let is_err = match result {
-        Err(_) => true,
-        Ok(df) => df.collect().await.is_err(),
-    };
-    assert!(is_err, "PK table with dynamic bucket should reject writes");
-}
 
 /// PK table with changelog-producer=input should be rejected.
 #[tokio::test]

--- a/crates/paimon/src/spec/binary_row.rs
+++ b/crates/paimon/src/spec/binary_row.rs
@@ -343,6 +343,29 @@ impl BinaryRow {
         Ok(Some(datum))
     }
 
+    /// Build a BinaryRow from selected columns of an Arrow RecordBatch at a given row.
+    ///
+    /// `field_indices` maps each position in the output BinaryRow to a column index
+    /// in the batch; `fields` provides the Paimon DataField metadata for every column
+    /// in the schema (indexed by the same column indices).
+    pub fn from_arrow(
+        batch: &RecordBatch,
+        row_idx: usize,
+        field_indices: &[usize],
+        fields: &[crate::spec::DataField],
+    ) -> crate::Result<Self> {
+        let arity = field_indices.len() as i32;
+        let mut builder = BinaryRowBuilder::new(arity);
+        for (pos, &field_idx) in field_indices.iter().enumerate() {
+            let field = &fields[field_idx];
+            match extract_datum_from_arrow(batch, row_idx, field_idx, field.data_type())? {
+                Some(datum) => builder.write_datum(pos, &datum, field.data_type()),
+                None => builder.set_null_at(pos),
+            }
+        }
+        Ok(builder.build())
+    }
+
     /// Build a BinaryRow from typed Datum values using `BinaryRowBuilder`.
     /// `None` entries are written as null fields.
     pub fn from_datums(datums: &[(Option<&crate::spec::Datum>, &crate::spec::DataType)]) -> Self {
@@ -365,7 +388,7 @@ impl BinaryRow {
     ) -> i32 {
         let row = Self::from_datums(datums);
         let hash = row.hash_code();
-        (hash % total_buckets).abs()
+        (hash % total_buckets).wrapping_abs()
     }
 }
 
@@ -788,6 +811,344 @@ fn type_mismatch_err(expected: &str, col_idx: usize) -> crate::Error {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Batch-level BinaryRow utilities
+// ---------------------------------------------------------------------------
+
+/// Pre-downcast column reference to avoid per-row dynamic dispatch.
+enum TypedColumn<'a> {
+    Boolean(&'a arrow_array::BooleanArray),
+    Int8(&'a arrow_array::Int8Array),
+    Int16(&'a arrow_array::Int16Array),
+    Int32(&'a arrow_array::Int32Array),
+    Int64(&'a arrow_array::Int64Array),
+    Float32(&'a arrow_array::Float32Array),
+    Float64(&'a arrow_array::Float64Array),
+    Utf8(&'a arrow_array::StringArray),
+    Utf8View(&'a arrow_array::StringViewArray),
+    LargeUtf8(&'a arrow_array::LargeStringArray),
+    Date32(&'a arrow_array::Date32Array),
+    Decimal128(&'a arrow_array::Decimal128Array, u32, u32), // (array, precision, scale)
+    Binary(&'a arrow_array::BinaryArray),
+    TimestampMs(&'a arrow_array::TimestampMillisecondArray),
+    TimestampUs(&'a arrow_array::TimestampMicrosecondArray),
+}
+
+/// Downcast Arrow columns once, returning typed references paired with their DataType.
+fn downcast_columns<'a>(
+    batch: &'a RecordBatch,
+    field_indices: &[usize],
+    fields: &'a [crate::spec::DataField],
+) -> crate::Result<Vec<(TypedColumn<'a>, &'a crate::spec::DataField)>> {
+    use arrow_array::Array;
+    field_indices
+        .iter()
+        .map(|&col_idx| {
+            let field = &fields[col_idx];
+            let col = batch.column(col_idx);
+            let typed =
+                match field.data_type() {
+                    DataType::Boolean(_) => TypedColumn::Boolean(
+                        col.as_any()
+                            .downcast_ref()
+                            .ok_or_else(|| type_mismatch_err("Boolean", col_idx))?,
+                    ),
+                    DataType::TinyInt(_) => TypedColumn::Int8(
+                        col.as_any()
+                            .downcast_ref()
+                            .ok_or_else(|| type_mismatch_err("TinyInt", col_idx))?,
+                    ),
+                    DataType::SmallInt(_) => TypedColumn::Int16(
+                        col.as_any()
+                            .downcast_ref()
+                            .ok_or_else(|| type_mismatch_err("SmallInt", col_idx))?,
+                    ),
+                    DataType::Int(_) => TypedColumn::Int32(
+                        col.as_any()
+                            .downcast_ref()
+                            .ok_or_else(|| type_mismatch_err("Int", col_idx))?,
+                    ),
+                    DataType::BigInt(_) => TypedColumn::Int64(
+                        col.as_any()
+                            .downcast_ref()
+                            .ok_or_else(|| type_mismatch_err("BigInt", col_idx))?,
+                    ),
+                    DataType::Float(_) => TypedColumn::Float32(
+                        col.as_any()
+                            .downcast_ref()
+                            .ok_or_else(|| type_mismatch_err("Float", col_idx))?,
+                    ),
+                    DataType::Double(_) => TypedColumn::Float64(
+                        col.as_any()
+                            .downcast_ref()
+                            .ok_or_else(|| type_mismatch_err("Double", col_idx))?,
+                    ),
+                    DataType::Char(_) | DataType::VarChar(_) => {
+                        if let Some(arr) = col.as_any().downcast_ref::<arrow_array::StringArray>() {
+                            TypedColumn::Utf8(arr)
+                        } else if let Some(arr) =
+                            col.as_any().downcast_ref::<arrow_array::StringViewArray>()
+                        {
+                            TypedColumn::Utf8View(arr)
+                        } else if let Some(arr) =
+                            col.as_any().downcast_ref::<arrow_array::LargeStringArray>()
+                        {
+                            TypedColumn::LargeUtf8(arr)
+                        } else {
+                            return Err(type_mismatch_err("String", col_idx));
+                        }
+                    }
+                    DataType::Date(_) => TypedColumn::Date32(
+                        col.as_any()
+                            .downcast_ref()
+                            .ok_or_else(|| type_mismatch_err("Date", col_idx))?,
+                    ),
+                    DataType::Decimal(d) => TypedColumn::Decimal128(
+                        col.as_any()
+                            .downcast_ref()
+                            .ok_or_else(|| type_mismatch_err("Decimal", col_idx))?,
+                        d.precision(),
+                        d.scale(),
+                    ),
+                    DataType::Binary(_) | DataType::VarBinary(_) => TypedColumn::Binary(
+                        col.as_any()
+                            .downcast_ref()
+                            .ok_or_else(|| type_mismatch_err("Binary", col_idx))?,
+                    ),
+                    DataType::Timestamp(ts) => {
+                        if ts.precision() <= 3 {
+                            TypedColumn::TimestampMs(
+                                col.as_any()
+                                    .downcast_ref()
+                                    .ok_or_else(|| type_mismatch_err("Timestamp(ms)", col_idx))?,
+                            )
+                        } else {
+                            TypedColumn::TimestampUs(
+                                col.as_any()
+                                    .downcast_ref()
+                                    .ok_or_else(|| type_mismatch_err("Timestamp(us)", col_idx))?,
+                            )
+                        }
+                    }
+                    DataType::LocalZonedTimestamp(ts) => {
+                        if ts.precision() <= 3 {
+                            TypedColumn::TimestampMs(col.as_any().downcast_ref().ok_or_else(
+                                || type_mismatch_err("LocalZonedTimestamp(ms)", col_idx),
+                            )?)
+                        } else {
+                            TypedColumn::TimestampUs(col.as_any().downcast_ref().ok_or_else(
+                                || type_mismatch_err("LocalZonedTimestamp(us)", col_idx),
+                            )?)
+                        }
+                    }
+                    other => {
+                        return Err(crate::Error::Unsupported {
+                            message: format!(
+                                "Unsupported data type {:?} for batch column downcast at column {}",
+                                other, col_idx
+                            ),
+                        });
+                    }
+                };
+            Ok((typed, field))
+        })
+        .collect()
+}
+
+/// Write a value from a pre-downcast column into a BinaryRowBuilder at the given position.
+fn write_typed_value(
+    builder: &mut BinaryRowBuilder,
+    pos: usize,
+    row_idx: usize,
+    typed_col: &TypedColumn,
+    _data_type: &DataType,
+) {
+    use arrow_array::Array;
+    match typed_col {
+        TypedColumn::Boolean(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                builder.write_boolean(pos, arr.value(row_idx));
+            }
+        }
+        TypedColumn::Int8(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                builder.write_byte(pos, arr.value(row_idx));
+            }
+        }
+        TypedColumn::Int16(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                builder.write_short(pos, arr.value(row_idx));
+            }
+        }
+        TypedColumn::Int32(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                builder.write_int(pos, arr.value(row_idx));
+            }
+        }
+        TypedColumn::Int64(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                builder.write_long(pos, arr.value(row_idx));
+            }
+        }
+        TypedColumn::Float32(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                builder.write_float(pos, arr.value(row_idx));
+            }
+        }
+        TypedColumn::Float64(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                builder.write_double(pos, arr.value(row_idx));
+            }
+        }
+        TypedColumn::Utf8(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                let s = arr.value(row_idx);
+                if s.len() <= 7 {
+                    builder.write_string_inline(pos, s);
+                } else {
+                    builder.write_string(pos, s);
+                }
+            }
+        }
+        TypedColumn::Utf8View(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                let s = arr.value(row_idx);
+                if s.len() <= 7 {
+                    builder.write_string_inline(pos, s);
+                } else {
+                    builder.write_string(pos, s);
+                }
+            }
+        }
+        TypedColumn::LargeUtf8(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                let s = arr.value(row_idx);
+                if s.len() <= 7 {
+                    builder.write_string_inline(pos, s);
+                } else {
+                    builder.write_string(pos, s);
+                }
+            }
+        }
+        TypedColumn::Date32(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                builder.write_int(pos, arr.value(row_idx));
+            }
+        }
+        TypedColumn::Decimal128(arr, precision, _scale) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                let unscaled = arr.value(row_idx);
+                if *precision <= 18 {
+                    builder.write_decimal_compact(pos, unscaled as i64);
+                } else {
+                    builder.write_decimal_var_len(pos, unscaled);
+                }
+            }
+        }
+        TypedColumn::Binary(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                let b = arr.value(row_idx);
+                if b.len() <= 7 {
+                    builder.write_binary_inline(pos, b);
+                } else {
+                    builder.write_binary(pos, b);
+                }
+            }
+        }
+        TypedColumn::TimestampMs(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                builder.write_timestamp_compact(pos, arr.value(row_idx));
+            }
+        }
+        TypedColumn::TimestampUs(arr) => {
+            if arr.is_null(row_idx) {
+                builder.set_null_at(pos);
+            } else {
+                let micros = arr.value(row_idx);
+                let millis = micros / 1000;
+                let nanos = ((micros % 1000) * 1000) as i32;
+                builder.write_timestamp_non_compact(pos, millis, nanos);
+            }
+        }
+    }
+}
+
+/// Build BinaryRows for all rows in the batch for the given field indices.
+/// Downcasts columns once, then iterates rows — O(F) downcasts instead of O(N*F).
+fn batch_build_binary_rows(
+    batch: &RecordBatch,
+    field_indices: &[usize],
+    fields: &[crate::spec::DataField],
+) -> crate::Result<Vec<BinaryRow>> {
+    let typed_columns = downcast_columns(batch, field_indices, fields)?;
+    let arity = field_indices.len() as i32;
+    let num_rows = batch.num_rows();
+    let mut rows = Vec::with_capacity(num_rows);
+
+    for row_idx in 0..num_rows {
+        let mut builder = BinaryRowBuilder::new(arity);
+        for (pos, (typed_col, field)) in typed_columns.iter().enumerate() {
+            write_typed_value(&mut builder, pos, row_idx, typed_col, field.data_type());
+        }
+        rows.push(builder.build());
+    }
+    Ok(rows)
+}
+
+/// Batch-compute serialized partition bytes for all rows.
+/// Returns one `Vec<u8>` per row, identical to calling
+/// `BinaryRow::from_arrow(batch, row_idx, field_indices, fields).to_serialized_bytes()`
+/// for each row, but with O(F) column downcasts instead of O(N*F).
+pub fn batch_to_serialized_bytes(
+    batch: &RecordBatch,
+    field_indices: &[usize],
+    fields: &[crate::spec::DataField],
+) -> crate::Result<Vec<Vec<u8>>> {
+    let rows = batch_build_binary_rows(batch, field_indices, fields)?;
+    Ok(rows.into_iter().map(|r| r.to_serialized_bytes()).collect())
+}
+
+/// Batch-compute Murmur3 hash codes for all rows.
+/// Returns one `i32` per row, identical to calling
+/// `BinaryRow::from_arrow(batch, row_idx, field_indices, fields).hash_code()`
+/// for each row, but with O(F) column downcasts instead of O(N*F).
+pub fn batch_hash_codes(
+    batch: &RecordBatch,
+    field_indices: &[usize],
+    fields: &[crate::spec::DataField],
+) -> crate::Result<Vec<i32>> {
+    let rows = batch_build_binary_rows(batch, field_indices, fields)?;
+    Ok(rows.into_iter().map(|r| r.hash_code()).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1097,5 +1458,54 @@ mod tests {
         let (millis, nano) = row.get_timestamp_raw(0, 6).unwrap();
         assert_eq!(millis, epoch_millis);
         assert_eq!(nano, nano_of_milli);
+    }
+
+    #[test]
+    fn test_batch_vs_per_row_equivalence() {
+        use arrow_array::{Int32Array, StringArray};
+        use arrow_schema::{DataType as ArrowDT, Field, Schema};
+        use std::sync::Arc;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", ArrowDT::Int32, true),
+            Field::new("name", ArrowDT::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![Some(1), None, Some(3)])),
+                Arc::new(StringArray::from(vec![Some("hello"), Some("world"), None])),
+            ],
+        )
+        .unwrap();
+
+        let fields = vec![
+            crate::spec::DataField::new(0, "id".into(), DataType::Int(crate::spec::IntType::new())),
+            crate::spec::DataField::new(
+                1,
+                "name".into(),
+                DataType::VarChar(crate::spec::VarCharType::string_type()),
+            ),
+        ];
+        let indices = vec![0, 1];
+
+        // Batch results
+        let batch_bytes = batch_to_serialized_bytes(&batch, &indices, &fields).unwrap();
+        let batch_hashes = batch_hash_codes(&batch, &indices, &fields).unwrap();
+
+        // Per-row results
+        for row_idx in 0..batch.num_rows() {
+            let row = BinaryRow::from_arrow(&batch, row_idx, &indices, &fields).unwrap();
+            assert_eq!(
+                batch_bytes[row_idx],
+                row.to_serialized_bytes(),
+                "serialized bytes mismatch at row {row_idx}"
+            );
+            assert_eq!(
+                batch_hashes[row_idx],
+                row.hash_code(),
+                "hash code mismatch at row {row_idx}"
+            );
+        }
     }
 }

--- a/crates/paimon/src/spec/core_options.rs
+++ b/crates/paimon/src/spec/core_options.rs
@@ -56,6 +56,8 @@ const DEFAULT_SOURCE_SPLIT_OPEN_FILE_COST: i64 = 4 * 1024 * 1024;
 const DEFAULT_PARTITION_DEFAULT_NAME: &str = "__DEFAULT_PARTITION__";
 const DEFAULT_TARGET_FILE_SIZE: i64 = 256 * 1024 * 1024;
 const DEFAULT_WRITE_PARQUET_BUFFER_SIZE: i64 = 256 * 1024 * 1024;
+const DYNAMIC_BUCKET_TARGET_ROW_NUM_OPTION: &str = "dynamic-bucket.target-row-num";
+const DEFAULT_DYNAMIC_BUCKET_TARGET_ROW_NUM: i64 = 200_000;
 
 /// Merge engine for primary-key tables.
 ///
@@ -346,6 +348,16 @@ impl<'a> CoreOptions<'a> {
             .get(WRITE_PARQUET_BUFFER_SIZE_OPTION)
             .and_then(|v| parse_memory_size(v))
             .unwrap_or(DEFAULT_WRITE_PARQUET_BUFFER_SIZE)
+    }
+
+    /// Target row number per bucket for dynamic bucket mode (bucket=-1).
+    /// When a bucket reaches this number, a new bucket is created.
+    /// Default is 200,000 (matching Java Paimon).
+    pub fn dynamic_bucket_target_row_num(&self) -> i64 {
+        self.options
+            .get(DYNAMIC_BUCKET_TARGET_ROW_NUM_OPTION)
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_DYNAMIC_BUCKET_TARGET_ROW_NUM)
     }
 }
 

--- a/crates/paimon/src/spec/index_file_meta.rs
+++ b/crates/paimon/src/spec/index_file_meta.rs
@@ -51,7 +51,7 @@ pub struct GlobalIndexMeta {
 /// Metadata of index file.
 ///
 /// Impl Reference: <https://github.com/apache/paimon/blob/release-0.8.2/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMeta.java>
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IndexFileMeta {
     #[serde(rename = "_INDEX_TYPE")]
     pub index_type: String,

--- a/crates/paimon/src/spec/index_manifest.rs
+++ b/crates/paimon/src/spec/index_manifest.rs
@@ -28,6 +28,11 @@ use crate::Result;
 /// Avro schema for IndexManifestEntry OCF serialization.
 ///
 /// Must match the serde layout of `IndexManifestEntry`.
+///
+/// Note: `_FILE_SIZE` and `_ROW_COUNT` are declared as Avro `long` to match
+/// Java Paimon's schema, while the Rust `IndexFileMeta` fields are `i32`.
+/// `serde_avro_fast` transparently coerces between integer widths during
+/// serialization/deserialization, so the mismatch is intentional.
 pub const INDEX_MANIFEST_ENTRY_SCHEMA: &str = r#"{
     "type": "record",
     "name": "org.apache.paimon.avro.generated.record",
@@ -55,6 +60,21 @@ pub const INDEX_MANIFEST_ENTRY_SCHEMA: &str = r#"{
                         {"name": "_CARDINALITY", "type": ["null", "long"], "default": null}
                     ]
                 }]
+            }]
+        },
+        {
+            "default": null,
+            "name": "_GLOBAL_INDEX",
+            "type": ["null", {
+                "type": "record",
+                "name": "org.apache.paimon.avro.generated.record__GLOBAL_INDEX",
+                "fields": [
+                    {"name": "_ROW_RANGE_START", "type": "long"},
+                    {"name": "_ROW_RANGE_END", "type": "long"},
+                    {"name": "_INDEX_FIELD_ID", "type": "int"},
+                    {"name": "_EXTRA_FIELD_IDS", "type": ["null", {"type": "array", "items": "int"}], "default": null},
+                    {"name": "_INDEX_META", "type": ["null", "bytes"], "default": null}
+                ]
             }]
         }
     ]

--- a/crates/paimon/src/spec/index_manifest.rs
+++ b/crates/paimon/src/spec/index_manifest.rs
@@ -25,10 +25,45 @@ use std::fmt::{Display, Formatter};
 
 use crate::Result;
 
+/// Avro schema for IndexManifestEntry OCF serialization.
+///
+/// Must match the serde layout of `IndexManifestEntry`.
+pub const INDEX_MANIFEST_ENTRY_SCHEMA: &str = r#"{
+    "type": "record",
+    "name": "org.apache.paimon.avro.generated.record",
+    "fields": [
+        {"name": "_VERSION", "type": "int"},
+        {"name": "_KIND", "type": "int"},
+        {"name": "_PARTITION", "type": "bytes"},
+        {"name": "_BUCKET", "type": "int"},
+        {"name": "_INDEX_TYPE", "type": "string"},
+        {"name": "_FILE_NAME", "type": "string"},
+        {"name": "_FILE_SIZE", "type": "long"},
+        {"name": "_ROW_COUNT", "type": "long"},
+        {
+            "default": null,
+            "name": "_DELETIONS_VECTORS_RANGES",
+            "type": ["null", {
+                "type": "array",
+                "items": ["null", {
+                    "type": "record",
+                    "name": "org.apache.paimon.avro.generated.record__DELETIONS_VECTORS_RANGES",
+                    "fields": [
+                        {"name": "f0", "type": "string"},
+                        {"name": "f1", "type": "int"},
+                        {"name": "f2", "type": "int"},
+                        {"name": "_CARDINALITY", "type": ["null", "long"], "default": null}
+                    ]
+                }]
+            }]
+        }
+    ]
+}"#;
+
 /// Manifest entry for index file.
 ///
 /// Impl Reference: <https://github.com/apache/paimon/blob/release-0.8.2/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java>
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IndexManifestEntry {
     #[serde(rename = "_KIND")]
     pub kind: FileKind,
@@ -80,6 +115,13 @@ impl IndexManifest {
             .deserialize::<IndexManifestEntry>()
             .collect::<std::result::Result<Vec<_>, _>>()
             .whatever_context::<_, crate::Error>("deserialize index manifest entry")
+    }
+
+    /// Write index manifest entries to a file.
+    pub async fn write(file_io: &FileIO, path: &str, entries: &[IndexManifestEntry]) -> Result<()> {
+        let bytes = crate::spec::to_avro_bytes(INDEX_MANIFEST_ENTRY_SCHEMA, entries)?;
+        let output = file_io.new_output(path)?;
+        output.write(bytes::Bytes::from(bytes)).await
     }
 }
 

--- a/crates/paimon/src/spec/schema.rs
+++ b/crates/paimon/src/spec/schema.rs
@@ -142,7 +142,7 @@ impl TableSchema {
             return keys;
         }
         if !self.primary_keys.is_empty() {
-            return self.primary_keys.clone();
+            return self.trimmed_primary_keys();
         }
         let partition_set: HashSet<&str> = self.partition_keys.iter().map(String::as_str).collect();
         self.fields

--- a/crates/paimon/src/spec/schema.rs
+++ b/crates/paimon/src/spec/schema.rs
@@ -98,6 +98,22 @@ impl TableSchema {
         &self.primary_keys
     }
 
+    /// Primary keys with partition columns removed.
+    ///
+    /// Within a single partition the partition columns are constant, so they
+    /// are redundant in the KV key. Java Paimon calls these "trimmed primary keys".
+    pub fn trimmed_primary_keys(&self) -> Vec<String> {
+        if self.partition_keys.is_empty() {
+            return self.primary_keys.clone();
+        }
+        let partition_set: HashSet<&str> = self.partition_keys.iter().map(String::as_str).collect();
+        self.primary_keys
+            .iter()
+            .filter(|pk| !partition_set.contains(pk.as_str()))
+            .cloned()
+            .collect()
+    }
+
     pub fn options(&self) -> &HashMap<String, String> {
         &self.options
     }
@@ -477,6 +493,22 @@ impl Schema {
 
     pub fn primary_keys(&self) -> &[String] {
         &self.primary_keys
+    }
+
+    /// Primary keys with partition columns removed.
+    ///
+    /// Within a single partition the partition columns are constant, so they
+    /// are redundant in the KV key. Java Paimon calls these "trimmed primary keys".
+    pub fn trimmed_primary_keys(&self) -> Vec<String> {
+        if self.partition_keys.is_empty() {
+            return self.primary_keys.clone();
+        }
+        let partition_set: HashSet<&str> = self.partition_keys.iter().map(String::as_str).collect();
+        self.primary_keys
+            .iter()
+            .filter(|pk| !partition_set.contains(pk.as_str()))
+            .cloned()
+            .collect()
     }
 
     pub fn options(&self) -> &HashMap<String, String> {

--- a/crates/paimon/src/table/bucket_assigner.rs
+++ b/crates/paimon/src/table/bucket_assigner.rs
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Bucket assignment strategy for different bucket modes.
+//!
+//! Uses enum dispatch to avoid dynamic dispatch overhead while keeping
+//! the different bucket modes in separate files.
+
+use crate::io::FileIO;
+use crate::spec::{DataField, IndexFileMeta};
+use crate::table::bucket_assigner_constant::ConstantBucketAssigner;
+use crate::table::bucket_assigner_cross::CrossPartitionAssigner;
+use crate::table::bucket_assigner_dynamic::DynamicBucketAssigner;
+use crate::table::bucket_assigner_fixed::FixedBucketAssigner;
+use crate::Result;
+use arrow_array::RecordBatch;
+use std::collections::HashMap;
+
+pub(crate) type PartitionBucketKey = (Vec<u8>, i32);
+
+/// Output of batch-level bucket assignment.
+pub(crate) struct BatchAssignOutput {
+    /// Per-row partition bytes. Length == batch.num_rows().
+    pub partition_bytes: Vec<Vec<u8>>,
+    /// Per-row bucket assignment. Length == batch.num_rows().
+    pub buckets: Vec<i32>,
+    /// Sparse delete info for cross-partition migrations.
+    /// Each entry: (row_idx, old_partition_bytes, old_bucket).
+    pub deletes: Vec<(usize, Vec<u8>, i32)>,
+    /// Row indices to skip entirely (FIRST_ROW: key already exists in another partition).
+    pub skips: Vec<usize>,
+}
+
+/// Bucket assignment strategy. Different bucket modes implement this trait.
+pub(crate) trait BucketAssigner: Send {
+    /// Assign partitions and buckets for all rows in the batch.
+    /// May perform async I/O (e.g., loading indexes) before assignment.
+    fn assign_batch(
+        &mut self,
+        batch: &RecordBatch,
+        fields: &[DataField],
+    ) -> impl std::future::Future<Output = Result<BatchAssignOutput>> + Send;
+
+    /// Collect index files at commit time. Returns (partition_bucket_key -> index_files).
+    fn prepare_commit_index(
+        &mut self,
+        file_io: &FileIO,
+        index_dir: &str,
+    ) -> impl std::future::Future<Output = Result<HashMap<PartitionBucketKey, Vec<IndexFileMeta>>>> + Send;
+}
+
+/// Enum dispatch wrapper for the bucket assigner implementations.
+pub(crate) enum BucketAssignerEnum {
+    Constant(ConstantBucketAssigner),
+    Fixed(FixedBucketAssigner),
+    Dynamic(DynamicBucketAssigner),
+    CrossPartition(Box<CrossPartitionAssigner>),
+}
+
+impl BucketAssignerEnum {
+    pub async fn assign_batch(
+        &mut self,
+        batch: &RecordBatch,
+        fields: &[DataField],
+    ) -> Result<BatchAssignOutput> {
+        match self {
+            Self::Constant(a) => a.assign_batch(batch, fields).await,
+            Self::Fixed(a) => a.assign_batch(batch, fields).await,
+            Self::Dynamic(a) => a.assign_batch(batch, fields).await,
+            Self::CrossPartition(a) => a.assign_batch(batch, fields).await,
+        }
+    }
+
+    pub async fn prepare_commit_index(
+        &mut self,
+        file_io: &FileIO,
+        index_dir: &str,
+    ) -> Result<HashMap<PartitionBucketKey, Vec<IndexFileMeta>>> {
+        match self {
+            Self::Constant(a) => a.prepare_commit_index(file_io, index_dir).await,
+            Self::Fixed(a) => a.prepare_commit_index(file_io, index_dir).await,
+            Self::Dynamic(a) => a.prepare_commit_index(file_io, index_dir).await,
+            Self::CrossPartition(a) => a.prepare_commit_index(file_io, index_dir).await,
+        }
+    }
+}

--- a/crates/paimon/src/table/bucket_assigner_constant.rs
+++ b/crates/paimon/src/table/bucket_assigner_constant.rs
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Constant bucket assigner for tables with a constant bucket value.
+//!
+//! Used for append-only single-bucket tables (bucket=0) and postpone tables (bucket=-2).
+
+use crate::io::FileIO;
+use crate::spec::{batch_to_serialized_bytes, DataField, IndexFileMeta, EMPTY_SERIALIZED_ROW};
+use crate::table::bucket_assigner::{BatchAssignOutput, BucketAssigner, PartitionBucketKey};
+use crate::Result;
+use arrow_array::RecordBatch;
+use std::collections::HashMap;
+
+/// Bucket assigner that always returns a constant bucket value.
+///
+/// No index loading or commit-time index files — pure partition extraction.
+pub(crate) struct ConstantBucketAssigner {
+    partition_field_indices: Vec<usize>,
+    bucket: i32,
+}
+
+impl ConstantBucketAssigner {
+    pub fn new(partition_field_indices: Vec<usize>, bucket: i32) -> Self {
+        Self {
+            partition_field_indices,
+            bucket,
+        }
+    }
+
+    pub fn bucket(&self) -> i32 {
+        self.bucket
+    }
+}
+
+impl BucketAssigner for ConstantBucketAssigner {
+    async fn assign_batch(
+        &mut self,
+        batch: &RecordBatch,
+        fields: &[DataField],
+    ) -> Result<BatchAssignOutput> {
+        let num_rows = batch.num_rows();
+        let partition_bytes = if self.partition_field_indices.is_empty() {
+            vec![EMPTY_SERIALIZED_ROW.clone(); num_rows]
+        } else {
+            batch_to_serialized_bytes(batch, &self.partition_field_indices, fields)?
+        };
+
+        Ok(BatchAssignOutput {
+            partition_bytes,
+            buckets: vec![self.bucket; num_rows],
+            deletes: Vec::new(),
+            skips: Vec::new(),
+        })
+    }
+
+    async fn prepare_commit_index(
+        &mut self,
+        _file_io: &FileIO,
+        _index_dir: &str,
+    ) -> Result<HashMap<PartitionBucketKey, Vec<IndexFileMeta>>> {
+        Ok(HashMap::new())
+    }
+}

--- a/crates/paimon/src/table/bucket_assigner_cross.rs
+++ b/crates/paimon/src/table/bucket_assigner_cross.rs
@@ -1,0 +1,346 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Cross-partition bucket assigner for PK tables where PK does not include partition fields.
+//!
+//! Builds the global PK → (partition, bucket) index by scanning all data files.
+
+use crate::io::FileIO;
+use crate::spec::{batch_to_serialized_bytes, DataField, IndexFileMeta, MergeEngine};
+use crate::table::bucket_assigner::{BatchAssignOutput, BucketAssigner, PartitionBucketKey};
+use crate::table::Table;
+use crate::Result;
+use arrow_array::RecordBatch;
+use futures::TryStreamExt;
+use std::collections::{HashMap, HashSet};
+
+/// Result of assigning a bucket for a key in cross-partition mode.
+enum AssignResult {
+    /// Key is new or stays in the same partition.
+    SamePartition { bucket: i32 },
+    /// Key moved to a different partition. Caller must write a DELETE to the old location.
+    CrossPartition {
+        old_partition: Vec<u8>,
+        old_bucket: i32,
+        new_bucket: i32,
+    },
+    /// FIRST_ROW: key already exists in a different partition, skip this row.
+    Skip,
+}
+
+/// Global index that maps primary keys to (partition, bucket) across all partitions.
+///
+/// Uses serialized PK bytes as the lookup key to avoid hash collisions.
+struct GlobalPartitionIndex {
+    /// pk_bytes -> (partition_bytes, bucket)
+    key_to_location: HashMap<Vec<u8>, (Vec<u8>, i32)>,
+    /// partition -> { bucket -> row_count } (only non-full buckets)
+    partition_non_full_buckets: HashMap<Vec<u8>, HashMap<i32, i64>>,
+    /// partition -> all known bucket ids
+    partition_all_buckets: HashMap<Vec<u8>, HashSet<i32>>,
+    /// partition -> next bucket id to allocate (avoids linear scan)
+    partition_next_bucket_id: HashMap<Vec<u8>, i32>,
+    /// (partition, bucket) -> total row count
+    bucket_row_counts: HashMap<(Vec<u8>, i32), i64>,
+    target_bucket_row_number: i64,
+    merge_engine: MergeEngine,
+}
+
+impl GlobalPartitionIndex {
+    /// Build the global partition index by scanning all data files from the latest snapshot.
+    ///
+    /// Uses TableRead to get deduplicated PK rows per split, so DELETE records
+    /// from previous cross-partition migrations are automatically filtered out.
+    async fn load_from_data_scan(
+        table: &Table,
+        primary_key_indices: &[usize],
+        target_bucket_row_number: i64,
+        merge_engine: MergeEngine,
+    ) -> Result<Self> {
+        let mut key_to_location: HashMap<Vec<u8>, (Vec<u8>, i32)> = HashMap::new();
+        let mut bucket_row_counts: HashMap<(Vec<u8>, i32), i64> = HashMap::new();
+
+        let fields = table.schema().fields();
+        let pk_field_names: Vec<&str> = primary_key_indices
+            .iter()
+            .map(|&idx| fields[idx].name())
+            .collect();
+        let pk_fields: Vec<DataField> = primary_key_indices
+            .iter()
+            .map(|&idx| fields[idx].clone())
+            .collect();
+        let projected_pk_indices: Vec<usize> = (0..pk_fields.len()).collect();
+
+        let mut rb = table.new_read_builder();
+        rb.with_projection(&pk_field_names);
+        let scan = rb.new_scan().with_scan_all_files();
+        let plan = scan.plan().await?;
+        let read = rb.new_read()?;
+
+        for split in plan.splits() {
+            let partition_bytes = split.partition().to_serialized_bytes();
+            let bucket = split.bucket();
+
+            let batches: Vec<RecordBatch> = read
+                .to_arrow(std::slice::from_ref(split))?
+                .try_collect()
+                .await?;
+
+            let pb_key = (partition_bytes.clone(), bucket);
+            for batch in &batches {
+                let pk_bytes_vec =
+                    batch_to_serialized_bytes(batch, &projected_pk_indices, &pk_fields)?;
+                let count = pk_bytes_vec.len() as i64;
+                for pk_bytes in pk_bytes_vec {
+                    key_to_location.insert(pk_bytes, (partition_bytes.clone(), bucket));
+                }
+                *bucket_row_counts.entry(pb_key.clone()).or_insert(0) += count;
+            }
+        }
+
+        let mut partition_all_buckets: HashMap<Vec<u8>, HashSet<i32>> = HashMap::new();
+        let mut partition_non_full_buckets: HashMap<Vec<u8>, HashMap<i32, i64>> = HashMap::new();
+        for ((partition, bucket), count) in &bucket_row_counts {
+            partition_all_buckets
+                .entry(partition.clone())
+                .or_default()
+                .insert(*bucket);
+            if *count < target_bucket_row_number {
+                partition_non_full_buckets
+                    .entry(partition.clone())
+                    .or_default()
+                    .insert(*bucket, *count);
+            }
+        }
+
+        let partition_next_bucket_id: HashMap<Vec<u8>, i32> = partition_all_buckets
+            .iter()
+            .map(|(p, buckets)| {
+                let next = buckets.iter().copied().max().map_or(0, |m| m + 1);
+                (p.clone(), next)
+            })
+            .collect();
+
+        Ok(Self {
+            key_to_location,
+            partition_non_full_buckets,
+            partition_all_buckets,
+            partition_next_bucket_id,
+            bucket_row_counts,
+            target_bucket_row_number,
+            merge_engine,
+        })
+    }
+
+    /// Assign a bucket for the given primary key targeting `new_partition`.
+    fn assign(&mut self, pk_bytes: &[u8], new_partition: &[u8]) -> AssignResult {
+        if let Some((existing_partition, existing_bucket)) = self.key_to_location.get(pk_bytes) {
+            if existing_partition == new_partition {
+                return AssignResult::SamePartition {
+                    bucket: *existing_bucket,
+                };
+            }
+
+            // Key exists in a different partition
+            match self.merge_engine {
+                MergeEngine::FirstRow => {
+                    // FIRST_ROW: keep old data, discard new row
+                    return AssignResult::Skip;
+                }
+                MergeEngine::Deduplicate => {
+                    let old_partition = existing_partition.clone();
+                    let old_bucket = *existing_bucket;
+
+                    // Decrement row count for old bucket
+                    let old_key = (old_partition.clone(), old_bucket);
+                    let old_count = self.bucket_row_counts.get(&old_key).copied().unwrap_or(0);
+                    let new_count = (old_count - 1).max(0);
+                    self.bucket_row_counts.insert(old_key, new_count);
+                    if new_count < self.target_bucket_row_number {
+                        self.partition_non_full_buckets
+                            .entry(old_partition.clone())
+                            .or_default()
+                            .insert(old_bucket, new_count);
+                    }
+
+                    let new_bucket = self.assign_bucket_in_partition(new_partition);
+                    self.key_to_location
+                        .insert(pk_bytes.to_vec(), (new_partition.to_vec(), new_bucket));
+
+                    return AssignResult::CrossPartition {
+                        old_partition,
+                        old_bucket,
+                        new_bucket,
+                    };
+                }
+            }
+        }
+
+        let bucket = self.assign_bucket_in_partition(new_partition);
+        self.key_to_location
+            .insert(pk_bytes.to_vec(), (new_partition.to_vec(), bucket));
+        AssignResult::SamePartition { bucket }
+    }
+
+    fn assign_bucket_in_partition(&mut self, partition: &[u8]) -> i32 {
+        let non_full = self
+            .partition_non_full_buckets
+            .entry(partition.to_vec())
+            .or_default();
+
+        let mut full_buckets = Vec::new();
+        let mut assigned_bucket = None;
+        for (&bucket, count) in non_full.iter_mut() {
+            if *count < self.target_bucket_row_number {
+                *count += 1;
+                assigned_bucket = Some(bucket);
+                break;
+            } else {
+                full_buckets.push(bucket);
+            }
+        }
+        for b in full_buckets {
+            non_full.remove(&b);
+        }
+
+        let bucket = if let Some(b) = assigned_bucket {
+            b
+        } else {
+            let all = self
+                .partition_all_buckets
+                .entry(partition.to_vec())
+                .or_default();
+            let next_id = self
+                .partition_next_bucket_id
+                .entry(partition.to_vec())
+                .or_insert(0);
+            let new_bucket = *next_id;
+            *next_id += 1;
+            all.insert(new_bucket);
+            self.partition_non_full_buckets
+                .entry(partition.to_vec())
+                .or_default()
+                .insert(new_bucket, 1);
+            new_bucket
+        };
+
+        *self
+            .bucket_row_counts
+            .entry((partition.to_vec(), bucket))
+            .or_insert(0) += 1;
+
+        bucket
+    }
+}
+
+/// Bucket assigner for cross-partition update mode.
+///
+/// Used when PK does not include partition fields and bucket=-1 (dynamic).
+/// A record's partition can change over time, requiring a global index
+/// across all partitions and DELETE generation for the old location.
+pub(crate) struct CrossPartitionAssigner {
+    table: Table,
+    partition_field_indices: Vec<usize>,
+    primary_key_indices: Vec<usize>,
+    global_partition_index: Option<GlobalPartitionIndex>,
+    target_bucket_row_number: i64,
+    merge_engine: MergeEngine,
+}
+
+impl CrossPartitionAssigner {
+    pub fn new(
+        table: Table,
+        partition_field_indices: Vec<usize>,
+        primary_key_indices: Vec<usize>,
+        target_bucket_row_number: i64,
+        merge_engine: MergeEngine,
+    ) -> Self {
+        Self {
+            table,
+            partition_field_indices,
+            primary_key_indices,
+            global_partition_index: None,
+            target_bucket_row_number,
+            merge_engine,
+        }
+    }
+}
+
+impl BucketAssigner for CrossPartitionAssigner {
+    async fn assign_batch(
+        &mut self,
+        batch: &RecordBatch,
+        fields: &[DataField],
+    ) -> Result<BatchAssignOutput> {
+        // Lazily load global partition index by scanning data files.
+        if self.global_partition_index.is_none() {
+            let index = GlobalPartitionIndex::load_from_data_scan(
+                &self.table,
+                &self.primary_key_indices,
+                self.target_bucket_row_number,
+                self.merge_engine,
+            )
+            .await?;
+            self.global_partition_index = Some(index);
+        }
+
+        let partition_bytes_vec =
+            batch_to_serialized_bytes(batch, &self.partition_field_indices, fields)?;
+        let pk_bytes_vec = batch_to_serialized_bytes(batch, &self.primary_key_indices, fields)?;
+
+        let global_index = self.global_partition_index.as_mut().unwrap();
+        let num_rows = batch.num_rows();
+        let mut buckets = Vec::with_capacity(num_rows);
+        let mut deletes = Vec::new();
+        let mut skips = Vec::new();
+
+        for row_idx in 0..num_rows {
+            match global_index.assign(&pk_bytes_vec[row_idx], &partition_bytes_vec[row_idx]) {
+                AssignResult::SamePartition { bucket } => {
+                    buckets.push(bucket);
+                }
+                AssignResult::CrossPartition {
+                    old_partition,
+                    old_bucket,
+                    new_bucket,
+                } => {
+                    buckets.push(new_bucket);
+                    deletes.push((row_idx, old_partition, old_bucket));
+                }
+                AssignResult::Skip => {
+                    buckets.push(-1); // dummy, will be skipped
+                    skips.push(row_idx);
+                }
+            }
+        }
+
+        Ok(BatchAssignOutput {
+            partition_bytes: partition_bytes_vec,
+            buckets,
+            deletes,
+            skips,
+        })
+    }
+
+    async fn prepare_commit_index(
+        &mut self,
+        _file_io: &FileIO,
+        _index_dir: &str,
+    ) -> Result<HashMap<PartitionBucketKey, Vec<IndexFileMeta>>> {
+        Ok(HashMap::new())
+    }
+}

--- a/crates/paimon/src/table/bucket_assigner_dynamic.rs
+++ b/crates/paimon/src/table/bucket_assigner_dynamic.rs
@@ -1,0 +1,588 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Dynamic bucket assigner for PK tables with bucket=-1 where PK includes partition fields.
+//!
+//! Also contains the per-bucket index maintainer (`DynamicBucketIndexMaintainer`)
+//! and per-partition index (`PartitionIndex`) used by both dynamic and cross-partition modes.
+
+use crate::io::FileIO;
+use crate::spec::{
+    batch_hash_codes, batch_to_serialized_bytes, DataField, IndexFileMeta, IndexManifest,
+    IndexManifestEntry, EMPTY_SERIALIZED_ROW,
+};
+use crate::table::bucket_assigner::{BatchAssignOutput, BucketAssigner, PartitionBucketKey};
+use crate::table::SnapshotManager;
+use crate::Result;
+use arrow_array::RecordBatch;
+use std::collections::{HashMap, HashSet};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Hash index file
+// ---------------------------------------------------------------------------
+
+/// Index type identifier for hash index files, matching Java's `HashIndexFile.HASH_INDEX`.
+const HASH_INDEX: &str = "HASH";
+
+/// Read/write hash index files.
+///
+/// A hash index file is a flat binary file containing `i32` values in little-endian byte order.
+/// Each value is the hash code of a primary key that belongs to the associated bucket.
+struct HashIndexFile;
+
+impl HashIndexFile {
+    /// Read all key hashes from a hash index file.
+    async fn read(file_io: &FileIO, path: &str) -> Result<Vec<i32>> {
+        let input = file_io.new_input(path)?;
+        let content = input.read().await?;
+        debug_assert!(
+            content.len() % 4 == 0,
+            "hash index file size {} is not aligned to 4 bytes",
+            content.len()
+        );
+        let count = content.len() / 4;
+        let mut hashes = Vec::with_capacity(count);
+        for i in 0..count {
+            let offset = i * 4;
+            let bytes = [
+                content[offset],
+                content[offset + 1],
+                content[offset + 2],
+                content[offset + 3],
+            ];
+            hashes.push(i32::from_be_bytes(bytes));
+        }
+        Ok(hashes)
+    }
+
+    /// Write key hashes to a new hash index file, returning its metadata.
+    async fn write(file_io: &FileIO, dir: &str, hashes: &[i32]) -> Result<IndexFileMeta> {
+        let file_name = format!("index-{}-0", Uuid::new_v4());
+        let path = format!("{dir}/{file_name}");
+
+        let mut buf = Vec::with_capacity(hashes.len() * 4);
+        for &h in hashes {
+            buf.extend_from_slice(&h.to_be_bytes());
+        }
+
+        let file_size: i32 = buf
+            .len()
+            .try_into()
+            .expect("hash index file size exceeds i32::MAX");
+        let output = file_io.new_output(&path)?;
+        output.write(bytes::Bytes::from(buf)).await?;
+
+        Ok(IndexFileMeta {
+            index_type: HASH_INDEX.to_string(),
+            file_name,
+            file_size,
+            row_count: hashes
+                .len()
+                .try_into()
+                .expect("hash index row count exceeds i32::MAX"),
+            deletion_vectors_ranges: None,
+            global_index_meta: None,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DynamicBucketIndexMaintainer
+// ---------------------------------------------------------------------------
+
+/// Maintains the set of key hashes for a single (partition, bucket) pair.
+///
+/// On each write, `notify_new_record` records the key hash. At commit time,
+/// `prepare_commit` writes the full hash set to a new hash index file.
+///
+/// Reference: [org.apache.paimon.index.DynamicBucketIndexMaintainer](https://github.com/apache/paimon/blob/master/paimon-core/src/main/java/org/apache/paimon/index/DynamicBucketIndexMaintainer.java)
+pub(crate) struct DynamicBucketIndexMaintainer {
+    /// All key hashes in this bucket (restored + new).
+    hashes: HashSet<i32>,
+    /// Whether any new hashes were added since last commit.
+    modified: bool,
+}
+
+impl DynamicBucketIndexMaintainer {
+    /// Create a new maintainer, optionally restoring from existing hashes.
+    pub fn new(restored_hashes: Vec<i32>) -> Self {
+        let hashes: HashSet<i32> = restored_hashes.into_iter().collect();
+        Self {
+            hashes,
+            modified: false,
+        }
+    }
+
+    /// Record a key hash from a newly written record.
+    pub fn notify_new_record(&mut self, key_hash: i32) {
+        if self.hashes.insert(key_hash) {
+            self.modified = true;
+        }
+    }
+
+    /// Write the hash index file if modified, returning the new index file metadata.
+    pub async fn prepare_commit(
+        &mut self,
+        file_io: &FileIO,
+        index_dir: &str,
+    ) -> Result<Vec<IndexFileMeta>> {
+        if !self.modified {
+            return Ok(Vec::new());
+        }
+        let hashes: Vec<i32> = self.hashes.iter().copied().collect();
+        let meta = HashIndexFile::write(file_io, index_dir, &hashes).await?;
+        self.modified = false;
+        Ok(vec![meta])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PartitionIndex
+// ---------------------------------------------------------------------------
+
+/// Per-partition index that maps key hashes to bucket ids.
+///
+/// Also maintains per-bucket index files via embedded `DynamicBucketIndexMaintainer`s,
+/// so callers only need a single `PartitionIndex` per partition.
+///
+/// Reference: [org.apache.paimon.index.PartitionIndex](https://github.com/apache/paimon/blob/master/paimon-core/src/main/java/org/apache/paimon/index/PartitionIndex.java)
+struct PartitionIndex {
+    /// key hash → bucket id
+    hash_to_bucket: HashMap<i32, i32>,
+    /// bucket id → current row count (only non-full buckets)
+    non_full_buckets: HashMap<i32, i64>,
+    /// All known bucket ids
+    all_buckets: HashSet<i32>,
+    /// Next bucket id to allocate (avoids linear scan).
+    next_bucket_id: i32,
+    target_bucket_row_number: i64,
+    /// Per-bucket index maintainers for writing hash index files at commit time.
+    bucket_maintainers: HashMap<i32, DynamicBucketIndexMaintainer>,
+}
+
+impl PartitionIndex {
+    /// Create an empty partition index.
+    fn empty(target_bucket_row_number: i64) -> Self {
+        Self {
+            hash_to_bucket: HashMap::new(),
+            non_full_buckets: HashMap::new(),
+            all_buckets: HashSet::new(),
+            next_bucket_id: 0,
+            target_bucket_row_number,
+            bucket_maintainers: HashMap::new(),
+        }
+    }
+
+    /// Load partition index from existing hash index files.
+    ///
+    /// Reads all HASH-type index entries for this partition and reconstructs
+    /// the hash→bucket mapping and bucket row counts.
+    async fn load(
+        file_io: &FileIO,
+        index_dir: &str,
+        entries: &[IndexManifestEntry],
+        target_bucket_row_number: i64,
+    ) -> Result<Self> {
+        let mut hash_to_bucket = HashMap::new();
+        let mut bucket_row_counts: HashMap<i32, i64> = HashMap::new();
+        let mut bucket_hashes: HashMap<i32, Vec<i32>> = HashMap::new();
+
+        for entry in entries {
+            if entry.index_file.index_type != HASH_INDEX {
+                continue;
+            }
+            let bucket = entry.bucket;
+            let path = format!("{index_dir}/{}", entry.index_file.file_name);
+            let hashes = HashIndexFile::read(file_io, &path).await?;
+            let count = hashes.len() as i64;
+            for &h in &hashes {
+                hash_to_bucket.insert(h, bucket);
+            }
+            *bucket_row_counts.entry(bucket).or_insert(0) += count;
+            bucket_hashes.entry(bucket).or_default().extend(hashes);
+        }
+
+        let all_buckets: HashSet<i32> = bucket_row_counts.keys().copied().collect();
+        let non_full_buckets: HashMap<i32, i64> = bucket_row_counts
+            .into_iter()
+            .filter(|(_, count)| *count < target_bucket_row_number)
+            .collect();
+
+        let bucket_maintainers: HashMap<i32, DynamicBucketIndexMaintainer> = bucket_hashes
+            .into_iter()
+            .map(|(bucket, hashes)| (bucket, DynamicBucketIndexMaintainer::new(hashes)))
+            .collect();
+
+        let next_bucket_id = all_buckets.iter().copied().max().map_or(0, |m| m + 1);
+
+        Ok(Self {
+            hash_to_bucket,
+            non_full_buckets,
+            all_buckets,
+            next_bucket_id,
+            target_bucket_row_number,
+            bucket_maintainers,
+        })
+    }
+
+    /// Assign a bucket for the given key hash.
+    ///
+    /// 1. If the hash was seen before, return its existing bucket.
+    /// 2. Otherwise, find a non-full bucket and assign the hash there.
+    /// 3. If all buckets are full, create a new bucket.
+    fn assign(&mut self, hash: i32) -> i32 {
+        // 1. Already assigned
+        if let Some(&bucket) = self.hash_to_bucket.get(&hash) {
+            return bucket;
+        }
+
+        // 2. Find a non-full bucket
+        let mut full_buckets = Vec::new();
+        let mut assigned_bucket = None;
+        for (&bucket, count) in &mut self.non_full_buckets {
+            if *count < self.target_bucket_row_number {
+                *count += 1;
+                self.hash_to_bucket.insert(hash, bucket);
+                assigned_bucket = Some(bucket);
+                break;
+            } else {
+                full_buckets.push(bucket);
+            }
+        }
+        for b in full_buckets {
+            self.non_full_buckets.remove(&b);
+        }
+        if let Some(bucket) = assigned_bucket {
+            self.bucket_maintainers
+                .entry(bucket)
+                .or_insert_with(|| DynamicBucketIndexMaintainer::new(vec![]))
+                .notify_new_record(hash);
+            return bucket;
+        }
+
+        // 3. Create a new bucket
+        let new_bucket = self.next_bucket_id;
+        self.next_bucket_id += 1;
+        self.all_buckets.insert(new_bucket);
+        self.non_full_buckets.insert(new_bucket, 1);
+        self.hash_to_bucket.insert(hash, new_bucket);
+        self.bucket_maintainers
+            .entry(new_bucket)
+            .or_insert_with(|| DynamicBucketIndexMaintainer::new(vec![]))
+            .notify_new_record(hash);
+        new_bucket
+    }
+
+    /// Write hash index files for all modified buckets, returning (bucket, index_files) pairs.
+    async fn prepare_commit(
+        &mut self,
+        file_io: &FileIO,
+        index_dir: &str,
+    ) -> Result<Vec<(i32, Vec<IndexFileMeta>)>> {
+        let mut result = Vec::new();
+        let buckets: Vec<i32> = self.bucket_maintainers.keys().copied().collect();
+        for bucket in buckets {
+            if let Some(maintainer) = self.bucket_maintainers.get_mut(&bucket) {
+                let files = maintainer.prepare_commit(file_io, index_dir).await?;
+                if !files.is_empty() {
+                    result.push((bucket, files));
+                }
+            }
+        }
+        Ok(result)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DynamicBucketAssigner
+// ---------------------------------------------------------------------------
+
+/// Bucket assigner for dynamic bucket mode (bucket=-1) where PK includes partition fields.
+///
+/// Maintains a per-partition `PartitionIndex` that maps key hashes to bucket ids.
+pub(crate) struct DynamicBucketAssigner {
+    partition_field_indices: Vec<usize>,
+    primary_key_indices: Vec<usize>,
+    /// Schema fields for BinaryRow extraction.
+    fields: Vec<DataField>,
+    partition_indexes: HashMap<Vec<u8>, PartitionIndex>,
+    target_bucket_row_number: i64,
+    file_io: FileIO,
+    table_location: String,
+    /// Cached index manifest entries from the latest snapshot (loaded once).
+    cached_index_entries: Option<Vec<IndexManifestEntry>>,
+    /// Overwrite mode: skip loading existing index entries.
+    is_overwrite: bool,
+}
+
+impl DynamicBucketAssigner {
+    pub fn new(
+        partition_field_indices: Vec<usize>,
+        primary_key_indices: Vec<usize>,
+        fields: Vec<DataField>,
+        target_bucket_row_number: i64,
+        file_io: FileIO,
+        table_location: String,
+        is_overwrite: bool,
+    ) -> Self {
+        Self {
+            partition_field_indices,
+            primary_key_indices,
+            fields,
+            partition_indexes: HashMap::new(),
+            target_bucket_row_number,
+            file_io,
+            table_location,
+            cached_index_entries: None,
+            is_overwrite,
+        }
+    }
+
+    /// Load all index manifest entries from the latest snapshot (cached).
+    /// Overwrite mode skips loading — old index is irrelevant.
+    async fn ensure_index_entries_loaded(&mut self) -> Result<()> {
+        if self.cached_index_entries.is_some() {
+            return Ok(());
+        }
+        if self.is_overwrite {
+            self.cached_index_entries = Some(Vec::new());
+            return Ok(());
+        }
+        let snapshot_manager =
+            SnapshotManager::new(self.file_io.clone(), self.table_location.clone());
+        let latest_snapshot = snapshot_manager.get_latest_snapshot().await?;
+
+        let entries = if let Some(snapshot) = latest_snapshot {
+            if let Some(index_manifest_name) = snapshot.index_manifest() {
+                let manifest_dir = snapshot_manager.manifest_dir();
+                let index_manifest_path = format!("{manifest_dir}/{index_manifest_name}");
+                IndexManifest::read(&self.file_io, &index_manifest_path).await?
+            } else {
+                Vec::new()
+            }
+        } else {
+            Vec::new()
+        };
+        self.cached_index_entries = Some(entries);
+        Ok(())
+    }
+
+    /// Load partition index from cached index manifest entries.
+    async fn load_partition_index(&self, partition_bytes: &[u8]) -> Result<PartitionIndex> {
+        let entries = self.cached_index_entries.as_deref().unwrap_or(&[]);
+        let partition_entries: Vec<_> = entries
+            .iter()
+            .filter(|e| e.partition == partition_bytes && e.index_file.index_type == HASH_INDEX)
+            .cloned()
+            .collect();
+
+        if !partition_entries.is_empty() {
+            let index_dir = format!("{}/index", self.table_location);
+            return PartitionIndex::load(
+                &self.file_io,
+                &index_dir,
+                &partition_entries,
+                self.target_bucket_row_number,
+            )
+            .await;
+        }
+
+        Ok(PartitionIndex::empty(self.target_bucket_row_number))
+    }
+}
+
+impl BucketAssigner for DynamicBucketAssigner {
+    async fn assign_batch(
+        &mut self,
+        batch: &RecordBatch,
+        _fields: &[DataField],
+    ) -> Result<BatchAssignOutput> {
+        // Batch-compute partition bytes
+        let partition_bytes_vec = if self.partition_field_indices.is_empty() {
+            vec![EMPTY_SERIALIZED_ROW.clone(); batch.num_rows()]
+        } else {
+            batch_to_serialized_bytes(batch, &self.partition_field_indices, &self.fields)?
+        };
+
+        // Load indexes for unseen partitions
+        let mut unseen = Vec::new();
+        let mut seen_set = HashSet::new();
+        for pb in &partition_bytes_vec {
+            if !self.partition_indexes.contains_key(pb) && seen_set.insert(pb.clone()) {
+                unseen.push(pb.clone());
+            }
+        }
+        if !unseen.is_empty() {
+            self.ensure_index_entries_loaded().await?;
+        }
+        for partition_bytes in unseen {
+            let index = self.load_partition_index(&partition_bytes).await?;
+            self.partition_indexes.insert(partition_bytes, index);
+        }
+
+        // Batch-compute hash codes and assign buckets
+        let hash_codes = batch_hash_codes(batch, &self.primary_key_indices, &self.fields)?;
+        let mut buckets = Vec::with_capacity(batch.num_rows());
+        for (row_idx, pb) in partition_bytes_vec.iter().enumerate() {
+            let partition_index = self.partition_indexes.get_mut(pb).unwrap();
+            buckets.push(partition_index.assign(hash_codes[row_idx]));
+        }
+
+        Ok(BatchAssignOutput {
+            partition_bytes: partition_bytes_vec,
+            buckets,
+            deletes: Vec::new(),
+            skips: Vec::new(),
+        })
+    }
+
+    async fn prepare_commit_index(
+        &mut self,
+        file_io: &FileIO,
+        index_dir: &str,
+    ) -> Result<HashMap<PartitionBucketKey, Vec<IndexFileMeta>>> {
+        let mut result = HashMap::new();
+        let partition_keys: Vec<Vec<u8>> = self.partition_indexes.keys().cloned().collect();
+        for partition_bytes in partition_keys {
+            if let Some(partition_index) = self.partition_indexes.get_mut(&partition_bytes) {
+                let bucket_files = partition_index.prepare_commit(file_io, index_dir).await?;
+                for (bucket, idx_files) in bucket_files {
+                    result.insert((partition_bytes.clone(), bucket), idx_files);
+                }
+            }
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- DynamicBucketIndexMaintainer tests --
+
+    #[tokio::test]
+    async fn test_maintainer_write_on_modify() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = format!("file://{}", tmp.path().display());
+        let file_io = FileIO::from_url(&dir).unwrap().build().unwrap();
+
+        let mut m = DynamicBucketIndexMaintainer::new(vec![]);
+        // No modification → empty
+        let files = m.prepare_commit(&file_io, &dir).await.unwrap();
+        assert!(files.is_empty());
+
+        // Add hashes
+        m.notify_new_record(1);
+        m.notify_new_record(2);
+        m.notify_new_record(1); // duplicate, no effect
+        let files = m.prepare_commit(&file_io, &dir).await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].index_type, HASH_INDEX);
+        assert_eq!(files[0].row_count, 2);
+
+        // No new modification → empty again
+        let files = m.prepare_commit(&file_io, &dir).await.unwrap();
+        assert!(files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_maintainer_with_restored() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = format!("file://{}", tmp.path().display());
+        let file_io = FileIO::from_url(&dir).unwrap().build().unwrap();
+
+        let mut m = DynamicBucketIndexMaintainer::new(vec![10, 20]);
+        // Restored hashes don't count as modified
+        let files = m.prepare_commit(&file_io, &dir).await.unwrap();
+        assert!(files.is_empty());
+
+        // Adding a new hash triggers write (includes restored + new)
+        m.notify_new_record(30);
+        let files = m.prepare_commit(&file_io, &dir).await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].row_count, 3);
+    }
+
+    // -- PartitionIndex tests --
+
+    #[test]
+    fn test_assign_new_keys() {
+        let mut index = PartitionIndex::empty(3);
+        assert_eq!(index.assign(100), 0);
+        assert_eq!(index.assign(200), 0);
+        assert_eq!(index.assign(300), 0);
+        // Bucket 0 is full, next key goes to bucket 1
+        assert_eq!(index.assign(400), 1);
+    }
+
+    #[test]
+    fn test_assign_existing_key() {
+        let mut index = PartitionIndex::empty(10);
+        assert_eq!(index.assign(42), 0);
+        // Same hash returns same bucket
+        assert_eq!(index.assign(42), 0);
+    }
+
+    #[test]
+    fn test_multiple_buckets() {
+        let mut index = PartitionIndex::empty(2);
+        assert_eq!(index.assign(1), 0);
+        assert_eq!(index.assign(2), 0);
+        // Bucket 0 full
+        assert_eq!(index.assign(3), 1);
+        assert_eq!(index.assign(4), 1);
+        // Bucket 1 full
+        assert_eq!(index.assign(5), 2);
+    }
+
+    // -- HashIndexFile tests --
+
+    #[tokio::test]
+    async fn test_hash_index_roundtrip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = format!("file://{}", tmp.path().display());
+        let file_io = FileIO::from_url(&dir).unwrap().build().unwrap();
+
+        let hashes = vec![42, -1, 0, i32::MAX, i32::MIN];
+        let meta = HashIndexFile::write(&file_io, &dir, &hashes).await.unwrap();
+
+        assert_eq!(meta.index_type, HASH_INDEX);
+        assert_eq!(meta.row_count, 5);
+        assert_eq!(meta.file_size, 20);
+
+        let path = format!("{dir}/{}", meta.file_name);
+        let read_back = HashIndexFile::read(&file_io, &path).await.unwrap();
+        assert_eq!(read_back, hashes);
+    }
+
+    #[tokio::test]
+    async fn test_hash_index_empty() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = format!("file://{}", tmp.path().display());
+        let file_io = FileIO::from_url(&dir).unwrap().build().unwrap();
+
+        let meta = HashIndexFile::write(&file_io, &dir, &[]).await.unwrap();
+        assert_eq!(meta.row_count, 0);
+        assert_eq!(meta.file_size, 0);
+
+        let path = format!("{dir}/{}", meta.file_name);
+        let read_back = HashIndexFile::read(&file_io, &path).await.unwrap();
+        assert!(read_back.is_empty());
+    }
+}

--- a/crates/paimon/src/table/bucket_assigner_fixed.rs
+++ b/crates/paimon/src/table/bucket_assigner_fixed.rs
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Fixed bucket assigner for hash-based bucket assignment (bucket >= 2).
+
+use crate::io::FileIO;
+use crate::spec::{
+    batch_hash_codes, batch_to_serialized_bytes, DataField, IndexFileMeta, EMPTY_SERIALIZED_ROW,
+};
+use crate::table::bucket_assigner::{BatchAssignOutput, BucketAssigner, PartitionBucketKey};
+use crate::Result;
+use arrow_array::RecordBatch;
+use std::collections::HashMap;
+
+/// Bucket assigner for fixed-bucket tables (bucket >= 2).
+///
+/// Routes rows to buckets via `hash(bucket_key) % total_buckets`.
+/// Pure computation — no index loading or commit-time index files.
+pub(crate) struct FixedBucketAssigner {
+    partition_field_indices: Vec<usize>,
+    bucket_key_indices: Vec<usize>,
+    total_buckets: i32,
+}
+
+impl FixedBucketAssigner {
+    pub fn new(
+        partition_field_indices: Vec<usize>,
+        bucket_key_indices: Vec<usize>,
+        total_buckets: i32,
+    ) -> Self {
+        Self {
+            partition_field_indices,
+            bucket_key_indices,
+            total_buckets,
+        }
+    }
+}
+
+impl BucketAssigner for FixedBucketAssigner {
+    async fn assign_batch(
+        &mut self,
+        batch: &RecordBatch,
+        fields: &[DataField],
+    ) -> Result<BatchAssignOutput> {
+        let num_rows = batch.num_rows();
+        let partition_bytes = if self.partition_field_indices.is_empty() {
+            vec![EMPTY_SERIALIZED_ROW.clone(); num_rows]
+        } else {
+            batch_to_serialized_bytes(batch, &self.partition_field_indices, fields)?
+        };
+
+        let hash_codes = batch_hash_codes(batch, &self.bucket_key_indices, fields)?;
+        let buckets: Vec<i32> = hash_codes
+            .iter()
+            .map(|h| (h % self.total_buckets).wrapping_abs())
+            .collect();
+
+        Ok(BatchAssignOutput {
+            partition_bytes,
+            buckets,
+            deletes: Vec::new(),
+            skips: Vec::new(),
+        })
+    }
+
+    async fn prepare_commit_index(
+        &mut self,
+        _file_io: &FileIO,
+        _index_dir: &str,
+    ) -> Result<HashMap<PartitionBucketKey, Vec<IndexFileMeta>>> {
+        Ok(HashMap::new())
+    }
+}

--- a/crates/paimon/src/table/commit_message.rs
+++ b/crates/paimon/src/table/commit_message.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::spec::DataFileMeta;
+use crate::spec::IndexFileMeta;
 
 /// A commit message representing new files to be committed for a specific partition and bucket.
 ///
@@ -28,6 +29,8 @@ pub struct CommitMessage {
     pub bucket: i32,
     /// New data files to be added.
     pub new_files: Vec<DataFileMeta>,
+    /// New index files to be added (used by dynamic bucket mode).
+    pub new_index_files: Vec<IndexFileMeta>,
 }
 
 impl CommitMessage {
@@ -36,6 +39,7 @@ impl CommitMessage {
             partition,
             bucket,
             new_files,
+            new_index_files: Vec::new(),
         }
     }
 }

--- a/crates/paimon/src/table/data_evolution_reader.rs
+++ b/crates/paimon/src/table/data_evolution_reader.rs
@@ -33,6 +33,31 @@ use futures::StreamExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+/// Whether the files in a split can be read independently (no column-wise merge needed).
+fn is_raw_convertible(files: &[DataFileMeta]) -> bool {
+    if files.len() <= 1 {
+        return true;
+    }
+    // If all files have first_row_id and their row_id ranges don't overlap, they're independent.
+    if files.iter().any(|f| f.first_row_id.is_none()) {
+        return false;
+    }
+    let mut ranges: Vec<(i64, i64)> = files
+        .iter()
+        .map(|f| {
+            let start = f.first_row_id.unwrap();
+            (start, start + f.row_count)
+        })
+        .collect();
+    ranges.sort_by_key(|r| r.0);
+    for w in ranges.windows(2) {
+        if w[0].1 > w[1].0 {
+            return false;
+        }
+    }
+    true
+}
+
 /// Reads data files in data evolution mode, merging columns from files
 /// that share the same row ID range.
 pub(crate) struct DataEvolutionReader {
@@ -96,7 +121,7 @@ impl DataEvolutionReader {
             for split in splits {
                 let row_ranges = split.row_ranges().map(|r| r.to_vec());
 
-                if split.raw_convertible() || split.data_files().len() == 1 {
+                if is_raw_convertible(split.data_files()) {
                     for file_meta in split.data_files().to_vec() {
                         let data_fields: Option<Vec<DataField>> = if file_meta.schema_id != self.table_schema_id {
                             let data_schema = self.schema_manager.schema(file_meta.schema_id).await?;

--- a/crates/paimon/src/table/data_evolution_writer.rs
+++ b/crates/paimon/src/table/data_evolution_writer.rs
@@ -101,7 +101,7 @@ impl DataEvolutionWriter {
                 message: "MERGE INTO requires 'row-tracking.enabled' = 'true'".to_string(),
             });
         }
-        if !schema.primary_keys().is_empty() {
+        if !schema.trimmed_primary_keys().is_empty() {
             return Err(crate::Error::Unsupported {
                 message: "MERGE INTO on data evolution tables does not support primary keys"
                     .to_string(),
@@ -261,7 +261,6 @@ impl DataEvolutionWriter {
             rb.with_projection(&col_refs);
             let read = rb.new_read()?;
 
-            let raw_convertible = file_range.files.len() == 1;
             let split = DataSplitBuilder::new()
                 .with_snapshot(file_range.snapshot_id)
                 .with_partition(BinaryRow::from_serialized_bytes(&file_range.partition)?)
@@ -269,7 +268,6 @@ impl DataEvolutionWriter {
                 .with_bucket_path(file_range.bucket_path.clone())
                 .with_total_buckets(file_range.total_buckets)
                 .with_data_files(file_range.files.clone())
-                .with_raw_convertible(raw_convertible)
                 .build()?;
 
             let stream = read.to_arrow(&[split])?;

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -18,6 +18,11 @@
 //! Table API for Apache Paimon
 
 pub(crate) mod bin_pack;
+mod bucket_assigner;
+mod bucket_assigner_constant;
+mod bucket_assigner_cross;
+mod bucket_assigner_dynamic;
+mod bucket_assigner_fixed;
 mod bucket_filter;
 mod commit_message;
 mod data_evolution_reader;

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -55,15 +55,10 @@ fn bucket_predicate(table: &Table, filter: &Predicate) -> Option<Predicate> {
     }
 
     let bucket_keys = core_options.bucket_key().unwrap_or_else(|| {
-        if table.schema().primary_keys().is_empty() {
+        if table.schema().trimmed_primary_keys().is_empty() {
             Vec::new()
         } else {
-            table
-                .schema()
-                .primary_keys()
-                .iter()
-                .map(|key| key.to_string())
-                .collect()
+            table.schema().trimmed_primary_keys()
         }
     });
     if bucket_keys.is_empty() {
@@ -331,7 +326,6 @@ mod tests {
             .with_bucket_path(local_file_path(&bucket_dir))
             .with_total_buckets(1)
             .with_data_files(vec![test_data_file("data.parquet", 4, file_size)])
-            .with_raw_convertible(true)
             .build()
             .unwrap();
 
@@ -391,7 +385,6 @@ mod tests {
             .with_bucket_path(local_file_path(&bucket_dir))
             .with_total_buckets(1)
             .with_data_files(vec![test_data_file("data.parquet", 4, file_size)])
-            .with_raw_convertible(true)
             .build()
             .unwrap();
 
@@ -449,7 +442,6 @@ mod tests {
             .with_bucket_path(local_file_path(&bucket_dir))
             .with_total_buckets(1)
             .with_data_files(vec![test_data_file("data.parquet", 4, file_size)])
-            .with_raw_convertible(true)
             .build()
             .unwrap();
 
@@ -510,7 +502,6 @@ mod tests {
             .with_bucket_path(local_file_path(&bucket_dir))
             .with_total_buckets(1)
             .with_data_files(vec![test_data_file("data.parquet", 4, file_size)])
-            .with_raw_convertible(true)
             .build()
             .unwrap();
 

--- a/crates/paimon/src/table/source.rs
+++ b/crates/paimon/src/table/source.rs
@@ -424,10 +424,6 @@ pub struct DataSplit {
     /// Deletion file for each data file, same order as `data_files`.
     /// `None` at index `i` means no deletion file for `data_files[i]` (matches Java getDeletionFiles() / List<DeletionFile> with null elements).
     data_deletion_files: Option<Vec<Option<DeletionFile>>>,
-    /// Whether this split can be read file-by-file without merging.
-    /// `false` when files need column-wise merge (e.g. data evolution) or
-    /// key-value merge (e.g. primary key tables without deletion vectors).
-    raw_convertible: bool,
     row_ranges: Option<Vec<RowRange>>,
 }
 
@@ -455,11 +451,6 @@ impl DataSplit {
     /// Deletion files for each data file (same order as `data_files`); `None` = no deletion file for that data file.
     pub fn data_deletion_files(&self) -> Option<&[Option<DeletionFile>]> {
         self.data_deletion_files.as_deref()
-    }
-
-    /// Whether this split can be read without column-wise merging.
-    pub fn raw_convertible(&self) -> bool {
-        self.raw_convertible
     }
 
     pub fn row_ranges(&self) -> Option<&[RowRange]> {
@@ -496,46 +487,23 @@ impl DataSplit {
 
     /// Returns the merged row count if it can be computed.
     ///
-    /// This method tries two approaches in order:
+    /// Two paths:
+    /// 1. If all files have `first_row_id` (data evolution mode): merge overlapping
+    ///    row ID ranges and take max row count per group.
+    /// 2. Otherwise: row_count() minus deleted rows (if deletion file cardinality is known).
     ///
-    /// 1. **Raw merged row count** (`raw_convertible = true`):
-    ///    - row_count() - total deleted rows (if deletion files have cardinality)
-    ///    - row_count() (if no deletion files)
-    ///
-    /// 2. **Data evolution merged row count** (`raw_convertible = false`):
-    ///    - Requires all files to have `first_row_id` set
-    ///    - Merges overlapping row ID ranges and takes max row count per group
-    ///
-    /// Returns `None` if:
-    /// - `raw_convertible = false` and not all files have `first_row_id`
-    /// - Deletion files exist but cardinality is unknown
+    /// Returns `None` if deletion files exist but cardinality is unknown.
     ///
     /// Reference: [DataSplit.mergedRowCount()](https://github.com/apache/paimon/blob/release-1.3/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java#L133)
     pub fn merged_row_count(&self) -> Option<i64> {
-        // Try raw merged row count first (for raw_convertible splits)
-        if let Some(count) = self.raw_merged_row_count() {
+        // Try data evolution merged row count first (all files have first_row_id)
+        if let Some(count) = self.data_evolution_merged_row_count() {
             return Some(count);
         }
 
-        // Try data evolution merged row count
-        self.data_evolution_merged_row_count()
-    }
-
-    /// Check if raw merged row count is available and compute it.
-    ///
-    /// Available when:
-    /// - `raw_convertible = true`
-    /// - All deletion files have known cardinality (or no deletion files)
-    fn raw_merged_row_count(&self) -> Option<i64> {
-        if !self.raw_convertible {
-            return None;
-        }
-
+        // Fallback: row_count - deleted rows
         match &self.data_deletion_files {
-            None => {
-                // No deletion files, merged count = row count
-                Some(self.row_count())
-            }
+            None => Some(self.row_count()),
             Some(deletion_files) => {
                 let mut total = 0i64;
                 for (i, file) in self.data_files.iter().enumerate() {
@@ -596,7 +564,6 @@ pub struct DataSplitBuilder {
     data_files: Option<Vec<DataFileMeta>>,
     /// Same length as data_files; `None` at index i = no deletion file for data_files[i].
     data_deletion_files: Option<Vec<Option<DeletionFile>>>,
-    raw_convertible: bool,
     row_ranges: Option<Vec<RowRange>>,
 }
 
@@ -610,7 +577,6 @@ impl DataSplitBuilder {
             total_buckets: -1,
             data_files: None,
             data_deletion_files: None,
-            raw_convertible: false,
             row_ranges: None,
         }
     }
@@ -646,11 +612,6 @@ impl DataSplitBuilder {
         data_deletion_files: Vec<Option<DeletionFile>>,
     ) -> Self {
         self.data_deletion_files = Some(data_deletion_files);
-        self
-    }
-
-    pub fn with_raw_convertible(mut self, raw_convertible: bool) -> Self {
-        self.raw_convertible = raw_convertible;
         self
     }
 
@@ -710,7 +671,6 @@ impl DataSplitBuilder {
             total_buckets: self.total_buckets,
             data_files,
             data_deletion_files: self.data_deletion_files,
-            raw_convertible: self.raw_convertible,
             row_ranges: self.row_ranges,
         })
     }

--- a/crates/paimon/src/table/table_commit.rs
+++ b/crates/paimon/src/table/table_commit.rs
@@ -24,9 +24,9 @@ use crate::io::FileIO;
 use crate::spec::stats::BinaryTableStats;
 use crate::spec::FileKind;
 use crate::spec::{
-    datums_to_binary_row, extract_datum, BinaryRow, CommitKind, CoreOptions, Datum, Manifest,
-    ManifestEntry, ManifestFileMeta, ManifestList, PartitionStatistics, Predicate,
-    PredicateBuilder, Snapshot,
+    datums_to_binary_row, extract_datum, BinaryRow, CommitKind, CoreOptions, DataType, Datum,
+    IndexManifest, IndexManifestEntry, Manifest, ManifestEntry, ManifestFileMeta, ManifestList,
+    PartitionStatistics, Predicate, PredicateBuilder, Snapshot,
 };
 use crate::table::commit_message::CommitMessage;
 use crate::table::snapshot_commit::SnapshotCommit;
@@ -97,9 +97,12 @@ impl TableCommit {
         }
 
         let commit_entries = self.messages_to_entries(&commit_messages);
+        let index_entries = self.messages_to_index_entries(&commit_messages);
         self.try_commit(
             CommitKind::APPEND,
             CommitEntriesPlan::Static(commit_entries),
+            index_entries,
+            None, // APPEND: no overwrite
         )
         .await
     }
@@ -114,13 +117,17 @@ impl TableCommit {
         }
 
         let commit_entries = self.messages_to_entries(&commit_messages);
+        let index_entries = self.messages_to_index_entries(&commit_messages);
         let partition_predicate = self.build_dynamic_partition_predicate(&commit_messages)?;
+        let overwrite_partitions = self.collect_overwrite_partitions(&commit_messages);
         self.try_commit(
             CommitKind::OVERWRITE,
             CommitEntriesPlan::Overwrite {
                 partition_predicate,
                 new_entries: commit_entries,
             },
+            index_entries,
+            Some(overwrite_partitions),
         )
         .await
     }
@@ -184,6 +191,17 @@ impl TableCommit {
         pb.partition_predicate(&fields)
     }
 
+    /// Collect the set of unique partition bytes from commit messages.
+    ///
+    /// For unpartitioned tables, returns an empty set (meaning full table overwrite).
+    fn collect_overwrite_partitions(&self, commit_messages: &[CommitMessage]) -> HashSet<Vec<u8>> {
+        let mut partitions = HashSet::new();
+        for msg in commit_messages {
+            partitions.insert(msg.partition.clone());
+        }
+        partitions
+    }
+
     /// Drop specific partitions (OVERWRITE with only deletes).
     pub async fn truncate_partitions(
         &self,
@@ -198,12 +216,35 @@ impl TableCommit {
             .map(|p| self.build_partition_predicate(p))
             .collect::<Result<Vec<_>>>()?;
 
+        // Build partition bytes for index cleanup
+        let overwrite_partitions: HashSet<Vec<u8>> = partitions
+            .iter()
+            .map(|p| {
+                let partition_fields = self.table.schema().partition_fields();
+                let partition_keys = self.table.schema().partition_keys();
+                let owned_datums: Vec<(Option<Datum>, DataType)> = partition_keys
+                    .iter()
+                    .enumerate()
+                    .map(|(i, key)| {
+                        let datum = p.get(key).cloned().flatten();
+                        let dt = partition_fields[i].data_type().clone();
+                        (datum, dt)
+                    })
+                    .collect();
+                let refs: Vec<(&Option<Datum>, &DataType)> =
+                    owned_datums.iter().map(|(d, t)| (d, t)).collect();
+                datums_to_binary_row(&refs)
+            })
+            .collect();
+
         self.try_commit(
             CommitKind::OVERWRITE,
             CommitEntriesPlan::Overwrite {
                 partition_predicate: Some(Predicate::or(predicates)),
                 new_entries: vec![],
             },
+            vec![],
+            Some(overwrite_partitions),
         )
         .await
     }
@@ -216,12 +257,24 @@ impl TableCommit {
                 partition_predicate: None,
                 new_entries: vec![],
             },
+            vec![],
+            Some(HashSet::new()), // empty set = full table overwrite
         )
         .await
     }
 
     /// Try to commit with retries.
-    async fn try_commit(&self, commit_kind: CommitKind, plan: CommitEntriesPlan) -> Result<()> {
+    ///
+    /// `overwrite_partitions`: `None` for APPEND; `Some(set)` for OVERWRITE.
+    /// An empty set means full table overwrite (all old index entries removed).
+    /// A non-empty set lists the partition bytes being overwritten.
+    async fn try_commit(
+        &self,
+        commit_kind: CommitKind,
+        plan: CommitEntriesPlan,
+        new_index_entries: Vec<IndexManifestEntry>,
+        overwrite_partitions: Option<HashSet<Vec<u8>>>,
+    ) -> Result<()> {
         let mut retry_count = 0u32;
         let mut last_snapshot_for_dup_check: Option<Snapshot> = None;
         let start_time_ms = current_time_millis();
@@ -243,7 +296,13 @@ impl TableCommit {
             }
 
             let result = self
-                .try_commit_once(&commit_kind, commit_entries, &latest_snapshot)
+                .try_commit_once(
+                    &commit_kind,
+                    commit_entries,
+                    &new_index_entries,
+                    overwrite_partitions.as_ref(),
+                    &latest_snapshot,
+                )
                 .await?;
 
             match result {
@@ -281,6 +340,8 @@ impl TableCommit {
         &self,
         commit_kind: &CommitKind,
         mut commit_entries: Vec<ManifestEntry>,
+        new_index_entries: &[IndexManifestEntry],
+        overwrite_partitions: Option<&HashSet<Vec<u8>>>,
         latest_snapshot: &Option<Snapshot>,
     ) -> Result<bool> {
         let new_snapshot_id = latest_snapshot.as_ref().map(|s| s.id() + 1).unwrap_or(1);
@@ -364,6 +425,16 @@ impl TableCommit {
         }
         total_record_count += delta_record_count;
 
+        // Handle index manifest (for dynamic bucket mode)
+        let index_manifest_name = Self::write_index_manifest(
+            file_io,
+            &manifest_dir,
+            new_index_entries,
+            overwrite_partitions,
+            latest_snapshot,
+        )
+        .await?;
+
         let snapshot = Snapshot::builder()
             .version(3)
             .id(new_snapshot_id)
@@ -377,11 +448,87 @@ impl TableCommit {
             .total_record_count(Some(total_record_count))
             .delta_record_count(Some(delta_record_count))
             .next_row_id(next_row_id)
+            .index_manifest(index_manifest_name)
             .build();
 
         let statistics = self.generate_partition_statistics(&commit_entries)?;
 
         self.snapshot_commit.commit(&snapshot, &statistics).await
+    }
+
+    /// Merge new index entries with existing ones and write the index manifest.
+    ///
+    /// For APPEND (`overwrite_partitions = None`): new HASH entries replace old ones
+    /// for the same (partition, bucket) key.
+    ///
+    /// For OVERWRITE (`overwrite_partitions = Some(set)`):
+    /// - Empty set = full table overwrite → discard all old index entries.
+    /// - Non-empty set = partition overwrite → remove all old index entries
+    ///   whose partition is in the set (not just matching bucket keys).
+    ///
+    /// Then append new entries and write the merged index manifest.
+    async fn write_index_manifest(
+        file_io: &FileIO,
+        manifest_dir: &str,
+        new_index_entries: &[IndexManifestEntry],
+        overwrite_partitions: Option<&HashSet<Vec<u8>>>,
+        latest_snapshot: &Option<Snapshot>,
+    ) -> Result<Option<String>> {
+        let is_overwrite = overwrite_partitions.is_some();
+
+        if !new_index_entries.is_empty() || is_overwrite {
+            let mut all_index_entries: Vec<IndexManifestEntry> = if let Some(snap) = latest_snapshot
+            {
+                if let Some(prev_index_manifest) = snap.index_manifest() {
+                    let prev_path = format!("{manifest_dir}/{prev_index_manifest}");
+                    IndexManifest::read(file_io, &prev_path).await?
+                } else {
+                    vec![]
+                }
+            } else {
+                vec![]
+            };
+
+            if let Some(partitions) = overwrite_partitions {
+                if partitions.is_empty() {
+                    // Full table overwrite: discard all old index entries
+                    all_index_entries.clear();
+                } else {
+                    // Partition overwrite: remove all old entries for overwritten partitions
+                    all_index_entries.retain(|e| !partitions.contains(&e.partition));
+                }
+            } else {
+                // APPEND: only replace entries with matching (partition, bucket) keys
+                let new_keys: HashSet<(Vec<u8>, i32)> = new_index_entries
+                    .iter()
+                    .filter(|e| e.index_file.index_type == "HASH")
+                    .map(|e| (e.partition.clone(), e.bucket))
+                    .collect();
+                all_index_entries.retain(|e| {
+                    if e.index_file.index_type == "HASH" {
+                        !new_keys.contains(&(e.partition.clone(), e.bucket))
+                    } else {
+                        true
+                    }
+                });
+            }
+
+            all_index_entries.extend_from_slice(new_index_entries);
+
+            if all_index_entries.is_empty() {
+                // All entries removed (e.g. full table truncate) — no index manifest needed
+                return Ok(None);
+            }
+
+            let name = format!("index-manifest-{}-0", uuid::Uuid::new_v4());
+            let path = format!("{manifest_dir}/{name}");
+            IndexManifest::write(file_io, &path, &all_index_entries).await?;
+            Ok(Some(name))
+        } else if let Some(snap) = latest_snapshot {
+            Ok(snap.index_manifest().map(|s| s.to_string()))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Write a manifest file and return its metadata.
@@ -771,6 +918,24 @@ impl TableCommit {
                         2,
                     )
                 })
+            })
+            .collect()
+    }
+
+    /// Convert commit messages to index manifest entries (ADD kind).
+    fn messages_to_index_entries(&self, messages: &[CommitMessage]) -> Vec<IndexManifestEntry> {
+        messages
+            .iter()
+            .flat_map(|msg| {
+                msg.new_index_files
+                    .iter()
+                    .map(move |index_file| IndexManifestEntry {
+                        kind: FileKind::Add,
+                        partition: msg.partition.clone(),
+                        bucket: msg.bucket,
+                        index_file: index_file.clone(),
+                        version: 1,
+                    })
             })
             .collect()
     }

--- a/crates/paimon/src/table/table_read.rs
+++ b/crates/paimon/src/table/table_read.rs
@@ -72,60 +72,112 @@ impl<'a> TableRead<'a> {
 
     /// Returns an [`ArrowRecordBatchStream`].
     pub fn to_arrow(&self, data_splits: &[DataSplit]) -> crate::Result<ArrowRecordBatchStream> {
-        let has_primary_keys = !self.table.schema.primary_keys().is_empty();
+        let has_primary_keys = !self.table.schema.trimmed_primary_keys().is_empty();
         let core_options = CoreOptions::new(self.table.schema.options());
-        let deletion_vectors_enabled = core_options.deletion_vectors_enabled();
-        let data_evolution = core_options.data_evolution_enabled();
 
-        // PK table without DV: route by merge engine.
-        // Exhaustive match ensures new MergeEngine variants trigger a compile error.
-        if has_primary_keys && !deletion_vectors_enabled {
-            match core_options.merge_engine()? {
-                crate::spec::MergeEngine::Deduplicate => {
-                    let reader = KeyValueFileReader::new(
-                        self.table.file_io.clone(),
-                        KeyValueReadConfig {
-                            schema_manager: self.table.schema_manager().clone(),
-                            table_schema_id: self.table.schema().id(),
-                            table_fields: self.table.schema.fields().to_vec(),
-                            read_type: self.read_type().to_vec(),
-                            predicates: self.data_predicates.clone(),
-                            primary_keys: self.table.schema.primary_keys().to_vec(),
-                            sequence_fields: core_options
-                                .sequence_fields()
-                                .iter()
-                                .map(|s| s.to_string())
-                                .collect(),
-                        },
-                    );
-                    return reader.read(data_splits);
-                }
-                crate::spec::MergeEngine::FirstRow => {
-                    // Fall through to DataFileReader — scan already skips level-0
-                }
+        // PK table with Deduplicate engine: splits containing level-0 files
+        // need KeyValueFileReader for sort-merge dedup; splits with only
+        // compacted files (level > 0) can use the faster DataFileReader.
+        // FirstRow engine falls through — scan already skips level-0.
+        if has_primary_keys
+            && core_options
+                .merge_engine()
+                .is_ok_and(|e| e == crate::spec::MergeEngine::Deduplicate)
+        {
+            return self.read_pk_deduplicate(data_splits, &core_options);
+        }
+
+        if core_options.data_evolution_enabled() {
+            self.read_with_evolution(data_splits)
+        } else {
+            self.read_raw(data_splits)
+        }
+    }
+
+    /// Read PK table with Deduplicate engine: level-0 splits go through
+    /// KeyValueFileReader for sort-merge dedup, compacted splits use DataFileReader.
+    fn read_pk_deduplicate(
+        &self,
+        data_splits: &[DataSplit],
+        core_options: &CoreOptions,
+    ) -> crate::Result<ArrowRecordBatchStream> {
+        let mut kv_splits = Vec::new();
+        let mut raw_splits = Vec::new();
+        for split in data_splits {
+            if split.data_files().iter().any(|f| f.level == 0) {
+                kv_splits.push(split.clone());
+            } else {
+                raw_splits.push(split.clone());
             }
         }
 
-        // PK table with DV or append-only table: DataFileReader / DataEvolutionReader
-        if data_evolution {
-            let reader = DataEvolutionReader::new(
-                self.table.file_io.clone(),
-                self.table.schema_manager().clone(),
-                self.table.schema().id(),
-                self.table.schema.fields().to_vec(),
-                self.read_type().to_vec(),
-            )?;
-            reader.read(data_splits)
-        } else {
-            let reader = DataFileReader::new(
-                self.table.file_io.clone(),
-                self.table.schema_manager().clone(),
-                self.table.schema().id(),
-                self.table.schema.fields().to_vec(),
-                self.read_type().to_vec(),
-                self.data_predicates.clone(),
-            );
-            reader.read(data_splits)
+        if raw_splits.is_empty() {
+            return self.read_kv(&kv_splits, core_options);
         }
+        if kv_splits.is_empty() {
+            return self.read_raw(&raw_splits);
+        }
+
+        let kv_stream = self.read_kv(&kv_splits, core_options)?;
+        let raw_stream = self.read_raw(&raw_splits)?;
+        Ok(Box::pin(futures::stream::select_all([
+            kv_stream, raw_stream,
+        ])))
+    }
+
+    /// Read splits via KeyValueFileReader (sort-merge dedup).
+    fn read_kv(
+        &self,
+        splits: &[DataSplit],
+        core_options: &CoreOptions,
+    ) -> crate::Result<ArrowRecordBatchStream> {
+        let reader = KeyValueFileReader::new(
+            self.table.file_io.clone(),
+            KeyValueReadConfig {
+                schema_manager: self.table.schema_manager().clone(),
+                table_schema_id: self.table.schema().id(),
+                table_fields: self.table.schema.fields().to_vec(),
+                read_type: self.read_type().to_vec(),
+                predicates: self.data_predicates.clone(),
+                primary_keys: self.table.schema.trimmed_primary_keys(),
+                sequence_fields: core_options
+                    .sequence_fields()
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            },
+        );
+        reader.read(splits)
+    }
+
+    /// Read with data-evolution support.
+    fn read_with_evolution(
+        &self,
+        data_splits: &[DataSplit],
+    ) -> crate::Result<ArrowRecordBatchStream> {
+        let reader = DataEvolutionReader::new(
+            self.table.file_io.clone(),
+            self.table.schema_manager().clone(),
+            self.table.schema().id(),
+            self.table.schema.fields().to_vec(),
+            self.read_type().to_vec(),
+        )?;
+        reader.read(data_splits)
+    }
+
+    /// Read raw data files without dedup or evolution.
+    fn read_raw(&self, data_splits: &[DataSplit]) -> crate::Result<ArrowRecordBatchStream> {
+        self.new_data_file_reader().read(data_splits)
+    }
+
+    fn new_data_file_reader(&self) -> DataFileReader {
+        DataFileReader::new(
+            self.table.file_io.clone(),
+            self.table.schema_manager().clone(),
+            self.table.schema().id(),
+            self.table.schema.fields().to_vec(),
+            self.read_type().to_vec(),
+            self.data_predicates.clone(),
+        )
     }
 }

--- a/crates/paimon/src/table/table_read.rs
+++ b/crates/paimon/src/table/table_read.rs
@@ -72,7 +72,7 @@ impl<'a> TableRead<'a> {
 
     /// Returns an [`ArrowRecordBatchStream`].
     pub fn to_arrow(&self, data_splits: &[DataSplit]) -> crate::Result<ArrowRecordBatchStream> {
-        let has_primary_keys = !self.table.schema.trimmed_primary_keys().is_empty();
+        let has_primary_keys = !self.table.schema.primary_keys().is_empty();
         let core_options = CoreOptions::new(self.table.schema.options());
 
         // PK table with Deduplicate engine: splits containing level-0 files

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -474,25 +474,24 @@ impl<'a> TableScan<'a> {
         let file_io = self.table.file_io();
         let table_path = self.table.location();
         let core_options = CoreOptions::new(self.table.schema().options());
-        let deletion_vectors_enabled = core_options.deletion_vectors_enabled();
         let data_evolution_enabled = core_options.data_evolution_enabled();
 
-        let has_primary_keys = !self.table.schema().primary_keys().is_empty();
+        let has_primary_keys = !self.table.schema().trimmed_primary_keys().is_empty();
 
-        // Skip level-0 files for PK tables when:
-        // - DV mode: level-0 files are unmerged, DV handles dedup at higher levels
-        // - FirstRow engine without DV: reads go through DataFileReader (no merge),
-        //   so only compacted (level > 0) files are safe to read directly
+        // Skip level-0 files for PK tables with FirstRow engine only.
+        // FirstRow reads go through DataFileReader (no merge), so only compacted
+        // (level > 0) files are safe to read directly.
+        // Deduplicate engine always uses KeyValueFileReader which handles level-0
+        // via sort-merge, so level-0 files must remain visible.
         //
         // Non-read paths (overwrite, truncate, writer restore) set scan_all_files=true
         // to see all files including level-0, matching Java's CommitScanner behavior.
         let skip_level_zero = if self.scan_all_files {
             false
         } else if has_primary_keys {
-            deletion_vectors_enabled
-                || core_options
-                    .merge_engine()
-                    .is_ok_and(|e| e == crate::spec::MergeEngine::FirstRow)
+            core_options
+                .merge_engine()
+                .is_ok_and(|e| e == crate::spec::MergeEngine::FirstRow)
         } else {
             false
         };
@@ -511,12 +510,7 @@ impl<'a> TableScan<'a> {
             } else {
                 let bucket_keys = core_options.bucket_key().unwrap_or_else(|| {
                     if has_primary_keys {
-                        self.table
-                            .schema()
-                            .primary_keys()
-                            .iter()
-                            .map(|s| s.to_string())
-                            .collect()
+                        self.table.schema().trimmed_primary_keys()
                     } else {
                         Vec::new()
                     }
@@ -689,7 +683,7 @@ impl<'a> TableScan<'a> {
             // Data-evolution tables merge overlapping row-id groups column-wise during read.
             // Keep that split boundary intact and only bin-pack single-file groups.
             // Apply group-level predicate filtering after grouping by row_id range.
-            let file_groups_with_raw: Vec<(Vec<DataFileMeta>, bool)> = if data_evolution_enabled {
+            let file_groups: Vec<Vec<DataFileMeta>> = if data_evolution_enabled {
                 let row_id_groups = group_by_overlapping_row_id(data_files);
 
                 // Filter groups by merged stats before splitting.
@@ -724,23 +718,20 @@ impl<'a> TableScan<'a> {
 
                 let mut result = Vec::new();
                 for group in multis {
-                    result.push((group, false));
+                    result.push(group);
                 }
 
                 let single_files: Vec<DataFileMeta> = singles.into_iter().flatten().collect();
                 for file_group in split_for_batch(single_files, target_split_size, open_file_cost) {
-                    result.push((file_group, true));
+                    result.push(file_group);
                 }
 
                 result
             } else {
                 split_for_batch(data_files, target_split_size, open_file_cost)
-                    .into_iter()
-                    .map(|group| (group, true))
-                    .collect()
             };
 
-            for (file_group, raw_convertible) in file_groups_with_raw {
+            for file_group in file_groups {
                 let data_deletion_files = per_bucket_deletion_map.map(|per_bucket| {
                     file_group
                         .iter()
@@ -770,8 +761,7 @@ impl<'a> TableScan<'a> {
                     .with_bucket(bucket)
                     .with_bucket_path(bucket_path.clone())
                     .with_total_buckets(total_buckets)
-                    .with_data_files(file_group)
-                    .with_raw_convertible(raw_convertible);
+                    .with_data_files(file_group);
                 if let Some(files) = data_deletion_files {
                     builder = builder.with_data_deletion_files(files);
                 }

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -476,11 +476,13 @@ impl<'a> TableScan<'a> {
         let core_options = CoreOptions::new(self.table.schema().options());
         let data_evolution_enabled = core_options.data_evolution_enabled();
 
-        let has_primary_keys = !self.table.schema().trimmed_primary_keys().is_empty();
+        let has_primary_keys = !self.table.schema().primary_keys().is_empty();
+        let deletion_vectors_enabled = core_options.deletion_vectors_enabled();
 
-        // Skip level-0 files for PK tables with FirstRow engine only.
-        // FirstRow reads go through DataFileReader (no merge), so only compacted
-        // (level > 0) files are safe to read directly.
+        // Skip level-0 files for PK tables when:
+        // - DV mode: level-0 files are unmerged, DV handles dedup at higher levels
+        // - FirstRow engine without DV: reads go through DataFileReader (no merge),
+        //   so only compacted (level > 0) files are safe to read directly
         // Deduplicate engine always uses KeyValueFileReader which handles level-0
         // via sort-merge, so level-0 files must remain visible.
         //
@@ -489,9 +491,10 @@ impl<'a> TableScan<'a> {
         let skip_level_zero = if self.scan_all_files {
             false
         } else if has_primary_keys {
-            core_options
-                .merge_engine()
-                .is_ok_and(|e| e == crate::spec::MergeEngine::FirstRow)
+            deletion_vectors_enabled
+                || core_options
+                    .merge_engine()
+                    .is_ok_and(|e| e == crate::spec::MergeEngine::FirstRow)
         } else {
             false
         };

--- a/crates/paimon/src/table/table_write.rs
+++ b/crates/paimon/src/table/table_write.rs
@@ -23,9 +23,14 @@
 use crate::spec::DataFileMeta;
 use crate::spec::PartitionComputer;
 use crate::spec::{
-    extract_datum_from_arrow, BinaryRow, BinaryRowBuilder, CoreOptions, DataField, DataType, Datum,
-    MergeEngine, Predicate, PredicateBuilder, EMPTY_SERIALIZED_ROW, POSTPONE_BUCKET,
+    BinaryRow, CoreOptions, DataField, DataType, Datum, MergeEngine, Predicate, PredicateBuilder,
+    EMPTY_SERIALIZED_ROW, POSTPONE_BUCKET,
 };
+use crate::table::bucket_assigner::{BucketAssignerEnum, PartitionBucketKey};
+use crate::table::bucket_assigner_constant::ConstantBucketAssigner;
+use crate::table::bucket_assigner_cross::CrossPartitionAssigner;
+use crate::table::bucket_assigner_dynamic::DynamicBucketAssigner;
+use crate::table::bucket_assigner_fixed::FixedBucketAssigner;
 use crate::table::commit_message::CommitMessage;
 use crate::table::data_file_writer::DataFileWriter;
 use crate::table::kv_file_writer::{KeyValueFileWriter, KeyValueWriteConfig};
@@ -33,10 +38,8 @@ use crate::table::postpone_file_writer::{PostponeFileWriter, PostponeWriteConfig
 use crate::table::{SnapshotManager, Table, TableScan};
 use crate::Result;
 use arrow_array::RecordBatch;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-
-type PartitionBucketKey = (Vec<u8>, i32);
 
 fn schema_contains_blob_type(fields: &[DataField]) -> bool {
     fields
@@ -83,30 +86,29 @@ pub struct TableWrite {
     partition_writers: HashMap<PartitionBucketKey, FileWriter>,
     partition_computer: PartitionComputer,
     partition_keys: Vec<String>,
-    partition_field_indices: Vec<usize>,
-    bucket_key_indices: Vec<usize>,
-    total_buckets: i32,
     schema_id: i64,
     target_file_size: i64,
     file_compression: String,
     file_compression_zstd_level: i32,
     write_buffer_size: i64,
-    /// Primary key column indices in the user schema (empty for append-only).
     primary_key_indices: Vec<usize>,
-    /// Paimon DataTypes for each primary key column (same order as primary_key_indices).
     primary_key_types: Vec<DataType>,
-    /// Sequence field column indices in the user schema (empty if not configured).
     sequence_field_indices: Vec<usize>,
-    /// Merge engine for primary-key tables.
     merge_engine: MergeEngine,
-    /// Cache of per-partition bucket→max_sequence_number, lazily populated on first write.
     partition_seq_cache: HashMap<Vec<u8>, HashMap<i32, i64>>,
-    /// Commit user identifier, used for postpone file naming.
     commit_user: String,
+    /// Bucket assignment strategy (fixed, dynamic, or cross-partition).
+    bucket_assigner: BucketAssignerEnum,
+    /// Whether this is an overwrite operation (skip seq/index restore).
+    is_overwrite: bool,
 }
 
 impl TableWrite {
-    pub(crate) fn new(table: &Table, commit_user: String) -> crate::Result<Self> {
+    pub(crate) fn new(
+        table: &Table,
+        commit_user: String,
+        is_overwrite: bool,
+    ) -> crate::Result<Self> {
         let schema = table.schema();
         let core_options = CoreOptions::new(schema.options());
 
@@ -125,26 +127,33 @@ impl TableWrite {
         }
 
         let total_buckets = core_options.bucket();
-        let has_primary_keys = !schema.primary_keys().is_empty();
+        let has_primary_keys = !schema.trimmed_primary_keys().is_empty();
+        let is_dynamic_bucket = has_primary_keys && total_buckets == -1;
 
-        if has_primary_keys {
-            if total_buckets < 1 && total_buckets != POSTPONE_BUCKET {
-                return Err(crate::Error::Unsupported {
-                    message: format!(
-                        "KeyValueFileWriter does not support bucket={total_buckets}, only fixed bucket (>= 1) or postpone bucket (= -2) is supported"
-                    ),
-                });
-            }
-            if total_buckets != POSTPONE_BUCKET
-                && core_options
-                    .changelog_producer()
-                    .eq_ignore_ascii_case("input")
-            {
-                return Err(crate::Error::Unsupported {
-                    message: "KeyValueFileWriter does not support changelog-producer=input"
-                        .to_string(),
-                });
-            }
+        let is_cross_partition = is_dynamic_bucket
+            && !schema.partition_keys().is_empty()
+            && schema.trimmed_primary_keys().len() == schema.primary_keys().len();
+
+        if has_primary_keys
+            && !is_dynamic_bucket
+            && total_buckets < 1
+            && total_buckets != POSTPONE_BUCKET
+        {
+            return Err(crate::Error::Unsupported {
+                message: format!(
+                    "KeyValueFileWriter does not support bucket={total_buckets}, only fixed bucket (>= 1), -1 (dynamic), or -2 (postpone) is supported"
+                ),
+            });
+        }
+        if has_primary_keys
+            && total_buckets != POSTPONE_BUCKET
+            && core_options
+                .changelog_producer()
+                .eq_ignore_ascii_case("input")
+        {
+            return Err(crate::Error::Unsupported {
+                message: "KeyValueFileWriter does not support changelog-producer=input".to_string(),
+            });
         }
 
         if !has_primary_keys && total_buckets != -1 && core_options.bucket_key().is_none() {
@@ -181,7 +190,7 @@ impl TableWrite {
         .unwrap();
 
         let primary_key_indices: Vec<usize> = schema
-            .primary_keys()
+            .trimmed_primary_keys()
             .iter()
             .filter_map(|pk| fields.iter().position(|f| f.name() == pk))
             .collect();
@@ -205,14 +214,46 @@ impl TableWrite {
             });
         }
 
+        let target_bucket_row_number = core_options.dynamic_bucket_target_row_num();
+
+        let bucket_assigner = if is_cross_partition {
+            BucketAssignerEnum::CrossPartition(Box::new(CrossPartitionAssigner::new(
+                table.clone(),
+                partition_field_indices,
+                primary_key_indices.clone(),
+                target_bucket_row_number,
+                merge_engine,
+            )))
+        } else if is_dynamic_bucket {
+            BucketAssignerEnum::Dynamic(DynamicBucketAssigner::new(
+                partition_field_indices,
+                primary_key_indices.clone(),
+                schema.fields().to_vec(),
+                target_bucket_row_number,
+                table.file_io().clone(),
+                table.location().to_string(),
+                is_overwrite,
+            ))
+        } else if total_buckets == POSTPONE_BUCKET {
+            BucketAssignerEnum::Constant(ConstantBucketAssigner::new(
+                partition_field_indices,
+                POSTPONE_BUCKET,
+            ))
+        } else if total_buckets <= 1 || bucket_key_indices.is_empty() {
+            BucketAssignerEnum::Constant(ConstantBucketAssigner::new(partition_field_indices, 0))
+        } else {
+            BucketAssignerEnum::Fixed(FixedBucketAssigner::new(
+                partition_field_indices,
+                bucket_key_indices,
+                total_buckets,
+            ))
+        };
+
         Ok(Self {
             table: table.clone(),
             partition_writers: HashMap::new(),
             partition_computer,
             partition_keys,
-            partition_field_indices,
-            bucket_key_indices,
-            total_buckets,
             schema_id: schema.id(),
             target_file_size,
             file_compression,
@@ -224,6 +265,8 @@ impl TableWrite {
             merge_engine,
             partition_seq_cache: HashMap::new(),
             commit_user,
+            bucket_assigner,
+            is_overwrite,
         })
     }
 
@@ -282,7 +325,7 @@ impl TableWrite {
             return Ok(());
         }
 
-        let grouped = self.divide_by_partition_bucket(batch)?;
+        let grouped = self.divide_by_partition_bucket(batch).await?;
         for ((partition_bytes, bucket), sub_batch) in grouped {
             self.write_bucket(partition_bytes, bucket, sub_batch)
                 .await?;
@@ -291,62 +334,116 @@ impl TableWrite {
     }
 
     /// Group rows by (partition_bytes, bucket) and return sub-batches.
-    fn divide_by_partition_bucket(
-        &self,
+    ///
+    /// In cross-partition mode, also generates DELETE sub-batches for keys that
+    /// migrated from one partition to another.
+    async fn divide_by_partition_bucket(
+        &mut self,
         batch: &RecordBatch,
     ) -> Result<Vec<(PartitionBucketKey, RecordBatch)>> {
-        // Fast path: no partitions and single bucket — skip per-row routing
-        if self.partition_field_indices.is_empty() && self.total_buckets <= 1 {
-            let bucket = if self.total_buckets == POSTPONE_BUCKET {
-                POSTPONE_BUCKET
-            } else {
-                0
-            };
-            return Ok(vec![(
-                (EMPTY_SERIALIZED_ROW.clone(), bucket),
-                batch.clone(),
-            )]);
+        // Fast path: constant bucket with no partitions — skip per-row routing
+        if let BucketAssignerEnum::Constant(ref a) = self.bucket_assigner {
+            if self.partition_keys.is_empty() {
+                return Ok(vec![(
+                    (EMPTY_SERIALIZED_ROW.clone(), a.bucket()),
+                    batch.clone(),
+                )]);
+            }
         }
 
-        let fields = self.table.schema().fields();
-        let mut groups: HashMap<PartitionBucketKey, Vec<usize>> = HashMap::new();
+        let fields = self.table.schema().fields().to_vec();
+        let output = self.bucket_assigner.assign_batch(batch, &fields).await?;
 
+        let mut groups: HashMap<PartitionBucketKey, Vec<usize>> = HashMap::new();
+        let skip_set: HashSet<usize> = output.skips.into_iter().collect();
         for row_idx in 0..batch.num_rows() {
-            let (partition_bytes, bucket) =
-                self.extract_partition_bucket(batch, row_idx, fields)?;
+            if skip_set.contains(&row_idx) {
+                continue;
+            }
             groups
-                .entry((partition_bytes, bucket))
+                .entry((
+                    output.partition_bytes[row_idx].clone(),
+                    output.buckets[row_idx],
+                ))
                 .or_default()
                 .push(row_idx);
         }
 
         let mut result = Vec::with_capacity(groups.len());
+        let has_deletes = !output.deletes.is_empty();
         for (key, row_indices) in groups {
-            let sub_batch = if row_indices.len() == batch.num_rows() {
-                batch.clone()
+            let sub_batch = Self::take_rows(batch, &row_indices)?;
+            let sub_batch = if has_deletes {
+                Self::add_value_kind_column(&sub_batch, 0)?
             } else {
-                let indices = arrow_array::UInt32Array::from(
-                    row_indices.iter().map(|&i| i as u32).collect::<Vec<_>>(),
-                );
-                let columns: Vec<Arc<dyn arrow_array::Array>> = batch
-                    .columns()
-                    .iter()
-                    .map(|col| arrow_select::take::take(col.as_ref(), &indices, None))
-                    .collect::<std::result::Result<Vec<_>, _>>()
-                    .map_err(|e| crate::Error::DataInvalid {
-                        message: format!("Failed to take rows: {e}"),
-                        source: None,
-                    })?;
-                RecordBatch::try_new(batch.schema(), columns).map_err(|e| {
-                    crate::Error::DataInvalid {
-                        message: format!("Failed to create sub-batch: {e}"),
-                        source: None,
-                    }
-                })?
+                sub_batch
             };
             result.push((key, sub_batch));
         }
+
+        if !output.deletes.is_empty() {
+            let mut delete_groups: HashMap<PartitionBucketKey, Vec<usize>> = HashMap::new();
+            for (row_idx, old_partition, old_bucket) in &output.deletes {
+                delete_groups
+                    .entry((old_partition.clone(), *old_bucket))
+                    .or_default()
+                    .push(*row_idx);
+            }
+            for (key, row_indices) in delete_groups {
+                let sub_batch = Self::take_rows(batch, &row_indices)?;
+                let delete_batch = Self::add_value_kind_column(&sub_batch, 1)?;
+                result.push((key, delete_batch));
+            }
+        }
+
         Ok(result)
+    }
+
+    /// Extract rows from a batch by indices.
+    fn take_rows(batch: &RecordBatch, row_indices: &[usize]) -> Result<RecordBatch> {
+        if row_indices.len() == batch.num_rows() {
+            return Ok(batch.clone());
+        }
+        let indices = arrow_array::UInt32Array::from(
+            row_indices.iter().map(|&i| i as u32).collect::<Vec<_>>(),
+        );
+        let columns: Vec<Arc<dyn arrow_array::Array>> = batch
+            .columns()
+            .iter()
+            .map(|col| arrow_select::take::take(col.as_ref(), &indices, None))
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| crate::Error::DataInvalid {
+                message: format!("Failed to take rows: {e}"),
+                source: None,
+            })?;
+        RecordBatch::try_new(batch.schema(), columns).map_err(|e| crate::Error::DataInvalid {
+            message: format!("Failed to create sub-batch: {e}"),
+            source: None,
+        })
+    }
+
+    /// Add a `_VALUE_KIND` column to a batch with the given value for all rows.
+    fn add_value_kind_column(batch: &RecordBatch, value_kind: i8) -> Result<RecordBatch> {
+        use arrow_array::Int8Array;
+        use arrow_schema::{DataType as ArrowDataType, Field as ArrowField};
+
+        let vk_array = Arc::new(Int8Array::from(vec![value_kind; batch.num_rows()]));
+        let vk_field = Arc::new(ArrowField::new(
+            crate::spec::VALUE_KIND_FIELD_NAME,
+            ArrowDataType::Int8,
+            false,
+        ));
+
+        let mut fields = batch.schema().fields().to_vec();
+        let mut columns: Vec<Arc<dyn arrow_array::Array>> = batch.columns().to_vec();
+        fields.push(vk_field);
+        columns.push(vk_array);
+
+        let schema = Arc::new(arrow_schema::Schema::new(fields));
+        RecordBatch::try_new(schema, columns).map_err(|e| crate::Error::DataInvalid {
+            message: format!("Failed to add _VALUE_KIND column: {e}"),
+            source: None,
+        })
     }
 
     /// Write a batch directly to the writer for the given (partition, bucket).
@@ -388,135 +485,138 @@ impl TableWrite {
 
         let results = futures::future::try_join_all(futures).await?;
 
+        // Collect index files from bucket assigner
+        let file_io = self.table.file_io();
+        let index_dir = format!("{}/index", self.table.location());
+        let mut index_files_by_key = self
+            .bucket_assigner
+            .prepare_commit_index(file_io, &index_dir)
+            .await?;
+
         let mut messages = Vec::new();
         for (partition_bytes, bucket, files) in results {
-            if !files.is_empty() {
-                messages.push(CommitMessage::new(partition_bytes, bucket, files));
+            let key = (partition_bytes.clone(), bucket);
+            let index_files = index_files_by_key.remove(&key).unwrap_or_default();
+            if !files.is_empty() || !index_files.is_empty() {
+                let mut msg = CommitMessage::new(partition_bytes, bucket, files);
+                msg.new_index_files = index_files;
+                messages.push(msg);
+            }
+        }
+        // Emit index-only messages for (partition, bucket) pairs that had no data writer
+        // (e.g., old buckets where keys migrated away in cross-partition mode).
+        for ((partition_bytes, bucket), idx_files) in index_files_by_key {
+            if !idx_files.is_empty() {
+                let mut msg = CommitMessage::new(partition_bytes, bucket, vec![]);
+                msg.new_index_files = idx_files;
+                messages.push(msg);
             }
         }
         Ok(messages)
     }
 
-    /// Extract partition bytes and bucket for a single row.
-    fn extract_partition_bucket(
-        &self,
-        batch: &RecordBatch,
-        row_idx: usize,
-        fields: &[DataField],
-    ) -> Result<PartitionBucketKey> {
-        // Build partition BinaryRow
-        let partition_bytes = if self.partition_field_indices.is_empty() {
-            EMPTY_SERIALIZED_ROW.clone()
-        } else {
-            let mut builder = BinaryRowBuilder::new(self.partition_field_indices.len() as i32);
-            for (pos, &field_idx) in self.partition_field_indices.iter().enumerate() {
-                let field = &fields[field_idx];
-                match extract_datum_from_arrow(batch, row_idx, field_idx, field.data_type())? {
-                    Some(datum) => builder.write_datum(pos, &datum, field.data_type()),
-                    None => builder.set_null_at(pos),
-                }
-            }
-            builder.build_serialized()
-        };
-
-        // Compute bucket
-        let bucket = if self.total_buckets == POSTPONE_BUCKET {
-            POSTPONE_BUCKET
-        } else if self.total_buckets <= 1 || self.bucket_key_indices.is_empty() {
-            0
-        } else {
-            let mut datums: Vec<(Option<Datum>, DataType)> = Vec::new();
-            for &field_idx in &self.bucket_key_indices {
-                let field = &fields[field_idx];
-                let datum = extract_datum_from_arrow(batch, row_idx, field_idx, field.data_type())?;
-                datums.push((datum, field.data_type().clone()));
-            }
-            let refs: Vec<(Option<&Datum>, &DataType)> =
-                datums.iter().map(|(d, t)| (d.as_ref(), t)).collect();
-            BinaryRow::compute_bucket_from_datums(&refs, self.total_buckets)
-        };
-
-        Ok((partition_bytes, bucket))
-    }
-
     async fn create_writer(&mut self, partition_bytes: Vec<u8>, bucket: i32) -> Result<()> {
-        let partition_path = if self.partition_keys.is_empty() {
-            String::new()
-        } else {
-            let row = BinaryRow::from_serialized_bytes(&partition_bytes)?;
-            self.partition_computer.generate_partition_path(&row)?
-        };
+        let partition_path = self.resolve_partition_path(&partition_bytes)?;
 
         let writer = if self.primary_key_indices.is_empty() {
-            // Append-only writer for non-PK tables.
-            FileWriter::Append(DataFileWriter::new(
-                self.table.file_io().clone(),
-                self.table.location().to_string(),
-                partition_path,
-                bucket,
-                self.schema_id,
-                self.target_file_size,
-                self.file_compression.clone(),
-                self.file_compression_zstd_level,
-                self.write_buffer_size,
-                Some(0), // file_source: APPEND
-                None,    // first_row_id: assigned by commit
-                None,    // write_cols: full-row write
-            ))
+            self.create_append_writer(partition_path, bucket)
         } else if bucket == POSTPONE_BUCKET {
-            // Postpone bucket: KV format but no sorting/dedup, special file naming.
-            let data_file_prefix = format!("data-u-{}-s-0-w-", self.commit_user);
-            FileWriter::Postpone(PostponeFileWriter::new(
-                self.table.file_io().clone(),
-                PostponeWriteConfig {
-                    table_location: self.table.location().to_string(),
-                    partition_path,
-                    bucket,
-                    schema_id: self.schema_id,
-                    target_file_size: self.target_file_size,
-                    file_compression: self.file_compression.clone(),
-                    file_compression_zstd_level: self.file_compression_zstd_level,
-                    write_buffer_size: self.write_buffer_size,
-                    data_file_prefix,
-                },
-            ))
+            self.create_postpone_writer(partition_path, bucket)
         } else {
-            // Lazily scan partition sequence numbers on first writer creation per partition.
-            if !self.partition_seq_cache.contains_key(&partition_bytes) {
-                let bucket_seq =
-                    Self::scan_partition_sequence_numbers(&self.table, &partition_bytes).await?;
-                self.partition_seq_cache
-                    .insert(partition_bytes.clone(), bucket_seq);
-            }
-            let next_seq = self
-                .partition_seq_cache
-                .get(&partition_bytes)
-                .and_then(|m| m.get(&bucket))
-                .copied()
-                .unwrap_or(0);
-
-            FileWriter::KeyValue(KeyValueFileWriter::new(
-                self.table.file_io().clone(),
-                KeyValueWriteConfig {
-                    table_location: self.table.location().to_string(),
-                    partition_path,
-                    bucket,
-                    schema_id: self.schema_id,
-                    file_compression: self.file_compression.clone(),
-                    file_compression_zstd_level: self.file_compression_zstd_level,
-                    write_buffer_size: self.write_buffer_size,
-                    primary_key_indices: self.primary_key_indices.clone(),
-                    primary_key_types: self.primary_key_types.clone(),
-                    sequence_field_indices: self.sequence_field_indices.clone(),
-                    merge_engine: self.merge_engine,
-                },
-                next_seq,
-            ))
+            self.create_kv_writer(partition_path, bucket, &partition_bytes)
+                .await?
         };
 
         self.partition_writers
             .insert((partition_bytes, bucket), writer);
         Ok(())
+    }
+
+    fn resolve_partition_path(&self, partition_bytes: &[u8]) -> Result<String> {
+        if self.partition_keys.is_empty() {
+            Ok(String::new())
+        } else {
+            let row = BinaryRow::from_serialized_bytes(partition_bytes)?;
+            self.partition_computer.generate_partition_path(&row)
+        }
+    }
+
+    /// Create an append-only writer for non-PK tables.
+    fn create_append_writer(&self, partition_path: String, bucket: i32) -> FileWriter {
+        FileWriter::Append(DataFileWriter::new(
+            self.table.file_io().clone(),
+            self.table.location().to_string(),
+            partition_path,
+            bucket,
+            self.schema_id,
+            self.target_file_size,
+            self.file_compression.clone(),
+            self.file_compression_zstd_level,
+            self.write_buffer_size,
+            Some(0), // file_source: APPEND
+            None,    // first_row_id: assigned by commit
+            None,    // write_cols: full-row write
+        ))
+    }
+
+    /// Create a postpone writer (KV format, no sorting/dedup, special file naming).
+    fn create_postpone_writer(&self, partition_path: String, bucket: i32) -> FileWriter {
+        let data_file_prefix = format!("data-u-{}-s-0-w-", self.commit_user);
+        FileWriter::Postpone(PostponeFileWriter::new(
+            self.table.file_io().clone(),
+            PostponeWriteConfig {
+                table_location: self.table.location().to_string(),
+                partition_path,
+                bucket,
+                schema_id: self.schema_id,
+                target_file_size: self.target_file_size,
+                file_compression: self.file_compression.clone(),
+                file_compression_zstd_level: self.file_compression_zstd_level,
+                write_buffer_size: self.write_buffer_size,
+                data_file_prefix,
+            },
+        ))
+    }
+
+    /// Create a key-value writer for PK tables with normal buckets.
+    async fn create_kv_writer(
+        &mut self,
+        partition_path: String,
+        bucket: i32,
+        partition_bytes: &[u8],
+    ) -> Result<FileWriter> {
+        // Lazily scan partition sequence numbers on first writer creation per partition.
+        // Overwrite mode skips this — old data will be replaced, so seq starts at 0.
+        if !self.is_overwrite && !self.partition_seq_cache.contains_key(partition_bytes) {
+            let bucket_seq =
+                Self::scan_partition_sequence_numbers(&self.table, partition_bytes).await?;
+            self.partition_seq_cache
+                .insert(partition_bytes.to_vec(), bucket_seq);
+        }
+        let next_seq = self
+            .partition_seq_cache
+            .get(partition_bytes)
+            .and_then(|m| m.get(&bucket))
+            .copied()
+            .unwrap_or(0);
+
+        Ok(FileWriter::KeyValue(KeyValueFileWriter::new(
+            self.table.file_io().clone(),
+            KeyValueWriteConfig {
+                table_location: self.table.location().to_string(),
+                partition_path,
+                bucket,
+                schema_id: self.schema_id,
+                file_compression: self.file_compression.clone(),
+                file_compression_zstd_level: self.file_compression_zstd_level,
+                write_buffer_size: self.write_buffer_size,
+                primary_key_indices: self.primary_key_indices.clone(),
+                primary_key_types: self.primary_key_types.clone(),
+                sequence_field_indices: self.sequence_field_indices.clone(),
+                merge_engine: self.merge_engine,
+            },
+            next_seq,
+        )))
     }
 }
 
@@ -526,8 +626,8 @@ mod tests {
     use crate::catalog::Identifier;
     use crate::io::{FileIO, FileIOBuilder};
     use crate::spec::{
-        BlobType, DataField, DataType, DecimalType, IntType, LocalZonedTimestampType, RowType,
-        Schema, TableSchema, TimestampType, VarCharType,
+        BinaryRowBuilder, BlobType, DataField, DataType, DecimalType, IntType,
+        LocalZonedTimestampType, RowType, Schema, TableSchema, TimestampType, VarCharType,
     };
     use crate::table::{SnapshotManager, TableCommit};
     use arrow_array::Int32Array;
@@ -653,7 +753,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         let batch = make_batch(vec![1, 2, 3], vec![10, 20, 30]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -684,7 +784,7 @@ mod tests {
             None,
         );
 
-        let err = TableWrite::new(&table, "test-user".to_string())
+        let err = TableWrite::new(&table, "test-user".to_string(), false)
             .err()
             .unwrap();
         assert!(
@@ -702,7 +802,7 @@ mod tests {
             None,
         );
 
-        let err = TableWrite::new(&table, "test-user".to_string())
+        let err = TableWrite::new(&table, "test-user".to_string(), false)
             .err()
             .unwrap();
         assert!(
@@ -717,7 +817,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_partitioned_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         let batch = make_partitioned_batch(vec!["a", "b", "a"], vec![1, 2, 3]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -748,7 +848,7 @@ mod tests {
         let file_io = test_file_io();
         let table_path = "memory:/test_table_write_empty";
         let table = test_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         let batch = make_batch(vec![], vec![]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -764,7 +864,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         // First write + prepare_commit
         table_write
@@ -796,7 +896,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         table_write
             .write_arrow_batch(&make_batch(vec![1, 2], vec![10, 20]))
@@ -860,7 +960,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_bucketed_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         // Row with NULL bucket key should not panic
         let batch = make_nullable_id_batch(vec![None, Some(1), None], vec![10, 20, 30]);
@@ -882,7 +982,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_bucketed_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         // Two NULLs should land in the same bucket
         let batch = make_nullable_id_batch(vec![None, None], vec![10, 20]);
@@ -910,18 +1010,24 @@ mod tests {
 
         // Compute bucket for NULL key
         let fields = table.schema().fields().to_vec();
-        let tw = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut tw = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         let batch_null = make_nullable_id_batch(vec![None], vec![10]);
-        let (_, bucket_null) = tw
-            .extract_partition_bucket(&batch_null, 0, &fields)
+        let out_null = tw
+            .bucket_assigner
+            .assign_batch(&batch_null, &fields)
+            .await
             .unwrap();
+        let bucket_null = out_null.buckets[0];
 
         // Compute bucket for key = 0 (the value a null field's fixed bytes happen to be)
         let batch_zero = make_nullable_id_batch(vec![Some(0)], vec![20]);
-        let (_, bucket_zero) = tw
-            .extract_partition_bucket(&batch_zero, 0, &fields)
+        let out_zero = tw
+            .bucket_assigner
+            .assign_batch(&batch_zero, &fields)
+            .await
             .unwrap();
+        let bucket_zero = out_zero.buckets[0];
 
         // A NULL bucket key must produce a BinaryRow with the null bit set,
         // which hashes differently from a non-null 0 value.
@@ -975,7 +1081,7 @@ mod tests {
                 None,
             );
 
-            let tw = TableWrite::new(&table, "test-user".to_string()).unwrap();
+            let mut tw = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
             let fields = table.schema().fields().to_vec();
 
             // Build a batch: d=NULL, ltz=NULL, ntz=NULL, k=1
@@ -1013,12 +1119,17 @@ mod tests {
             )
             .unwrap();
 
-            let (_, bucket) = tw.extract_partition_bucket(&batch, 0, &fields).unwrap();
+            let batch_output = tw
+                .bucket_assigner
+                .assign_batch(&batch, &fields)
+                .await
+                .unwrap();
+            let bucket = batch_output.buckets[0];
 
             // Expected: BinaryRow with 1 field, null at pos 0
             let mut builder = BinaryRowBuilder::new(1);
             builder.set_null_at(0);
-            let expected_bucket = (builder.build().hash_code() % total_buckets).abs();
+            let expected_bucket = (builder.build().hash_code() % total_buckets).wrapping_abs();
 
             assert_eq!(
                 bucket, expected_bucket,
@@ -1049,7 +1160,7 @@ mod tests {
             None,
         );
 
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         // Write multiple batches — each should roll to a new file
         table_write
@@ -1102,7 +1213,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         let batch = make_batch(vec![3, 1, 2], vec![30, 10, 20]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -1137,7 +1248,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         // Write unsorted data
         let batch = make_batch(vec![5, 2, 4, 1, 3], vec![50, 20, 40, 10, 30]);
@@ -1195,7 +1306,7 @@ mod tests {
         let table = test_pk_table(&file_io, table_path);
 
         // First commit: id=1,2,3
-        let mut tw1 = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut tw1 = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
         tw1.write_arrow_batch(&make_batch(vec![1, 2, 3], vec![10, 20, 30]))
             .await
             .unwrap();
@@ -1204,7 +1315,7 @@ mod tests {
         commit.commit(msgs1).await.unwrap();
 
         // Second commit: id=2,3,4 with updated values, higher sequence numbers
-        let mut tw2 = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut tw2 = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
         tw2.write_arrow_batch(&make_batch(vec![2, 3, 4], vec![200, 300, 400]))
             .await
             .unwrap();
@@ -1257,7 +1368,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         let batch = make_batch(vec![1, 2], vec![10, 20]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -1341,7 +1452,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_postpone_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         let batch = make_batch(vec![3, 1, 2], vec![30, 10, 20]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -1367,7 +1478,7 @@ mod tests {
         let file_io = test_file_io();
         let table_path = "memory:/test_postpone_empty";
         let table = test_postpone_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         let batch = make_batch(vec![], vec![]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -1383,7 +1494,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_postpone_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         table_write
             .write_arrow_batch(&make_batch(vec![1, 2], vec![10, 20]))
@@ -1409,7 +1520,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_postpone_partitioned_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         let batch =
             make_partitioned_batch_3col(vec!["a", "b", "a"], vec![1, 2, 3], vec![10, 20, 30]);
@@ -1447,7 +1558,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_postpone_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
 
         // First write + prepare_commit
         table_write
@@ -1479,7 +1590,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_postpone_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "my-commit-user".to_string()).unwrap();
+        let mut table_write = TableWrite::new(&table, "my-commit-user".to_string(), false).unwrap();
 
         let batch = make_batch(vec![3, 1, 2], vec![30, 10, 20]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -1537,5 +1648,173 @@ mod tests {
         // Empty key stats for postpone mode
         assert_eq!(file.min_key, EMPTY_SERIALIZED_ROW.clone());
         assert_eq!(file.max_key, EMPTY_SERIALIZED_ROW.clone());
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-partition update tests (dynamic bucket, PK not including partition)
+    // -----------------------------------------------------------------------
+
+    fn test_cross_partition_schema() -> TableSchema {
+        // PK is only "id", partition is "pt" — PK does NOT include partition field
+        let schema = Schema::builder()
+            .column("pt", DataType::VarChar(VarCharType::string_type()))
+            .column("id", DataType::Int(IntType::new()))
+            .column("value", DataType::Int(IntType::new()))
+            .primary_key(["id"])
+            .partition_keys(["pt"])
+            .build()
+            .unwrap();
+        TableSchema::new(0, &schema)
+    }
+
+    fn test_cross_partition_table(file_io: &FileIO, table_path: &str) -> Table {
+        Table::new(
+            file_io.clone(),
+            Identifier::new("default", "test_cross_partition"),
+            table_path.to_string(),
+            test_cross_partition_schema(),
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_cross_partition_detection() {
+        let file_io = test_file_io();
+        let table_path = "memory:/test_cross_detect";
+
+        // Cross-partition: PK=id, partition=pt, bucket=-1
+        let table = test_cross_partition_table(&file_io, table_path);
+        let tw = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        assert!(matches!(
+            tw.bucket_assigner,
+            BucketAssignerEnum::CrossPartition(_)
+        ));
+
+        // Non-cross-partition: PK includes partition field
+        let schema = Schema::builder()
+            .column("pt", DataType::VarChar(VarCharType::string_type()))
+            .column("id", DataType::Int(IntType::new()))
+            .column("value", DataType::Int(IntType::new()))
+            .primary_key(["pt", "id"])
+            .partition_keys(["pt"])
+            .build()
+            .unwrap();
+        let table2 = Table::new(
+            file_io.clone(),
+            Identifier::new("default", "test"),
+            table_path.to_string(),
+            TableSchema::new(0, &schema),
+            None,
+        );
+        let tw2 = TableWrite::new(&table2, "test-user".to_string(), false).unwrap();
+        assert!(matches!(
+            tw2.bucket_assigner,
+            BucketAssignerEnum::Dynamic(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_cross_partition_write_same_partition() {
+        let file_io = test_file_io();
+        let table_path = "memory:/test_cross_same_pt";
+        setup_dirs(&file_io, table_path).await;
+
+        let table = test_cross_partition_table(&file_io, table_path);
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+
+        // All rows in same partition — no cross-partition deletes
+        let batch =
+            make_partitioned_batch_3col(vec!["a", "a", "a"], vec![1, 2, 3], vec![10, 20, 30]);
+        table_write.write_arrow_batch(&batch).await.unwrap();
+
+        let messages = table_write.prepare_commit().await.unwrap();
+        let total_data_files: usize = messages.iter().map(|m| m.new_files.len()).sum();
+        assert!(total_data_files >= 1);
+
+        let total_rows: i64 = messages
+            .iter()
+            .flat_map(|m| &m.new_files)
+            .map(|f| f.row_count)
+            .sum();
+        assert_eq!(total_rows, 3);
+    }
+
+    #[tokio::test]
+    async fn test_cross_partition_write_generates_delete() {
+        let file_io = test_file_io();
+        let table_path = "memory:/test_cross_delete";
+        setup_dirs(&file_io, table_path).await;
+
+        let table = test_cross_partition_table(&file_io, table_path);
+
+        // First commit: id=1 in partition "a"
+        let mut tw1 = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let batch1 = make_partitioned_batch_3col(vec!["a"], vec![1], vec![10]);
+        tw1.write_arrow_batch(&batch1).await.unwrap();
+        let msgs1 = tw1.prepare_commit().await.unwrap();
+        let commit = TableCommit::new(table.clone(), "test-user".to_string());
+        commit.commit(msgs1).await.unwrap();
+
+        // Second commit: id=1 moves to partition "b"
+        let mut tw2 = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let batch2 = make_partitioned_batch_3col(vec!["b"], vec![1], vec![20]);
+        tw2.write_arrow_batch(&batch2).await.unwrap();
+        let msgs2 = tw2.prepare_commit().await.unwrap();
+
+        // Should have messages for both partition "a" (delete) and partition "b" (add)
+        assert!(
+            msgs2.len() >= 2,
+            "Expected messages for both old and new partition, got {}",
+            msgs2.len()
+        );
+
+        // The total data files should include both the DELETE and ADD records
+        let total_rows: i64 = msgs2
+            .iter()
+            .flat_map(|m| &m.new_files)
+            .map(|f| f.row_count)
+            .sum();
+        // 1 ADD in partition "b" + 1 DELETE in partition "a"
+        assert_eq!(total_rows, 2);
+
+        commit.commit(msgs2).await.unwrap();
+
+        // Read back — should only see id=1 with value=20 in partition "b"
+        let rb = table.new_read_builder();
+        let scan = rb.new_scan();
+        let plan = scan.plan().await.unwrap();
+        let read = rb.new_read().unwrap();
+        let batches: Vec<RecordBatch> =
+            futures::TryStreamExt::try_collect(read.to_arrow(plan.splits()).unwrap())
+                .await
+                .unwrap();
+
+        let ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|b| {
+                b.column(1)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .iter()
+                    .copied()
+            })
+            .collect();
+        let values: Vec<i32> = batches
+            .iter()
+            .flat_map(|b| {
+                b.column(2)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .iter()
+                    .copied()
+            })
+            .collect();
+
+        assert_eq!(ids, vec![1]);
+        assert_eq!(values, vec![20]);
     }
 }

--- a/crates/paimon/src/table/table_write.rs
+++ b/crates/paimon/src/table/table_write.rs
@@ -127,12 +127,16 @@ impl TableWrite {
         }
 
         let total_buckets = core_options.bucket();
-        let has_primary_keys = !schema.trimmed_primary_keys().is_empty();
+        let has_primary_keys = !schema.primary_keys().is_empty();
         let is_dynamic_bucket = has_primary_keys && total_buckets == -1;
 
-        let is_cross_partition = is_dynamic_bucket
-            && !schema.partition_keys().is_empty()
-            && schema.trimmed_primary_keys().len() == schema.primary_keys().len();
+        let is_cross_partition = is_dynamic_bucket && !schema.partition_keys().is_empty() && {
+            let pk_set: HashSet<&str> = schema.primary_keys().iter().map(String::as_str).collect();
+            schema
+                .partition_keys()
+                .iter()
+                .any(|p| !pk_set.contains(p.as_str()))
+        };
 
         if has_primary_keys
             && !is_dynamic_bucket
@@ -370,10 +374,16 @@ impl TableWrite {
         }
 
         let mut result = Vec::with_capacity(groups.len());
-        let has_deletes = !output.deletes.is_empty();
+        // Cross-partition writers must always include _VALUE_KIND to keep the
+        // Arrow schema stable across batches (some batches may have deletes,
+        // others may not — KeyValueFileWriter's concat_batches requires a
+        // consistent schema).
+        let needs_value_kind =
+            matches!(self.bucket_assigner, BucketAssignerEnum::CrossPartition(_))
+                || !output.deletes.is_empty();
         for (key, row_indices) in groups {
             let sub_batch = Self::take_rows(batch, &row_indices)?;
-            let sub_batch = if has_deletes {
+            let sub_batch = if needs_value_kind {
                 Self::add_value_kind_column(&sub_batch, 0)?
             } else {
                 sub_batch

--- a/crates/paimon/src/table/write_builder.rs
+++ b/crates/paimon/src/table/write_builder.rs
@@ -29,6 +29,7 @@ use uuid::Uuid;
 pub struct WriteBuilder<'a> {
     table: &'a Table,
     commit_user: String,
+    is_overwrite: bool,
 }
 
 impl<'a> WriteBuilder<'a> {
@@ -36,7 +37,17 @@ impl<'a> WriteBuilder<'a> {
         Self {
             table,
             commit_user: Uuid::new_v4().to_string(),
+            is_overwrite: false,
         }
+    }
+
+    /// Mark this write as an overwrite operation.
+    ///
+    /// Overwrite skips restoring sequence numbers and bucket index loading
+    /// since old data will be fully replaced at commit time.
+    pub fn with_overwrite(mut self) -> Self {
+        self.is_overwrite = true;
+        self
     }
 
     /// Create a new TableCommit for committing write results.
@@ -49,6 +60,6 @@ impl<'a> WriteBuilder<'a> {
     /// For primary-key tables, sequence numbers are lazily scanned per partition
     /// when the first writer for that partition is created.
     pub fn new_write(&self) -> crate::Result<TableWrite> {
-        TableWrite::new(self.table, self.commit_user.clone())
+        TableWrite::new(self.table, self.commit_user.clone(), self.is_overwrite)
     }
 }

--- a/dev/spark/provision.py
+++ b/dev/spark/provision.py
@@ -622,6 +622,39 @@ def main():
     )
 
 
+    # ===== Dynamic bucket PK table (bucket=-1) =====
+    # Two commits with overlapping keys to exercise dynamic bucket assignment
+    # and index file generation. Used to verify that paimon-rust produces
+    # identical hash index values when writing the same data.
+    spark.sql(
+        """
+        CREATE TABLE IF NOT EXISTS dynamic_bucket_pk_table (
+            id INT,
+            name STRING
+        ) USING paimon
+        TBLPROPERTIES (
+            'primary-key' = 'id',
+            'bucket' = '-1'
+        )
+        """
+    )
+    spark.sql(
+        """
+        INSERT INTO dynamic_bucket_pk_table VALUES
+            (1, 'alice'),
+            (2, 'bob'),
+            (3, 'carol')
+        """
+    )
+    spark.sql(
+        """
+        INSERT INTO dynamic_bucket_pk_table VALUES
+            (2, 'bob-v2'),
+            (3, 'carol-v2'),
+            (4, 'dave')
+        """
+    )
+
     # ===== Multi-bucket PK table for bucket predicate filtering tests =====
     # PK table with bucket=4 so data distributes across multiple buckets.
     # Bucket key defaults to primary key (id). Used to test that bucket predicate


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Implement bucket assigner framework with four strategies: fixed, dynamic, cross-partition, and constant. Add BinaryRow hash/comparison support for bucket key computation. Update table read/write/scan/commit pipeline to support dynamic bucket mode. Include DataFusion integration tests for dynamic bucket and cross-partition table scenarios.


<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
