### PR TITLE
remove stale raw_convertible builder calls

### DIFF
--- a/crates/paimon/src/table/data_evolution_reader.rs
+++ b/crates/paimon/src/table/data_evolution_reader.rs
@@ -1331,7 +1331,6 @@ mod tests {
                     Some(vec!["payload"]),
                 ),
             ])
-            .with_raw_convertible(false)
             .build()
             .unwrap();
 
@@ -1441,7 +1440,6 @@ mod tests {
                     Some(vec!["payload2"]),
                 ),
             ])
-            .with_raw_convertible(false)
             .with_row_ranges(vec![RowRange::new(1, 2)])
             .build()
             .unwrap();


### PR DESCRIPTION
 Clean up stale test setup in the data evolution reader tests after `raw_convertible` is now derived automatically
  from split data files.

  ### Brief change log

  - Remove obsolete `with_raw_convertible(false)` calls from the data evolution reader tests.
  - Align the test setup with the current split reading behavior.
  - Keep the change scoped to tests only, with no production logic change.

  ### Tests

  Not run.

  ### API and Format

  No API or storage format changes.

  ### Documentation

  No documentation updates are required.