### PR TITLE
feat(blob): add blob descriptor write support for append-only tables

### DIFF
--- a/crates/integrations/datafusion/tests/blob_tests.rs
+++ b/crates/integrations/datafusion/tests/blob_tests.rs
@@ -1,0 +1,610 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Blob type integration tests.
+//!
+//! Reference: Java Paimon's `BlobTestBase` in paimon-spark.
+
+mod common;
+
+use arrow_array::{Array, BinaryArray, Int32Array, RecordBatch, StringArray};
+use common::{create_handler, create_test_env, ctx_exec, exec};
+use paimon::spec::BlobDescriptor;
+use paimon_datafusion::PaimonSqlHandler;
+
+// ======================= Helpers =======================
+
+fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02X}")).collect()
+}
+
+async fn setup(table_ddl: &str) -> (tempfile::TempDir, PaimonSqlHandler) {
+    let (tmp, catalog) = create_test_env();
+    let handler = create_handler(catalog);
+    handler.sql("CREATE SCHEMA paimon.test_db").await.unwrap();
+    handler.sql(table_ddl).await.unwrap();
+    (tmp, handler)
+}
+
+fn collect_id_name_picture(batches: &[RecordBatch]) -> Vec<(i32, String, Option<Vec<u8>>)> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let names = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let pics = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            let pic = if pics.is_null(i) {
+                None
+            } else {
+                Some(pics.value(i).to_vec())
+            };
+            rows.push((ids.value(i), names.value(i).to_string(), pic));
+        }
+    }
+    rows.sort_by_key(|(id, _, _)| *id);
+    rows
+}
+
+async fn query_id_name_picture(
+    handler: &PaimonSqlHandler,
+    sql: &str,
+) -> Vec<(i32, String, Option<Vec<u8>>)> {
+    let batches = handler.sql(sql).await.unwrap().collect().await.unwrap();
+    collect_id_name_picture(&batches)
+}
+
+fn collect_id_name(batches: &[RecordBatch]) -> Vec<(i32, String)> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let names = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            rows.push((ids.value(i), names.value(i).to_string()));
+        }
+    }
+    rows.sort_by_key(|(id, _)| *id);
+    rows
+}
+
+const BLOB_TABLE_DDL: &str = "\
+    CREATE TABLE paimon.test_db.t (\
+        id INT, \
+        name STRING, \
+        picture BLOB \
+    ) WITH (\
+        'data-evolution.enabled' = 'true', \
+        'row-tracking.enabled' = 'true'\
+    )";
+
+// ======================= Tests =======================
+
+/// Reference: BlobTestBase "Blob: test basic"
+#[tokio::test]
+async fn test_blob_basic() {
+    let (_tmp, handler) = setup(BLOB_TABLE_DDL).await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES (1, 'Alice', X'48656C6C6F')",
+    )
+    .await;
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, 1);
+    assert_eq!(rows[0].1, "Alice");
+    assert_eq!(rows[0].2, Some(b"Hello".to_vec()));
+}
+
+/// Reference: BlobTestBase "Blob: test multiple blobs"
+#[tokio::test]
+async fn test_blob_multiple_columns() {
+    let (_tmp, handler) = setup(
+        "CREATE TABLE paimon.test_db.t (\
+            id INT, \
+            pic1 BLOB, \
+            pic2 BLOB \
+         ) WITH (\
+            'data-evolution.enabled' = 'true', \
+            'row-tracking.enabled' = 'true'\
+         )",
+    )
+    .await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, pic1, pic2) VALUES (1, X'414141', X'424242')",
+    )
+    .await;
+
+    let batches = handler
+        .sql("SELECT id, pic1, pic2 FROM paimon.test_db.t")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+
+    let batch = &batches[0];
+    let ids = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let p1 = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .unwrap();
+    let p2 = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .unwrap();
+    assert_eq!(ids.value(0), 1);
+    assert_eq!(p1.value(0), b"AAA");
+    assert_eq!(p2.value(0), b"BBB");
+}
+
+/// Blob with NULL values.
+#[tokio::test]
+async fn test_blob_with_nulls() {
+    let (_tmp, handler) = setup(BLOB_TABLE_DDL).await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES \
+         (1, 'Alice', X'48656C6C6F'), \
+         (2, 'Bob', NULL), \
+         (3, 'Carol', X'576F726C64')",
+    )
+    .await;
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(
+        rows,
+        vec![
+            (1, "Alice".into(), Some(b"Hello".to_vec())),
+            (2, "Bob".into(), None),
+            (3, "Carol".into(), Some(b"World".to_vec())),
+        ]
+    );
+}
+
+/// Multiple inserts produce multiple file pairs, all readable.
+#[tokio::test]
+async fn test_blob_multiple_inserts() {
+    let (_tmp, handler) = setup(BLOB_TABLE_DDL).await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES (1, 'Alice', X'4141')",
+    )
+    .await;
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES (2, 'Bob', X'4242')",
+    )
+    .await;
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(
+        rows,
+        vec![
+            (1, "Alice".into(), Some(b"AA".to_vec())),
+            (2, "Bob".into(), Some(b"BB".to_vec())),
+        ]
+    );
+}
+
+/// blob-descriptor-field: listed fields are stored inline in parquet (no .blob files).
+#[tokio::test]
+async fn test_blob_descriptor_field_inline() {
+    let (_tmp, handler) = setup(
+        "CREATE TABLE paimon.test_db.t (\
+            id INT, \
+            name STRING, \
+            picture BLOB \
+         ) WITH (\
+            'data-evolution.enabled' = 'true', \
+            'row-tracking.enabled' = 'true', \
+            'blob-descriptor-field' = 'picture'\
+         )",
+    )
+    .await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES (1, 'Alice', X'48656C6C6F')",
+    )
+    .await;
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, 1);
+    assert_eq!(rows[0].1, "Alice");
+    assert_eq!(rows[0].2, Some(b"Hello".to_vec()));
+}
+
+/// Reference: BlobTestBase "Blob: merge-into rejects updating raw-data BLOB column"
+#[tokio::test]
+async fn test_merge_into_rejects_raw_blob_update() {
+    let (_tmp, handler) = setup(BLOB_TABLE_DDL).await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES (1, 'Alice', X'4141')",
+    )
+    .await;
+
+    ctx_exec(
+        &handler,
+        "CREATE TABLE src (id INT, picture BYTEA) AS VALUES (1, X'4242')",
+    )
+    .await;
+
+    let result = handler
+        .sql(
+            "MERGE INTO paimon.test_db.t t \
+             USING src s ON t.id = s.id \
+             WHEN MATCHED THEN UPDATE SET picture = s.picture",
+        )
+        .await;
+
+    assert!(
+        result.is_err() || {
+            let df = result.unwrap();
+            df.collect().await.is_err()
+        }
+    );
+}
+
+/// Reference: BlobTestBase "Blob: merge-into updates non-blob column on descriptor blob table"
+#[tokio::test]
+async fn test_merge_into_updates_non_blob_on_descriptor_table() {
+    let (_tmp, handler) = setup(
+        "CREATE TABLE paimon.test_db.t (\
+            id INT, \
+            name STRING, \
+            picture BLOB \
+         ) WITH (\
+            'data-evolution.enabled' = 'true', \
+            'row-tracking.enabled' = 'true', \
+            'blob-descriptor-field' = 'picture'\
+         )",
+    )
+    .await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES \
+         (1, 'Alice', X'4141'), \
+         (2, 'Bob', X'4242')",
+    )
+    .await;
+
+    ctx_exec(
+        &handler,
+        "CREATE TABLE src (id INT, name VARCHAR) AS VALUES (1, 'Updated')",
+    )
+    .await;
+
+    exec(
+        &handler,
+        "MERGE INTO paimon.test_db.t t \
+         USING src s ON t.id = s.id \
+         WHEN MATCHED THEN UPDATE SET name = s.name",
+    )
+    .await;
+
+    let batches = handler
+        .sql("SELECT id, name FROM paimon.test_db.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let rows = collect_id_name(&batches);
+    assert_eq!(rows, vec![(1, "Updated".into()), (2, "Bob".into())]);
+}
+
+/// Blob with partitioned table.
+#[tokio::test]
+async fn test_blob_with_partition() {
+    let (_tmp, handler) = setup(
+        "CREATE TABLE paimon.test_db.t (\
+            id INT, \
+            picture BLOB, \
+            pt STRING \
+         ) PARTITIONED BY (pt STRING) WITH (\
+            'data-evolution.enabled' = 'true', \
+            'row-tracking.enabled' = 'true'\
+         )",
+    )
+    .await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, picture, pt) VALUES \
+         (1, X'4141', 'a'), \
+         (2, X'4242', 'b')",
+    )
+    .await;
+
+    let batches = handler
+        .sql("SELECT id, picture FROM paimon.test_db.t ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let pics = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            rows.push((ids.value(i), pics.value(i).to_vec()));
+        }
+    }
+    rows.sort_by_key(|(id, _)| *id);
+
+    assert_eq!(rows, vec![(1, b"AA".to_vec()), (2, b"BB".to_vec())]);
+}
+
+/// When a blob column value is a serialized BlobDescriptor, the writer should
+/// resolve it by reading actual data from the referenced URI.
+#[tokio::test]
+async fn test_blob_resolve_descriptor() {
+    let (tmp, handler) = setup(BLOB_TABLE_DDL).await;
+
+    // Write a source file that the BlobDescriptor will reference.
+    let source_data = b"ResolvedBlobContent";
+    let source_path = tmp.path().join("blob_source.bin");
+    std::fs::write(&source_path, source_data).unwrap();
+
+    let uri = format!("file://{}", source_path.display());
+    let desc = BlobDescriptor::new(uri, 0, source_data.len() as i64);
+    let desc_hex = to_hex(&desc.serialize());
+
+    // Insert: row 1 has a BlobDescriptor value, row 2 has raw data.
+    let sql = format!(
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES \
+         (1, 'Descriptor', X'{desc_hex}'), \
+         (2, 'Raw', X'48656C6C6F')"
+    );
+    exec(&handler, &sql).await;
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows.len(), 2);
+    // Descriptor was resolved to actual file content
+    assert_eq!(
+        rows[0],
+        (1, "Descriptor".into(), Some(source_data.to_vec()))
+    );
+    // Raw data passed through unchanged
+    assert_eq!(rows[1], (2, "Raw".into(), Some(b"Hello".to_vec())));
+}
+
+/// BlobDescriptor with non-zero offset and partial length.
+#[tokio::test]
+async fn test_blob_resolve_descriptor_with_offset() {
+    let (tmp, handler) = setup(BLOB_TABLE_DDL).await;
+
+    let source_data = b"HEADER_PAYLOAD_TRAILER";
+    let source_path = tmp.path().join("blob_offset.bin");
+    std::fs::write(&source_path, source_data).unwrap();
+
+    // Reference only "PAYLOAD" (offset=7, length=7)
+    let uri = format!("file://{}", source_path.display());
+    let desc = BlobDescriptor::new(uri, 7, 7);
+    let desc_hex = to_hex(&desc.serialize());
+
+    let sql = format!(
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES (1, 'Partial', X'{desc_hex}')"
+    );
+    exec(&handler, &sql).await;
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0], (1, "Partial".into(), Some(b"PAYLOAD".to_vec())));
+}
+
+/// Blob files roll independently when `blob.target-file-size` is small.
+#[tokio::test]
+async fn test_blob_rolling() {
+    let (_tmp, handler) = setup(
+        "CREATE TABLE paimon.test_db.t (\
+            id INT, \
+            name STRING, \
+            picture BLOB \
+         ) WITH (\
+            'data-evolution.enabled' = 'true', \
+            'row-tracking.enabled' = 'true', \
+            'blob.target-file-size' = '50'\
+         )",
+    )
+    .await;
+
+    // Insert multiple rows with blob data large enough to trigger rolling at 50 bytes.
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES \
+         (1, 'A', X'4141414141414141414141414141414141414141414141414141414141414141'), \
+         (2, 'B', X'4242424242424242424242424242424242424242424242424242424242424242'), \
+         (3, 'C', X'4343434343434343434343434343434343434343434343434343434343434343')",
+    )
+    .await;
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0], (1, "A".into(), Some(vec![0x41; 32])));
+    assert_eq!(rows[1], (2, "B".into(), Some(vec![0x42; 32])));
+    assert_eq!(rows[2], (3, "C".into(), Some(vec![0x43; 32])));
+}
+
+/// blob-descriptor-field with multiple inserts: descriptor values are resolved to actual data.
+#[tokio::test]
+async fn test_blob_descriptor_field_resolve_on_read() {
+    let (_tmp, handler) = setup(
+        "CREATE TABLE paimon.test_db.t (\
+            id INT, \
+            name STRING, \
+            picture BLOB \
+         ) WITH (\
+            'data-evolution.enabled' = 'true', \
+            'row-tracking.enabled' = 'true', \
+            'blob-descriptor-field' = 'picture'\
+         )",
+    )
+    .await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES \
+         (1, 'Alice', X'48656C6C6F'), \
+         (2, 'Bob', NULL), \
+         (3, 'Carol', X'576F726C64')",
+    )
+    .await;
+
+    // Second insert to exercise multi-file merge path.
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES \
+         (4, 'Dave', X'5061696D6F6E')",
+    )
+    .await;
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(
+        rows,
+        vec![
+            (1, "Alice".into(), Some(b"Hello".to_vec())),
+            (2, "Bob".into(), None),
+            (3, "Carol".into(), Some(b"World".to_vec())),
+            (4, "Dave".into(), Some(b"Paimon".to_vec())),
+        ]
+    );
+}
+
+/// blob-descriptor-field: inserting a serialized BlobDescriptor resolves to actual data on read.
+#[tokio::test]
+async fn test_blob_descriptor_field_resolve_descriptor_value() {
+    let (tmp, handler) = setup(
+        "CREATE TABLE paimon.test_db.t (\
+            id INT, \
+            name STRING, \
+            picture BLOB \
+         ) WITH (\
+            'data-evolution.enabled' = 'true', \
+            'row-tracking.enabled' = 'true', \
+            'blob-descriptor-field' = 'picture'\
+         )",
+    )
+    .await;
+
+    // Write a source file that the BlobDescriptor will reference.
+    let source_data = b"DescriptorResolved";
+    let source_path = tmp.path().join("desc_source.bin");
+    std::fs::write(&source_path, source_data).unwrap();
+
+    let uri = format!("file://{}", source_path.display());
+    let desc = BlobDescriptor::new(uri, 0, source_data.len() as i64);
+    let desc_hex = to_hex(&desc.serialize());
+
+    let sql = format!(
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES \
+         (1, 'FromDesc', X'{desc_hex}'), \
+         (2, 'Raw', X'48656C6C6F')"
+    );
+    exec(&handler, &sql).await;
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(
+        rows,
+        vec![
+            (1, "FromDesc".into(), Some(b"DescriptorResolved".to_vec())),
+            (2, "Raw".into(), Some(b"Hello".to_vec())),
+        ]
+    );
+}

--- a/crates/integrations/datafusion/tests/blob_tests.rs
+++ b/crates/integrations/datafusion/tests/blob_tests.rs
@@ -277,6 +277,48 @@ async fn test_blob_descriptor_field_inline() {
     assert_eq!(rows[0].2, Some(b"Hello".to_vec()));
 }
 
+/// MERGE INTO on a raw-blob table: updating a non-blob column should succeed,
+/// and the blob data should be preserved.
+#[tokio::test]
+async fn test_merge_into_updates_non_blob_on_raw_blob_table() {
+    let (_tmp, handler) = setup(BLOB_TABLE_DDL).await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES \
+         (1, 'Alice', X'4141'), \
+         (2, 'Bob', X'4242')",
+    )
+    .await;
+
+    ctx_exec(
+        &handler,
+        "CREATE TABLE src (id INT, name VARCHAR) AS VALUES (1, 'Updated')",
+    )
+    .await;
+
+    exec(
+        &handler,
+        "MERGE INTO paimon.test_db.t t \
+         USING src s ON t.id = s.id \
+         WHEN MATCHED THEN UPDATE SET name = s.name",
+    )
+    .await;
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(
+        rows,
+        vec![
+            (1, "Updated".into(), Some(b"AA".to_vec())),
+            (2, "Bob".into(), Some(b"BB".to_vec())),
+        ]
+    );
+}
+
 /// Reference: BlobTestBase "Blob: merge-into rejects updating raw-data BLOB column"
 #[tokio::test]
 async fn test_merge_into_rejects_raw_blob_update() {
@@ -357,6 +399,58 @@ async fn test_merge_into_updates_non_blob_on_descriptor_table() {
         .unwrap();
     let rows = collect_id_name(&batches);
     assert_eq!(rows, vec![(1, "Updated".into()), (2, "Bob".into())]);
+}
+
+/// Merge-into on a descriptor blob table: updating the blob column should succeed.
+#[tokio::test]
+async fn test_merge_into_updates_blob_on_descriptor_table() {
+    let (_tmp, handler) = setup(
+        "CREATE TABLE paimon.test_db.t (\
+            id INT, \
+            name STRING, \
+            picture BLOB \
+         ) WITH (\
+            'data-evolution.enabled' = 'true', \
+            'row-tracking.enabled' = 'true', \
+            'blob-descriptor-field' = 'picture'\
+         )",
+    )
+    .await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES \
+         (1, 'Alice', X'4141'), \
+         (2, 'Bob', X'4242')",
+    )
+    .await;
+
+    ctx_exec(
+        &handler,
+        "CREATE TABLE src (id INT, picture BYTEA) AS VALUES (1, X'4343')",
+    )
+    .await;
+
+    exec(
+        &handler,
+        "MERGE INTO paimon.test_db.t t \
+         USING src s ON t.id = s.id \
+         WHEN MATCHED THEN UPDATE SET picture = s.picture",
+    )
+    .await;
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(
+        rows,
+        vec![
+            (1, "Alice".into(), Some(b"CC".to_vec())),
+            (2, "Bob".into(), Some(b"BB".to_vec())),
+        ]
+    );
 }
 
 /// Blob with partitioned table.

--- a/crates/paimon/src/arrow/format/blob.rs
+++ b/crates/paimon/src/arrow/format/blob.rs
@@ -15,14 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::{FilePredicates, FormatFileReader};
+use super::{FilePredicates, FormatFileReader, FormatFileWriter};
 use crate::arrow::build_target_arrow_schema;
-use crate::io::FileRead;
-use crate::spec::{DataField, DataType};
+use crate::io::{FileRead, FileWrite};
+use crate::spec::{BlobDescriptor, DataField, DataType};
 use crate::table::{ArrowRecordBatchStream, RowRange};
 use crate::Error;
 use arrow_array::builder::BinaryBuilder;
-use arrow_array::{ArrayRef, RecordBatch, RecordBatchOptions};
+use arrow_array::{Array, ArrayRef, RecordBatch, RecordBatchOptions};
 use async_stream::try_stream;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -30,7 +30,19 @@ use futures::{StreamExt, TryStreamExt};
 use std::ops::Range;
 use std::sync::Arc;
 
-pub(crate) struct BlobFormatReader;
+pub(crate) struct BlobFormatReader {
+    descriptor_mode: bool,
+    file_path: String,
+}
+
+impl BlobFormatReader {
+    pub(crate) fn new(file_path: String, descriptor_mode: bool) -> Self {
+        Self {
+            descriptor_mode,
+            file_path,
+        }
+    }
+}
 
 const BLOB_FOOTER_SIZE: u64 = 5;
 const BLOB_FORMAT_VERSION: u8 = 1;
@@ -59,19 +71,42 @@ impl FormatFileReader for BlobFormatReader {
         let mut selection = RowSelectionCursor::new(blob_index.num_rows(), row_selection)?;
         let project_values = !read_fields.is_empty();
 
-        Ok(try_stream! {
-            while let Some(positions) = selection.next_batch(batch_size) {
-                let batch = read_blob_batch(
-                    reader.as_ref(),
-                    &blob_index,
-                    &target_schema,
-                    &positions,
-                    project_values,
-                ).await?;
-                yield batch;
+        if self.descriptor_mode {
+            let file_path = self.file_path.clone();
+            Ok(try_stream! {
+                while let Some(positions) = selection.next_batch(batch_size) {
+                    let batch = if project_values {
+                        build_descriptor_batch(&blob_index, &target_schema, &positions, &file_path)?
+                    } else {
+                        RecordBatch::try_new_with_options(
+                            target_schema.clone(),
+                            Vec::new(),
+                            &RecordBatchOptions::new().with_row_count(Some(positions.len())),
+                        )
+                        .map_err(|e| Error::UnexpectedError {
+                            message: format!("Failed to build empty blob RecordBatch: {e}"),
+                            source: Some(Box::new(e)),
+                        })?
+                    };
+                    yield batch;
+                }
             }
+            .boxed())
+        } else {
+            Ok(try_stream! {
+                while let Some(positions) = selection.next_batch(batch_size) {
+                    let batch = read_blob_batch(
+                        reader.as_ref(),
+                        &blob_index,
+                        &target_schema,
+                        &positions,
+                        project_values,
+                    ).await?;
+                    yield batch;
+                }
+            }
+            .boxed())
         }
-        .boxed())
     }
 }
 
@@ -101,6 +136,44 @@ fn validate_read_fields(read_fields: &[DataField]) -> crate::Result<()> {
     }
 
     Ok(())
+}
+
+fn build_descriptor_batch(
+    blob_index: &BlobFileIndex,
+    target_schema: &Arc<arrow_schema::Schema>,
+    positions: &[usize],
+    file_path: &str,
+) -> crate::Result<RecordBatch> {
+    let mut builder = BinaryBuilder::new();
+    for &position in positions {
+        let entry = blob_index
+            .entry(position)
+            .ok_or_else(|| Error::DataInvalid {
+                message: format!(
+                    "Blob row selection referenced out-of-range position {position} for {} rows",
+                    blob_index.num_rows()
+                ),
+                source: None,
+            })?;
+
+        match entry.inline_data_range() {
+            None => builder.append_null(),
+            Some(range) => {
+                let descriptor = BlobDescriptor::new(
+                    file_path.to_string(),
+                    range.start as i64,
+                    (range.end - range.start) as i64,
+                );
+                builder.append_value(descriptor.serialize());
+            }
+        }
+    }
+
+    let columns: Vec<ArrayRef> = vec![Arc::new(builder.finish())];
+    RecordBatch::try_new(target_schema.clone(), columns).map_err(|e| Error::UnexpectedError {
+        message: format!("Failed to build descriptor blob RecordBatch: {e}"),
+        source: Some(Box::new(e)),
+    })
 }
 
 async fn read_blob_batch(
@@ -516,6 +589,183 @@ fn decode_varint(bytes: &[u8]) -> crate::Result<(i64, usize)> {
     })
 }
 
+// --- Blob Format Writer ---
+
+const BLOB_MAGIC_NUMBER_BYTES: [u8; 4] = 1481511375_i32.to_le_bytes();
+
+pub(crate) struct BlobFormatWriter {
+    writer: Box<dyn FileWrite>,
+    file_io: Option<crate::io::FileIO>,
+    bytes_written: u64,
+    lengths: Vec<i64>,
+}
+
+impl BlobFormatWriter {
+    pub(crate) async fn new(
+        output: &crate::io::OutputFile,
+        file_io: Option<crate::io::FileIO>,
+    ) -> crate::Result<Self> {
+        let writer = output.writer().await?;
+        Ok(Self {
+            writer,
+            file_io,
+            bytes_written: 0,
+            lengths: Vec::new(),
+        })
+    }
+}
+
+const BLOB_WRITE_BUFFER_SIZE: u64 = 8 * 1024 * 1024; // 8 MB
+
+#[async_trait]
+impl FormatFileWriter for BlobFormatWriter {
+    async fn write(&mut self, batch: &RecordBatch) -> crate::Result<()> {
+        if batch.num_rows() == 0 {
+            return Ok(());
+        }
+
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow_array::BinaryArray>()
+            .ok_or_else(|| Error::DataInvalid {
+                message: "BlobFormatWriter expects a single Binary column".to_string(),
+                source: None,
+            })?;
+
+        for row_idx in 0..col.len() {
+            if col.is_null(row_idx) {
+                self.lengths.push(-1);
+                continue;
+            }
+
+            let value = col.value(row_idx);
+
+            if BlobDescriptor::is_blob_descriptor(value) {
+                let desc = BlobDescriptor::deserialize(value)?;
+                let payload_len = desc.length() as u64;
+                let entry_length = (payload_len + BLOB_ENTRY_OVERHEAD) as i64;
+                self.lengths.push(entry_length);
+
+                let file_io = self.file_io.as_ref().ok_or_else(|| Error::DataInvalid {
+                    message:
+                        "BlobFormatWriter received a BlobDescriptor but has no FileIO to resolve it"
+                            .to_string(),
+                    source: None,
+                })?;
+                let input = file_io.new_input(desc.uri())?;
+                let reader = input.reader().await?;
+
+                let mut hasher = crc32fast::Hasher::new();
+
+                hasher.update(&BLOB_MAGIC_NUMBER_BYTES);
+                self.writer
+                    .write(Bytes::copy_from_slice(&BLOB_MAGIC_NUMBER_BYTES))
+                    .await?;
+
+                // Stream payload in chunks to avoid loading entire blob into memory
+                let start = desc.offset() as u64;
+                let end = start + payload_len;
+                let mut pos = start;
+                while pos < end {
+                    let chunk_end = (pos + BLOB_WRITE_BUFFER_SIZE).min(end);
+                    let chunk = reader.read(pos..chunk_end).await?;
+                    hasher.update(&chunk);
+                    self.writer.write(chunk).await?;
+                    pos = chunk_end;
+                }
+
+                let entry_length_bytes = entry_length.to_le_bytes();
+                hasher.update(&entry_length_bytes);
+                self.writer
+                    .write(Bytes::copy_from_slice(&entry_length_bytes))
+                    .await?;
+
+                self.writer
+                    .write(Bytes::copy_from_slice(&hasher.finalize().to_le_bytes()))
+                    .await?;
+
+                self.bytes_written += entry_length as u64;
+            } else {
+                let entry_length = (value.len() + BLOB_ENTRY_OVERHEAD as usize) as i64;
+                self.lengths.push(entry_length);
+
+                let mut buf = Vec::with_capacity(entry_length as usize);
+                let mut hasher = crc32fast::Hasher::new();
+
+                hasher.update(&BLOB_MAGIC_NUMBER_BYTES);
+                buf.extend_from_slice(&BLOB_MAGIC_NUMBER_BYTES);
+
+                hasher.update(value);
+                buf.extend_from_slice(value);
+
+                let entry_length_bytes = entry_length.to_le_bytes();
+                hasher.update(&entry_length_bytes);
+                buf.extend_from_slice(&entry_length_bytes);
+
+                buf.extend_from_slice(&hasher.finalize().to_le_bytes());
+
+                self.writer.write(Bytes::from(buf)).await?;
+                self.bytes_written += entry_length as u64;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn num_bytes(&self) -> usize {
+        self.bytes_written as usize
+    }
+
+    fn in_progress_size(&self) -> usize {
+        0
+    }
+
+    async fn flush(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn close(mut self: Box<Self>) -> crate::Result<u64> {
+        let index_bytes = encode_delta_varints_write(&self.lengths);
+        let index_length = index_bytes.len() as i32;
+
+        self.writer.write(Bytes::from(index_bytes)).await?;
+        self.writer
+            .write(Bytes::copy_from_slice(&index_length.to_le_bytes()))
+            .await?;
+        self.writer
+            .write(Bytes::from_static(&[BLOB_FORMAT_VERSION]))
+            .await?;
+
+        let total = self.bytes_written + index_length as u64 + BLOB_FOOTER_SIZE;
+        self.writer.close().await?;
+        Ok(total)
+    }
+}
+
+fn encode_delta_varints_write(values: &[i64]) -> Vec<u8> {
+    if values.is_empty() {
+        return Vec::new();
+    }
+    let mut encoded = Vec::new();
+    let mut previous = 0_i64;
+    for (idx, &value) in values.iter().enumerate() {
+        let delta = if idx == 0 { value } else { value - previous };
+        previous = value;
+        encode_varint(delta, &mut encoded);
+    }
+    encoded
+}
+
+fn encode_varint(value: i64, out: &mut Vec<u8>) {
+    let mut remaining = ((value << 1) ^ (value >> 63)) as u64;
+    while (remaining & !0x7f) != 0 {
+        out.push(((remaining & 0x7f) as u8) | 0x80);
+        remaining >>= 7;
+    }
+    out.push(remaining as u8);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -542,7 +792,7 @@ mod tests {
             "payload".to_string(),
             DataType::Blob(BlobType::new()),
         )];
-        let reader = BlobFormatReader;
+        let reader = BlobFormatReader::new(String::new(), false);
         let file_bytes = load_blob_fixture("blob-basic.blob");
 
         let stream = reader
@@ -568,7 +818,7 @@ mod tests {
             vec![Some(b"world".to_vec()), Some(Vec::new())]
         );
 
-        let selected = reader
+        let selected = BlobFormatReader::new(String::new(), false)
             .read_batch_stream(
                 Box::new(BytesFileRead(Bytes::from(file_bytes.clone()))),
                 file_bytes.len() as u64,
@@ -600,7 +850,7 @@ mod tests {
         let file_bytes = load_blob_fixture("blob-basic.blob");
         let reader = TrackingFileRead::new(Bytes::from(file_bytes.clone()));
 
-        let batches = BlobFormatReader
+        let batches = BlobFormatReader::new(String::new(), false)
             .read_batch_stream(
                 Box::new(reader.clone()),
                 file_bytes.len() as u64,
@@ -637,7 +887,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_blob_reader_supports_empty_projection() {
-        let reader = BlobFormatReader;
+        let reader = BlobFormatReader::new(String::new(), false);
         let file_bytes = load_blob_fixture("blob-basic.blob");
 
         let batches = reader
@@ -664,7 +914,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_blob_reader_rejects_out_of_range_selection() {
-        let reader = BlobFormatReader;
+        let reader = BlobFormatReader::new(String::new(), false);
         let file_bytes = load_blob_fixture("blob-basic.blob");
         let read_fields = vec![DataField::new(
             0,
@@ -690,7 +940,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_blob_reader_rejects_wrong_field_family() {
-        let reader = BlobFormatReader;
+        let reader = BlobFormatReader::new(String::new(), false);
         let file_bytes = load_blob_fixture("blob-basic.blob");
         let read_fields = vec![DataField::new(
             0,
@@ -720,7 +970,7 @@ mod tests {
         let last = file_bytes.len() - 1;
         file_bytes[last] = 2;
 
-        let result = BlobFormatReader
+        let result = BlobFormatReader::new(String::new(), false)
             .read_batch_stream(
                 Box::new(BytesFileRead(Bytes::from(file_bytes.clone()))),
                 file_bytes.len() as u64,
@@ -759,7 +1009,7 @@ mod tests {
         file_bytes[footer_start..footer_start + 4]
             .copy_from_slice(&(replacement.len() as i32).to_le_bytes());
 
-        let result = BlobFormatReader
+        let result = BlobFormatReader::new(String::new(), false)
             .read_batch_stream(
                 Box::new(BytesFileRead(Bytes::from(file_bytes.clone()))),
                 file_bytes.len() as u64,
@@ -778,6 +1028,26 @@ mod tests {
         assert!(
             matches!(result, Err(Error::DataInvalid { message, .. }) if message.contains("minimum overhead"))
         );
+    }
+
+    #[test]
+    fn test_varint_encode_decode_roundtrip() {
+        let values = vec![21, -1, 0, i64::MAX, i64::MIN + 1, 127, -128, 300, -300];
+        for &v in &values {
+            let mut buf = Vec::new();
+            encode_varint(v, &mut buf);
+            let (decoded, consumed) = decode_varint(&buf).unwrap();
+            assert_eq!(decoded, v, "roundtrip failed for {v}");
+            assert_eq!(consumed, buf.len());
+        }
+    }
+
+    #[test]
+    fn test_delta_varints_encode_decode_roundtrip() {
+        let values = vec![21, -1, 0, 100, -50, 1000];
+        let encoded = encode_delta_varints_write(&values);
+        let decoded = decode_delta_varints(&encoded).unwrap();
+        assert_eq!(decoded, values);
     }
 
     fn basic_blob_rows() -> [Option<&'static [u8]>; 4] {

--- a/crates/paimon/src/arrow/format/mod.rs
+++ b/crates/paimon/src/arrow/format/mod.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 mod avro;
-mod blob;
+pub(crate) mod blob;
 mod orc;
 mod parquet;
 #[cfg(feature = "vortex")]
@@ -88,12 +88,18 @@ pub(crate) trait FormatFileWriter: Send {
 }
 
 /// Create a format reader based on the file extension.
-pub(crate) fn create_format_reader(path: &str) -> crate::Result<Box<dyn FormatFileReader>> {
+pub(crate) fn create_format_reader(
+    path: &str,
+    blob_as_descriptor: bool,
+) -> crate::Result<Box<dyn FormatFileReader>> {
     let lower = path.to_ascii_lowercase();
     if lower.ends_with(".parquet") {
         Ok(Box::new(parquet::ParquetFormatReader))
     } else if lower.ends_with(".blob") {
-        Ok(Box::new(blob::BlobFormatReader))
+        Ok(Box::new(blob::BlobFormatReader::new(
+            path.to_string(),
+            blob_as_descriptor,
+        )))
     } else if lower.ends_with(".orc") {
         Ok(Box::new(orc::OrcFormatReader))
     } else if lower.ends_with(".avro") {
@@ -117,12 +123,17 @@ pub(crate) async fn create_format_writer(
     schema: SchemaRef,
     compression: &str,
     zstd_level: i32,
+    file_io: Option<crate::io::FileIO>,
 ) -> crate::Result<Box<dyn FormatFileWriter>> {
     let path = output.location();
     let lower = path.to_ascii_lowercase();
     if lower.ends_with(".parquet") {
         Ok(Box::new(
             parquet::ParquetFormatWriter::new(output, schema, compression, zstd_level).await?,
+        ))
+    } else if lower.ends_with(".blob") {
+        Ok(Box::new(
+            blob::BlobFormatWriter::new(output, file_io).await?,
         ))
     } else {
         #[cfg(feature = "vortex")]

--- a/crates/paimon/src/spec/blob_descriptor.rs
+++ b/crates/paimon/src/spec/blob_descriptor.rs
@@ -1,0 +1,201 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::Error;
+
+const CURRENT_VERSION: u8 = 2;
+const MAGIC: u64 = 0x424C4F4244455343; // "BLOBDESC"
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlobDescriptor {
+    version: u8,
+    uri: String,
+    offset: i64,
+    length: i64,
+}
+
+impl BlobDescriptor {
+    pub fn new(uri: String, offset: i64, length: i64) -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            uri,
+            offset,
+            length,
+        }
+    }
+
+    pub fn uri(&self) -> &str {
+        &self.uri
+    }
+
+    pub fn offset(&self) -> i64 {
+        self.offset
+    }
+
+    pub fn length(&self) -> i64 {
+        self.length
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        let uri_bytes = self.uri.as_bytes();
+        let uri_length = uri_bytes.len();
+        let total_size = 1 + 8 + 4 + uri_length + 8 + 8;
+        let mut buf = Vec::with_capacity(total_size);
+
+        buf.push(self.version);
+        buf.extend_from_slice(&MAGIC.to_le_bytes());
+        buf.extend_from_slice(&(uri_length as i32).to_le_bytes());
+        buf.extend_from_slice(uri_bytes);
+        buf.extend_from_slice(&self.offset.to_le_bytes());
+        buf.extend_from_slice(&self.length.to_le_bytes());
+
+        buf
+    }
+
+    pub fn deserialize(bytes: &[u8]) -> crate::Result<Self> {
+        if bytes.len() < 1 + 8 + 4 {
+            return Err(Error::DataInvalid {
+                message: "BlobDescriptor bytes too short".to_string(),
+                source: None,
+            });
+        }
+
+        let version = bytes[0];
+        if version > CURRENT_VERSION {
+            return Err(Error::Unsupported {
+                message: format!(
+                    "Expecting BlobDescriptor version <= {CURRENT_VERSION}, but found {version}"
+                ),
+            });
+        }
+
+        let mut pos = 1;
+
+        if version > 1 {
+            let magic = u64::from_le_bytes(bytes[pos..pos + 8].try_into().unwrap());
+            if magic != MAGIC {
+                return Err(Error::DataInvalid {
+                    message: format!(
+                        "Invalid BlobDescriptor: missing magic header. Expected {MAGIC:#X}, found {magic:#X}"
+                    ),
+                    source: None,
+                });
+            }
+            pos += 8;
+        }
+
+        if bytes.len() < pos + 4 {
+            return Err(Error::DataInvalid {
+                message: "BlobDescriptor bytes too short for uri_length".to_string(),
+                source: None,
+            });
+        }
+        let uri_length_raw = i32::from_le_bytes(bytes[pos..pos + 4].try_into().unwrap());
+        if uri_length_raw < 0 {
+            return Err(Error::DataInvalid {
+                message: format!("BlobDescriptor has negative uri_length: {uri_length_raw}"),
+                source: None,
+            });
+        }
+        let uri_length = uri_length_raw as usize;
+        pos += 4;
+
+        if bytes.len() < pos + uri_length + 16 {
+            return Err(Error::DataInvalid {
+                message: "BlobDescriptor bytes too short for uri + offset + length".to_string(),
+                source: None,
+            });
+        }
+        let uri = String::from_utf8(bytes[pos..pos + uri_length].to_vec()).map_err(|e| {
+            Error::DataInvalid {
+                message: format!("Invalid UTF-8 in BlobDescriptor uri: {e}"),
+                source: Some(Box::new(e)),
+            }
+        })?;
+        pos += uri_length;
+
+        let offset = i64::from_le_bytes(bytes[pos..pos + 8].try_into().unwrap());
+        pos += 8;
+        let length = i64::from_le_bytes(bytes[pos..pos + 8].try_into().unwrap());
+
+        Ok(Self {
+            version,
+            uri,
+            offset,
+            length,
+        })
+    }
+
+    pub fn is_blob_descriptor(bytes: &[u8]) -> bool {
+        if bytes.len() < 9 {
+            return false;
+        }
+        let version = bytes[0];
+        if version > CURRENT_VERSION {
+            return false;
+        }
+        let magic = u64::from_le_bytes(bytes[1..9].try_into().unwrap());
+        magic == MAGIC
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize_deserialize_roundtrip() {
+        let desc = BlobDescriptor::new("s3://bucket/path/to/blob.blob".to_string(), 100, 2048);
+        let bytes = desc.serialize();
+        let deserialized = BlobDescriptor::deserialize(&bytes).unwrap();
+        assert_eq!(desc, deserialized);
+    }
+
+    #[test]
+    fn test_is_blob_descriptor() {
+        let desc = BlobDescriptor::new("file:///tmp/test.blob".to_string(), 0, 1024);
+        let bytes = desc.serialize();
+        assert!(BlobDescriptor::is_blob_descriptor(&bytes));
+        assert!(!BlobDescriptor::is_blob_descriptor(&[0u8; 5]));
+        assert!(!BlobDescriptor::is_blob_descriptor(b"not a descriptor"));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_future_version() {
+        let mut bytes = BlobDescriptor::new("x".to_string(), 0, 0).serialize();
+        bytes[0] = 255;
+        assert!(BlobDescriptor::deserialize(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_deserialize_rejects_negative_uri_length() {
+        let mut bytes = BlobDescriptor::new("x".to_string(), 0, 0).serialize();
+        // Overwrite uri_length (at offset 9, after version + magic) with -1
+        bytes[9..13].copy_from_slice(&(-1_i32).to_le_bytes());
+        let err = BlobDescriptor::deserialize(&bytes).unwrap_err();
+        assert!(
+            matches!(err, Error::DataInvalid { message, .. } if message.contains("negative uri_length"))
+        );
+    }
+
+    #[test]
+    fn test_deserialize_rejects_bad_magic() {
+        let mut bytes = BlobDescriptor::new("x".to_string(), 0, 0).serialize();
+        bytes[1] = 0xFF;
+        assert!(BlobDescriptor::deserialize(&bytes).is_err());
+    }
+}

--- a/crates/paimon/src/spec/core_options.rs
+++ b/crates/paimon/src/spec/core_options.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 const DELETION_VECTORS_ENABLED_OPTION: &str = "deletion-vectors.enabled";
 const DATA_EVOLUTION_ENABLED_OPTION: &str = "data-evolution.enabled";
@@ -59,6 +59,8 @@ const DEFAULT_TARGET_FILE_SIZE: i64 = 256 * 1024 * 1024;
 const DEFAULT_WRITE_PARQUET_BUFFER_SIZE: i64 = 256 * 1024 * 1024;
 const DYNAMIC_BUCKET_TARGET_ROW_NUM_OPTION: &str = "dynamic-bucket.target-row-num";
 const DEFAULT_DYNAMIC_BUCKET_TARGET_ROW_NUM: i64 = 200_000;
+const BLOB_AS_DESCRIPTOR_OPTION: &str = "blob-as-descriptor";
+const BLOB_DESCRIPTOR_FIELD_OPTION: &str = "blob-descriptor-field";
 
 /// Merge engine for primary-key tables.
 ///
@@ -324,6 +326,13 @@ impl<'a> CoreOptions<'a> {
             .unwrap_or(DEFAULT_TARGET_FILE_SIZE)
     }
 
+    pub fn blob_target_file_size(&self) -> i64 {
+        self.options
+            .get("blob.target-file-size")
+            .and_then(|v| parse_memory_size(v))
+            .unwrap_or_else(|| self.target_file_size())
+    }
+
     /// File format for data files (e.g. "parquet", "orc", "avro", "vortex").
     /// Default is "parquet".
     pub fn file_format(&self) -> &str {
@@ -368,6 +377,24 @@ impl<'a> CoreOptions<'a> {
             .get(DYNAMIC_BUCKET_TARGET_ROW_NUM_OPTION)
             .and_then(|v| v.parse().ok())
             .unwrap_or(DEFAULT_DYNAMIC_BUCKET_TARGET_ROW_NUM)
+    }
+
+    /// When true, blob field reads return serialized BlobDescriptor bytes
+    /// instead of actual blob bytes. Default is false.
+    pub fn blob_as_descriptor(&self) -> bool {
+        self.options
+            .get(BLOB_AS_DESCRIPTOR_OPTION)
+            .map(|v| v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    }
+
+    /// Comma-separated BLOB field names stored as serialized BlobDescriptor
+    /// bytes inline in normal data files (no .blob files for these fields).
+    pub fn blob_descriptor_fields(&self) -> HashSet<String> {
+        self.options
+            .get(BLOB_DESCRIPTOR_FIELD_OPTION)
+            .map(|s| s.split(',').map(|f| f.trim().to_string()).collect())
+            .unwrap_or_default()
     }
 }
 

--- a/crates/paimon/src/spec/mod.rs
+++ b/crates/paimon/src/spec/mod.rs
@@ -22,6 +22,9 @@
 mod binary_row;
 pub use binary_row::*;
 
+mod blob_descriptor;
+pub use blob_descriptor::BlobDescriptor;
+
 mod data_file;
 pub use data_file::*;
 

--- a/crates/paimon/src/spec/types.rs
+++ b/crates/paimon/src/spec/types.rs
@@ -119,18 +119,8 @@ impl DataType {
         }
     }
 
-    /// Returns whether this type is or contains (recursively) a [`BlobType`].
-    pub fn contains_blob_type(&self) -> bool {
-        match self {
-            DataType::Blob(_) => true,
-            DataType::Array(v) => v.element_type.contains_blob_type(),
-            DataType::Map(v) => {
-                v.key_type.contains_blob_type() || v.value_type.contains_blob_type()
-            }
-            DataType::Multiset(v) => v.element_type.contains_blob_type(),
-            DataType::Row(v) => v.fields.iter().any(|f| f.data_type().contains_blob_type()),
-            _ => false,
-        }
+    pub fn is_blob_type(&self) -> bool {
+        matches!(self, DataType::Blob(_))
     }
 
     /// Returns whether this type is nullable.

--- a/crates/paimon/src/table/blob_file_writer.rs
+++ b/crates/paimon/src/table/blob_file_writer.rs
@@ -1,0 +1,229 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::io::FileIO;
+use crate::spec::{BlobDescriptor, DataFileMeta};
+use crate::table::data_file_writer::DataFileWriter;
+use crate::Result;
+use arrow_array::builder::BinaryBuilder;
+use arrow_array::{Array, RecordBatch};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+pub(crate) fn is_blob_file_name(file_name: &str) -> bool {
+    file_name.to_ascii_lowercase().ends_with(".blob")
+}
+
+struct BlobFieldWriter {
+    writer: DataFileWriter,
+    field_name: String,
+    column_index: usize,
+}
+
+/// Writes append-only data with blob columns split into separate `.blob` files.
+///
+/// Normal (non-blob) columns go to a parquet `DataFileWriter`.
+/// Each blob column (not in `blob_descriptor_fields`) gets its own `DataFileWriter`
+/// with `file_format = "blob"` and `write_cols = Some(vec![field_name])`.
+///
+/// If a blob value is already a serialized `BlobDescriptor`, the actual data is
+/// resolved from the referenced URI and written to the `.blob` file.
+pub(crate) struct AppendBlobFileWriter {
+    normal_writer: DataFileWriter,
+    blob_writers: Vec<BlobFieldWriter>,
+    normal_column_indices: Vec<usize>,
+    normal_schema: Arc<arrow_schema::Schema>,
+}
+
+impl AppendBlobFileWriter {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        file_io: FileIO,
+        table_location: String,
+        partition_path: String,
+        bucket: i32,
+        schema_id: i64,
+        target_file_size: i64,
+        blob_target_file_size: i64,
+        file_compression: String,
+        file_compression_zstd_level: i32,
+        write_buffer_size: i64,
+        file_format: String,
+        input_schema: &arrow_schema::Schema,
+        table_fields: &[crate::spec::DataField],
+        blob_descriptor_fields: &HashSet<String>,
+    ) -> Self {
+        let mut normal_column_indices = Vec::new();
+        let mut normal_arrow_fields = Vec::new();
+        let mut blob_writers = Vec::new();
+
+        for (idx, field) in table_fields.iter().enumerate() {
+            let is_blob = field.data_type().contains_blob_type();
+            let is_descriptor = blob_descriptor_fields.contains(field.name());
+
+            if is_blob && !is_descriptor {
+                blob_writers.push(BlobFieldWriter {
+                    writer: DataFileWriter::new(
+                        file_io.clone(),
+                        table_location.clone(),
+                        partition_path.clone(),
+                        bucket,
+                        schema_id,
+                        blob_target_file_size,
+                        String::new(),
+                        0,
+                        write_buffer_size,
+                        "blob".to_string(),
+                        Some(0),
+                        None,
+                        Some(vec![field.name().to_string()]),
+                    ),
+                    field_name: field.name().to_string(),
+                    column_index: idx,
+                });
+            } else {
+                normal_column_indices.push(idx);
+                normal_arrow_fields.push(input_schema.field(idx).clone());
+            }
+        }
+
+        let normal_schema = Arc::new(arrow_schema::Schema::new(normal_arrow_fields));
+
+        let normal_writer = DataFileWriter::new(
+            file_io.clone(),
+            table_location,
+            partition_path,
+            bucket,
+            schema_id,
+            target_file_size,
+            file_compression,
+            file_compression_zstd_level,
+            write_buffer_size,
+            file_format,
+            Some(0),
+            None,
+            None,
+        );
+
+        Self {
+            normal_writer,
+            blob_writers,
+            normal_column_indices,
+            normal_schema,
+        }
+    }
+
+    pub(crate) async fn write(&mut self, batch: &RecordBatch) -> Result<()> {
+        if batch.num_rows() == 0 {
+            return Ok(());
+        }
+
+        // Write normal columns
+        let normal_columns: Vec<Arc<dyn arrow_array::Array>> = self
+            .normal_column_indices
+            .iter()
+            .map(|&idx| batch.column(idx).clone())
+            .collect();
+        let normal_batch = RecordBatch::try_new(self.normal_schema.clone(), normal_columns)
+            .map_err(|e| crate::Error::DataInvalid {
+                message: format!("Failed to project normal columns: {e}"),
+                source: None,
+            })?;
+        self.normal_writer.write(&normal_batch).await?;
+
+        // Write each blob column directly — BlobFormatWriter resolves descriptors inline
+        for blob_writer in &mut self.blob_writers {
+            let col = batch.column(blob_writer.column_index).clone();
+            let schema = Arc::new(arrow_schema::Schema::new(vec![batch
+                .schema()
+                .field(blob_writer.column_index)
+                .clone()]));
+            let blob_batch =
+                RecordBatch::try_new(schema, vec![col]).map_err(|e| crate::Error::DataInvalid {
+                    message: format!(
+                        "Failed to project blob column '{}': {e}",
+                        blob_writer.field_name
+                    ),
+                    source: None,
+                })?;
+            blob_writer.writer.write(&blob_batch).await?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn prepare_commit(&mut self) -> Result<Vec<DataFileMeta>> {
+        let mut results = self.normal_writer.prepare_commit().await?;
+
+        for blob_writer in &mut self.blob_writers {
+            let blob_metas = blob_writer.writer.prepare_commit().await?;
+            results.extend(blob_metas);
+        }
+
+        Ok(results)
+    }
+}
+
+/// For each row in a blob column, if the value is a serialized `BlobDescriptor`,
+/// resolve it by reading the actual data from the referenced URI+offset+length.
+/// Raw data values are passed through unchanged.
+pub(crate) async fn resolve_blob_column(
+    col: &arrow_array::BinaryArray,
+    file_io: &FileIO,
+) -> Result<arrow_array::BinaryArray> {
+    use crate::io::FileRead;
+    use std::collections::HashMap;
+
+    let mut needs_resolve = false;
+    for i in 0..col.len() {
+        if !col.is_null(i) && BlobDescriptor::is_blob_descriptor(col.value(i)) {
+            needs_resolve = true;
+            break;
+        }
+    }
+
+    if !needs_resolve {
+        return Ok(col.clone());
+    }
+
+    let mut readers: HashMap<String, Box<dyn FileRead>> = HashMap::new();
+    let mut builder = BinaryBuilder::with_capacity(col.len(), 0);
+    for i in 0..col.len() {
+        if col.is_null(i) {
+            builder.append_null();
+        } else {
+            let value = col.value(i);
+            if BlobDescriptor::is_blob_descriptor(value) {
+                let desc = BlobDescriptor::deserialize(value)?;
+                let uri = desc.uri().to_string();
+                if !readers.contains_key(&uri) {
+                    let input = file_io.new_input(&uri)?;
+                    let reader = input.reader().await?;
+                    readers.insert(uri.clone(), Box::new(reader));
+                }
+                let reader = readers.get(&uri).unwrap();
+                let start = desc.offset() as u64;
+                let end = start + desc.length() as u64;
+                let data = reader.read(start..end).await?;
+                builder.append_value(&data);
+            } else {
+                builder.append_value(value);
+            }
+        }
+    }
+    Ok(builder.finish())
+}

--- a/crates/paimon/src/table/blob_file_writer.rs
+++ b/crates/paimon/src/table/blob_file_writer.rs
@@ -72,7 +72,7 @@ impl AppendBlobFileWriter {
         let mut blob_writers = Vec::new();
 
         for (idx, field) in table_fields.iter().enumerate() {
-            let is_blob = field.data_type().contains_blob_type();
+            let is_blob = field.data_type().is_blob_type();
             let is_descriptor = blob_descriptor_fields.contains(field.name());
 
             if is_blob && !is_descriptor {

--- a/crates/paimon/src/table/cow_writer.rs
+++ b/crates/paimon/src/table/cow_writer.rs
@@ -73,14 +73,6 @@ pub struct CopyOnWriteMergeWriter {
     update_batches: Vec<RecordBatch>,
 }
 
-fn schema_contains_blob_type(table: &Table) -> bool {
-    table
-        .schema()
-        .fields()
-        .iter()
-        .any(|field| field.data_type().contains_blob_type())
-}
-
 impl CopyOnWriteMergeWriter {
     /// Create a new CoW writer for the given table.
     ///
@@ -100,12 +92,6 @@ impl CopyOnWriteMergeWriter {
         let schema = table.schema();
         let core_options = CoreOptions::new(schema.options());
 
-        if schema_contains_blob_type(table) {
-            return Err(crate::Error::Unsupported {
-                message: "Copy-on-write MERGE INTO does not support BlobType".to_string(),
-            });
-        }
-
         if !schema.trimmed_primary_keys().is_empty() {
             return Err(crate::Error::Unsupported {
                 message: "Copy-on-write MERGE INTO is only supported for append-only tables (no primary keys)".to_string(),
@@ -119,11 +105,22 @@ impl CopyOnWriteMergeWriter {
         }
 
         let partition_keys = schema.partition_keys();
+        let blob_descriptor_fields = core_options.blob_descriptor_fields();
         for col in &update_columns {
             if partition_keys.contains(col) {
                 return Err(crate::Error::Unsupported {
                     message: format!("Cannot update partition column '{col}' in MERGE INTO"),
                 });
+            }
+            if let Some(field) = schema.fields().iter().find(|f| f.name() == col) {
+                if field.data_type().is_blob_type() && !blob_descriptor_fields.contains(col) {
+                    return Err(crate::Error::Unsupported {
+                        message: format!(
+                            "Cannot update raw-data BLOB column '{col}' in MERGE INTO. \
+                             Only BLOB columns listed in 'blob-descriptor-field' can be updated"
+                        ),
+                    });
+                }
             }
         }
 

--- a/crates/paimon/src/table/cow_writer.rs
+++ b/crates/paimon/src/table/cow_writer.rs
@@ -227,6 +227,7 @@ impl CopyOnWriteMergeWriter {
         let file_compression = core_options.file_compression().to_string();
         let file_compression_zstd_level = core_options.file_compression_zstd_level();
         let write_buffer_size = core_options.write_parquet_buffer_size();
+        let file_format = core_options.file_format().to_string();
         let schema_id = schema.id();
 
         let update_columns = &self.update_columns;
@@ -236,6 +237,7 @@ impl CopyOnWriteMergeWriter {
         let partition_keys = &partition_keys;
         let partition_computer = &partition_computer;
         let file_compression = file_compression.as_str();
+        let file_format = file_format.as_str();
 
         // Process each affected file in parallel
         let rewrite_futures: Vec<_> = self
@@ -297,6 +299,7 @@ impl CopyOnWriteMergeWriter {
                         file_compression.to_string(),
                         file_compression_zstd_level,
                         write_buffer_size,
+                        file_format.to_string(),
                         Some(0),
                         None,
                         None,

--- a/crates/paimon/src/table/data_evolution_reader.rs
+++ b/crates/paimon/src/table/data_evolution_reader.rs
@@ -22,14 +22,15 @@ use super::data_file_reader::{
 use crate::arrow::build_target_arrow_schema;
 use crate::io::FileIO;
 use crate::spec::{DataField, DataFileMeta, DataType, ROW_ID_FIELD_NAME};
+use crate::table::blob_file_writer::is_blob_file_name;
 use crate::table::schema_manager::SchemaManager;
 use crate::table::ArrowRecordBatchStream;
 use crate::table::RowRange;
 use crate::{DataSplit, Error};
-use arrow_array::{Int64Array, RecordBatch};
+use arrow_array::{Array, Int64Array, RecordBatch};
 use async_stream::try_stream;
 use futures::StreamExt;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// Whether the files in a split can be read independently (no column-wise merge needed).
@@ -70,6 +71,8 @@ pub(crate) struct DataEvolutionReader {
     row_id_index: Option<usize>,
     /// Arrow schema for the full output (including _ROW_ID if requested).
     output_schema: Arc<arrow_schema::Schema>,
+    blob_as_descriptor: bool,
+    blob_descriptor_fields: HashSet<String>,
 }
 
 impl DataEvolutionReader {
@@ -79,6 +82,8 @@ impl DataEvolutionReader {
         table_schema_id: i64,
         table_fields: Vec<DataField>,
         read_type: Vec<DataField>,
+        blob_as_descriptor: bool,
+        blob_descriptor_fields: HashSet<String>,
     ) -> crate::Result<Self> {
         let row_id_index = read_type.iter().position(|f| f.name() == ROW_ID_FIELD_NAME);
         let file_read_type: Vec<DataField> = read_type
@@ -96,6 +101,8 @@ impl DataEvolutionReader {
             file_read_type,
             row_id_index,
             output_schema,
+            blob_as_descriptor,
+            blob_descriptor_fields,
         })
     }
 
@@ -154,6 +161,11 @@ impl DataEvolutionReader {
                         )?;
                         while let Some(batch) = stream.next().await {
                             let batch = batch?;
+                            let batch = if !self.blob_as_descriptor && !self.blob_descriptor_fields.is_empty() {
+                                resolve_descriptor_columns(batch, &self.blob_descriptor_fields, &self.file_io).await?
+                            } else {
+                                batch
+                            };
                             let num_rows = batch.num_rows();
                             if let Some(idx) = self.row_id_index {
                                 if !has_row_id {
@@ -245,6 +257,8 @@ impl DataEvolutionReader {
         let prepared_group = prepared_group.clone();
         let read_type = self.file_read_type.clone();
         let table_fields = self.table_fields.clone();
+        let blob_descriptor_fields = self.blob_descriptor_fields.clone();
+        let blob_as_descriptor = self.blob_as_descriptor;
         // Batch size for column-merge output. Matches the default Parquet reader batch size.
         const MERGE_BATCH_SIZE: usize = 1024;
         let target_schema = build_target_arrow_schema(&read_type)?;
@@ -257,7 +271,7 @@ impl DataEvolutionReader {
                 &prepared_group.files,
             )
             .await?;
-            let source_plan = build_source_plan(&prepared_group, &file_infos, &read_type)?;
+            let source_plan = build_source_plan(&prepared_group, &file_infos, &read_type, &blob_descriptor_fields)?;
 
             let active_source_indices: Vec<usize> = source_plan
                 .sources
@@ -310,6 +324,7 @@ impl DataEvolutionReader {
                             schema_manager.clone(),
                             table_schema_id,
                             table_fields.clone(),
+                            blob_as_descriptor,
                         )
                         .map(Some)
                     }
@@ -413,6 +428,11 @@ impl DataEvolutionReader {
                             source: Some(Box::new(e)),
                         }
                     })?;
+                let merged = if !blob_as_descriptor && !blob_descriptor_fields.is_empty() {
+                    resolve_descriptor_columns(merged, &blob_descriptor_fields, &file_io).await?
+                } else {
+                    merged
+                };
                 yield merged;
             }
         }
@@ -420,6 +440,43 @@ impl DataEvolutionReader {
     }
 }
 
+async fn resolve_descriptor_columns(
+    batch: RecordBatch,
+    blob_descriptor_fields: &HashSet<String>,
+    file_io: &FileIO,
+) -> crate::Result<RecordBatch> {
+    let schema = batch.schema();
+    let mut columns: Vec<Arc<dyn arrow_array::Array>> = Vec::with_capacity(batch.num_columns());
+    let mut changed = false;
+
+    for (idx, field) in schema.fields().iter().enumerate() {
+        if blob_descriptor_fields.contains(field.name()) {
+            if let Some(bin_col) = batch
+                .column(idx)
+                .as_any()
+                .downcast_ref::<arrow_array::BinaryArray>()
+            {
+                let resolved =
+                    super::blob_file_writer::resolve_blob_column(bin_col, file_io).await?;
+                columns.push(Arc::new(resolved));
+                changed = true;
+                continue;
+            }
+        }
+        columns.push(batch.column(idx).clone());
+    }
+
+    if !changed {
+        return Ok(batch);
+    }
+
+    RecordBatch::try_new(schema, columns).map_err(|e| Error::UnexpectedError {
+        message: format!("Failed to rebuild RecordBatch after resolving blob descriptors: {e}"),
+        source: Some(Box::new(e)),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
 fn open_source_stream(
     split: &DataSplit,
     source: &FieldSource,
@@ -428,6 +485,7 @@ fn open_source_stream(
     schema_manager: SchemaManager,
     table_schema_id: i64,
     table_fields: Vec<DataField>,
+    blob_as_descriptor: bool,
 ) -> crate::Result<ArrowRecordBatchStream> {
     let file_reader = DataFileReader::new(
         file_io,
@@ -436,7 +494,8 @@ fn open_source_stream(
         table_fields,
         source.read_fields().to_vec(),
         Vec::new(),
-    );
+    )
+    .with_blob_as_descriptor(blob_as_descriptor);
 
     match source {
         FieldSource::DataFile {
@@ -593,6 +652,7 @@ fn build_source_plan(
     prepared_group: &PreparedMergeGroup,
     file_infos: &[ResolvedFileInfo],
     read_type: &[DataField],
+    blob_descriptor_fields: &HashSet<String>,
 ) -> crate::Result<SourcePlan> {
     let mut sources = Vec::new();
     let mut normal_source_indices: HashMap<usize, usize> = HashMap::new();
@@ -642,7 +702,9 @@ fn build_source_plan(
 
     let mut column_plan = Vec::with_capacity(read_type.len());
     for field in read_type {
-        let source_idx = if matches!(field.data_type(), DataType::Blob(_)) {
+        let source_idx = if matches!(field.data_type(), DataType::Blob(_))
+            && !blob_descriptor_fields.contains(field.name())
+        {
             blob_source_indices.get(&field.id()).copied()
         } else {
             select_normal_provider(
@@ -924,10 +986,6 @@ fn normalize_merge_group(files: Vec<DataFileMeta>) -> crate::Result<Vec<DataFile
     Ok(data_files)
 }
 
-fn is_blob_file_name(file_name: &str) -> bool {
-    file_name.to_ascii_lowercase().ends_with(".blob")
-}
-
 fn count_selected_rows(
     first_row_id: i64,
     row_count: i64,
@@ -1152,7 +1210,8 @@ mod tests {
             DataField::new(1, "id".to_string(), DataType::Int(IntType::new())),
             DataField::new(2, "payload".to_string(), DataType::Blob(BlobType::new())),
         ];
-        let source_plan = build_source_plan(&prepared_group, &file_infos, &read_type).unwrap();
+        let source_plan =
+            build_source_plan(&prepared_group, &file_infos, &read_type, &HashSet::new()).unwrap();
 
         assert_eq!(source_plan.sources.len(), 2);
         assert_eq!(source_plan.column_plan, vec![Some((0, 0)), Some((1, 0))]);
@@ -1191,7 +1250,8 @@ mod tests {
             DataField::new(2, "payload".to_string(), DataType::Blob(BlobType::new())),
         ];
 
-        let source_plan = build_source_plan(&prepared_group, &file_infos, &read_type).unwrap();
+        let source_plan =
+            build_source_plan(&prepared_group, &file_infos, &read_type, &HashSet::new()).unwrap();
 
         assert_eq!(source_plan.column_plan, vec![Some((0, 0)), Some((2, 0))]);
     }
@@ -1227,7 +1287,8 @@ mod tests {
             DataField::new(2, "payload".to_string(), DataType::Blob(BlobType::new())),
             DataField::new(3, "payload2".to_string(), DataType::Blob(BlobType::new())),
         ];
-        let source_plan = build_source_plan(&prepared_group, &file_infos, &read_type).unwrap();
+        let source_plan =
+            build_source_plan(&prepared_group, &file_infos, &read_type, &HashSet::new()).unwrap();
 
         assert_eq!(source_plan.sources.len(), 3);
         assert_eq!(

--- a/crates/paimon/src/table/data_evolution_writer.rs
+++ b/crates/paimon/src/table/data_evolution_writer.rs
@@ -61,12 +61,12 @@ pub struct DataEvolutionWriter {
     matched_batches: Vec<RecordBatch>,
 }
 
-fn schema_contains_blob_type(table: &Table) -> bool {
-    table
-        .schema()
-        .fields()
-        .iter()
-        .any(|field| field.data_type().contains_blob_type())
+fn schema_contains_non_descriptor_blob(table: &Table) -> bool {
+    let core_options = CoreOptions::new(table.schema().options());
+    let descriptor_fields = core_options.blob_descriptor_fields();
+    table.schema().fields().iter().any(|field| {
+        field.data_type().contains_blob_type() && !descriptor_fields.contains(field.name())
+    })
 }
 
 impl DataEvolutionWriter {
@@ -81,11 +81,9 @@ impl DataEvolutionWriter {
         let schema = table.schema();
         let core_options = CoreOptions::new(schema.options());
 
-        if schema_contains_blob_type(table) {
+        if schema_contains_non_descriptor_blob(table) {
             return Err(crate::Error::Unsupported {
-                message:
-                    "MERGE INTO does not support BlobType yet; blob write path is out of scope"
-                        .to_string(),
+                message: "MERGE INTO does not support non-descriptor BlobType fields".to_string(),
             });
         }
 
@@ -485,9 +483,11 @@ impl DataEvolutionPartialWriter {
         let schema = table.schema();
         let core_options = CoreOptions::new(schema.options());
 
-        if schema_contains_blob_type(table) {
+        if schema_contains_non_descriptor_blob(table) {
             return Err(crate::Error::Unsupported {
-                message: "DataEvolutionPartialWriter does not support BlobType yet".to_string(),
+                message:
+                    "DataEvolutionPartialWriter does not support non-descriptor BlobType fields"
+                        .to_string(),
             });
         }
 

--- a/crates/paimon/src/table/data_evolution_writer.rs
+++ b/crates/paimon/src/table/data_evolution_writer.rs
@@ -61,14 +61,6 @@ pub struct DataEvolutionWriter {
     matched_batches: Vec<RecordBatch>,
 }
 
-fn schema_contains_non_descriptor_blob(table: &Table) -> bool {
-    let core_options = CoreOptions::new(table.schema().options());
-    let descriptor_fields = core_options.blob_descriptor_fields();
-    table.schema().fields().iter().any(|field| {
-        field.data_type().contains_blob_type() && !descriptor_fields.contains(field.name())
-    })
-}
-
 impl DataEvolutionWriter {
     /// Create a new writer for the given table and update columns.
     ///
@@ -80,12 +72,6 @@ impl DataEvolutionWriter {
     pub fn new(table: &Table, update_columns: Vec<String>) -> Result<Self> {
         let schema = table.schema();
         let core_options = CoreOptions::new(schema.options());
-
-        if schema_contains_non_descriptor_blob(table) {
-            return Err(crate::Error::Unsupported {
-                message: "MERGE INTO does not support non-descriptor BlobType fields".to_string(),
-            });
-        }
 
         if !core_options.data_evolution_enabled() {
             return Err(crate::Error::Unsupported {
@@ -107,11 +93,22 @@ impl DataEvolutionWriter {
         }
 
         let partition_keys = schema.partition_keys();
+        let blob_descriptor_fields = core_options.blob_descriptor_fields();
         for col in &update_columns {
             if partition_keys.contains(col) {
                 return Err(crate::Error::Unsupported {
                     message: format!("Cannot update partition column '{col}' in MERGE INTO"),
                 });
+            }
+            if let Some(field) = schema.fields().iter().find(|f| f.name() == col) {
+                if field.data_type().is_blob_type() && !blob_descriptor_fields.contains(col) {
+                    return Err(crate::Error::Unsupported {
+                        message: format!(
+                            "Cannot update raw-data BLOB column '{col}' in MERGE INTO. \
+                             Only BLOB columns listed in 'blob-descriptor-field' can be updated"
+                        ),
+                    });
+                }
             }
         }
 
@@ -483,14 +480,6 @@ impl DataEvolutionPartialWriter {
         let schema = table.schema();
         let core_options = CoreOptions::new(schema.options());
 
-        if schema_contains_non_descriptor_blob(table) {
-            return Err(crate::Error::Unsupported {
-                message:
-                    "DataEvolutionPartialWriter does not support non-descriptor BlobType fields"
-                        .to_string(),
-            });
-        }
-
         if !core_options.data_evolution_enabled() {
             return Err(crate::Error::Unsupported {
                 message: "DataEvolutionPartialWriter requires data-evolution.enabled = true"
@@ -609,9 +598,7 @@ mod tests {
     use super::*;
     use crate::catalog::Identifier;
     use crate::io::FileIOBuilder;
-    use crate::spec::{
-        BlobType, DataField, DataType, IntType, RowType, Schema, TableSchema, VarCharType,
-    };
+    use crate::spec::{DataType, IntType, Schema, TableSchema, VarCharType};
     use arrow_array::StringArray;
     use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
     use std::sync::Arc;
@@ -665,40 +652,12 @@ mod tests {
         TableSchema::new(0, &schema)
     }
 
-    fn test_blob_data_evolution_schema() -> TableSchema {
-        let schema = Schema::builder()
-            .column("id", DataType::Int(IntType::new()))
-            .column(
-                "payload",
-                DataType::Row(RowType::new(vec![DataField::new(
-                    1,
-                    "blob".into(),
-                    DataType::Blob(BlobType::new()),
-                )])),
-            )
-            .option("data-evolution.enabled", "true")
-            .option("row-tracking.enabled", "true")
-            .build()
-            .unwrap();
-        TableSchema::new(0, &schema)
-    }
-
     fn test_table(file_io: &FileIO, table_path: &str) -> Table {
         Table::new(
             file_io.clone(),
             Identifier::new("default", "test_de_table"),
             table_path.to_string(),
             test_data_evolution_schema(),
-            None,
-        )
-    }
-
-    fn test_blob_table(file_io: &FileIO, table_path: &str) -> Table {
-        Table::new(
-            file_io.clone(),
-            Identifier::new("default", "test_de_blob_table"),
-            table_path.to_string(),
-            test_blob_data_evolution_schema(),
             None,
         )
     }
@@ -911,31 +870,5 @@ mod tests {
 
         let result = DataEvolutionPartialWriter::new(&table, vec!["id".to_string()]);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_rejects_blob_data_evolution_writer() {
-        let file_io = test_file_io();
-        let table = test_blob_table(&file_io, "memory:/test_blob_de_writer");
-
-        let err = DataEvolutionWriter::new(&table, vec!["id".to_string()])
-            .err()
-            .unwrap();
-        assert!(
-            matches!(err, crate::Error::Unsupported { message } if message.contains("BlobType"))
-        );
-    }
-
-    #[test]
-    fn test_rejects_blob_partial_writer() {
-        let file_io = test_file_io();
-        let table = test_blob_table(&file_io, "memory:/test_blob_partial_writer");
-
-        let err = DataEvolutionPartialWriter::new(&table, vec!["id".to_string()])
-            .err()
-            .unwrap();
-        assert!(
-            matches!(err, crate::Error::Unsupported { message } if message.contains("BlobType"))
-        );
     }
 }

--- a/crates/paimon/src/table/data_file_reader.rs
+++ b/crates/paimon/src/table/data_file_reader.rs
@@ -41,6 +41,7 @@ pub(crate) struct DataFileReader {
     table_fields: Vec<DataField>,
     read_type: Vec<DataField>,
     predicates: Vec<Predicate>,
+    blob_as_descriptor: bool,
 }
 
 impl DataFileReader {
@@ -59,7 +60,13 @@ impl DataFileReader {
             table_fields,
             read_type,
             predicates,
+            blob_as_descriptor: false,
         }
+    }
+
+    pub(crate) fn with_blob_as_descriptor(mut self, blob_as_descriptor: bool) -> Self {
+        self.blob_as_descriptor = blob_as_descriptor;
+        self
     }
 
     /// Take a stream of DataSplits and read every data file in each split.
@@ -145,6 +152,7 @@ impl DataFileReader {
         let predicates = self.predicates.clone();
         let file_io = self.file_io.clone();
         let split = split.clone();
+        let blob_as_descriptor = self.blob_as_descriptor;
 
         let target_schema = build_target_arrow_schema(&read_type)?;
         let file_fields = data_fields.clone().unwrap_or_else(|| table_fields.clone());
@@ -187,7 +195,7 @@ impl DataFileReader {
 
         Ok(try_stream! {
             let path_to_read = split.data_file_path(&file_meta);
-            let format_reader = create_format_reader(&path_to_read)?;
+            let format_reader = create_format_reader(&path_to_read, blob_as_descriptor)?;
             let input_file = file_io.new_input(&path_to_read)?;
             let file_reader = input_file.reader().await?;
             let local_ranges = row_ranges.as_ref().map(|ranges| {

--- a/crates/paimon/src/table/data_file_writer.rs
+++ b/crates/paimon/src/table/data_file_writer.rs
@@ -155,6 +155,7 @@ impl DataFileWriter {
             schema,
             &self.file_compression,
             self.file_compression_zstd_level,
+            Some(self.file_io.clone()),
         )
         .await?;
         self.current_writer = Some(writer);

--- a/crates/paimon/src/table/kv_file_writer.rs
+++ b/crates/paimon/src/table/kv_file_writer.rs
@@ -227,6 +227,7 @@ impl KeyValueFileWriter {
             physical_schema.clone(),
             &self.config.file_compression,
             self.config.file_compression_zstd_level,
+            None,
         )
         .await?;
 

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -18,6 +18,7 @@
 //! Table API for Apache Paimon
 
 pub(crate) mod bin_pack;
+mod blob_file_writer;
 mod bucket_assigner;
 mod bucket_assigner_constant;
 mod bucket_assigner_cross;

--- a/crates/paimon/src/table/postpone_file_writer.rs
+++ b/crates/paimon/src/table/postpone_file_writer.rs
@@ -228,6 +228,7 @@ impl PostponeFileWriter {
             physical_schema,
             &self.config.file_compression,
             self.config.file_compression_zstd_level,
+            None,
         )
         .await?;
         self.current_writer = Some(writer);

--- a/crates/paimon/src/table/table_commit.rs
+++ b/crates/paimon/src/table/table_commit.rs
@@ -614,6 +614,9 @@ impl TableCommit {
 
     /// Assign row tracking metadata: snapshot ID as sequence number, and
     /// first_row_id for new APPEND files that don't already have one.
+    /// Normal files advance the main counter. Blob files (identified by file name)
+    /// use per-column counters starting from the same base, since each blob column
+    /// rolls independently.
     fn assign_row_tracking_meta(
         &self,
         snapshot_id: i64,
@@ -622,6 +625,8 @@ impl TableCommit {
     ) -> (Vec<ManifestEntry>, i64) {
         let mut result = Vec::with_capacity(entries.len());
         let mut start = first_row_id_start;
+        // Per blob column (write_cols key) counter, each starts from first_row_id_start.
+        let mut blob_starts: HashMap<Vec<String>, i64> = HashMap::new();
 
         for entry in entries {
             let mut entry = entry.with_sequence_number(snapshot_id, snapshot_id);
@@ -629,9 +634,17 @@ impl TableCommit {
                 && entry.file().file_source == Some(0) // APPEND
                 && entry.file().first_row_id.is_none()
             {
-                let row_count = entry.file().row_count;
-                entry = entry.with_first_row_id(start);
-                start += row_count;
+                let is_blob_file =
+                    crate::table::blob_file_writer::is_blob_file_name(&entry.file().file_name);
+                if is_blob_file {
+                    let key = entry.file().write_cols.clone().unwrap_or_default();
+                    let blob_start = blob_starts.entry(key).or_insert(first_row_id_start);
+                    entry = entry.with_first_row_id(*blob_start);
+                    *blob_start += entry.file().row_count;
+                } else {
+                    entry = entry.with_first_row_id(start);
+                    start += entry.file().row_count;
+                }
             }
             result.push(entry);
         }

--- a/crates/paimon/src/table/table_read.rs
+++ b/crates/paimon/src/table/table_read.rs
@@ -88,7 +88,7 @@ impl<'a> TableRead<'a> {
         }
 
         if core_options.data_evolution_enabled() {
-            self.read_with_evolution(data_splits)
+            self.read_with_evolution(data_splits, &core_options)
         } else {
             self.read_raw(data_splits)
         }
@@ -154,6 +154,7 @@ impl<'a> TableRead<'a> {
     fn read_with_evolution(
         &self,
         data_splits: &[DataSplit],
+        core_options: &CoreOptions,
     ) -> crate::Result<ArrowRecordBatchStream> {
         let reader = DataEvolutionReader::new(
             self.table.file_io.clone(),
@@ -161,6 +162,8 @@ impl<'a> TableRead<'a> {
             self.table.schema().id(),
             self.table.schema.fields().to_vec(),
             self.read_type().to_vec(),
+            core_options.blob_as_descriptor(),
+            core_options.blob_descriptor_fields(),
         )?;
         reader.read(data_splits)
     }

--- a/crates/paimon/src/table/table_write.rs
+++ b/crates/paimon/src/table/table_write.rs
@@ -24,7 +24,7 @@ use crate::arrow::build_target_arrow_schema;
 use crate::spec::DataFileMeta;
 use crate::spec::PartitionComputer;
 use crate::spec::{
-    BinaryRow, CoreOptions, DataField, DataType, MergeEngine, EMPTY_SERIALIZED_ROW, POSTPONE_BUCKET,
+    BinaryRow, CoreOptions, DataType, MergeEngine, EMPTY_SERIALIZED_ROW, POSTPONE_BUCKET,
 };
 use crate::table::blob_file_writer::AppendBlobFileWriter;
 use crate::table::bucket_assigner::{BucketAssignerEnum, PartitionBucketKey};
@@ -42,12 +42,6 @@ use crate::Result;
 use arrow_array::RecordBatch;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-
-fn schema_contains_blob_type(fields: &[DataField]) -> bool {
-    fields
-        .iter()
-        .any(|field| field.data_type().contains_blob_type())
-}
 
 /// Enum to hold either an append-only writer, a key-value writer, or a postpone writer.
 enum FileWriter {
@@ -122,14 +116,27 @@ impl TableWrite {
     ) -> crate::Result<Self> {
         let schema = table.schema();
         let core_options = CoreOptions::new(schema.options());
-
-        if schema_contains_blob_type(schema.fields()) && !schema.primary_keys().is_empty() {
-            return Err(crate::Error::Unsupported {
-                message: "TableWrite does not support BlobType with primary keys".to_string(),
-            });
-        }
-
         let blob_descriptor_fields = core_options.blob_descriptor_fields();
+
+        for name in &blob_descriptor_fields {
+            match schema.fields().iter().find(|f| f.name() == name) {
+                None => {
+                    return Err(crate::Error::DataInvalid {
+                        message: format!("blob-descriptor-field '{name}' does not exist in schema"),
+                        source: None,
+                    });
+                }
+                Some(f) if !f.data_type().is_blob_type() => {
+                    return Err(crate::Error::DataInvalid {
+                        message: format!(
+                            "blob-descriptor-field '{name}' is not a top-level BLOB field"
+                        ),
+                        source: None,
+                    });
+                }
+                _ => {}
+            }
+        }
 
         let total_buckets = core_options.bucket();
         let has_primary_keys = !schema.primary_keys().is_empty();
@@ -260,9 +267,10 @@ impl TableWrite {
             ))
         };
 
-        let has_blob_fields = schema.fields().iter().any(|f| {
-            f.data_type().contains_blob_type() && !blob_descriptor_fields.contains(f.name())
-        });
+        let has_blob_fields = schema
+            .fields()
+            .iter()
+            .any(|f| f.data_type().is_blob_type() && !blob_descriptor_fields.contains(f.name()));
 
         Ok(Self {
             table: table.clone(),
@@ -671,8 +679,8 @@ mod tests {
     use crate::catalog::Identifier;
     use crate::io::{FileIO, FileIOBuilder};
     use crate::spec::{
-        BinaryRowBuilder, BlobType, DataField, DataType, DecimalType, IntType,
-        LocalZonedTimestampType, RowType, Schema, TableSchema, TimestampType, VarCharType,
+        BinaryRowBuilder, BlobType, DataType, DecimalType, IntType, LocalZonedTimestampType,
+        Schema, TableSchema, TimestampType, VarCharType,
     };
     use crate::table::{SnapshotManager, TableCommit};
     use arrow_array::Int32Array;
@@ -730,21 +738,6 @@ mod tests {
             .column("id", DataType::Int(IntType::new()))
             .column("payload", DataType::Blob(BlobType::new()))
             .option("data-evolution.enabled", "true")
-            .build()
-            .unwrap();
-        TableSchema::new(0, &schema)
-    }
-
-    fn test_nested_blob_table_schema() -> TableSchema {
-        let schema = Schema::builder()
-            .column(
-                "payload",
-                DataType::Row(RowType::new(vec![DataField::new(
-                    1,
-                    "blob".into(),
-                    DataType::Blob(BlobType::new()),
-                )])),
-            )
             .build()
             .unwrap();
         TableSchema::new(0, &schema)
@@ -820,51 +813,12 @@ mod tests {
     }
 
     #[test]
-    fn test_rejects_pk_blob_table() {
-        let schema = Schema::builder()
-            .column("id", DataType::Int(IntType::new()))
-            .column("payload", DataType::Blob(BlobType::new()))
-            .primary_key(["id"])
-            .option("bucket", "1")
-            .option("data-evolution.enabled", "true")
-            .build()
-            .unwrap();
-        let table = Table::new(
-            test_file_io(),
-            Identifier::new("default", "test_blob_table"),
-            "memory:/test_blob_table".to_string(),
-            TableSchema::new(0, &schema),
-            None,
-        );
-
-        let err = TableWrite::new(&table, "test-user".to_string(), false)
-            .err()
-            .unwrap();
-        assert!(
-            matches!(err, crate::Error::Unsupported { message } if message.contains("BlobType"))
-        );
-    }
-
-    #[test]
     fn test_allows_append_blob_table() {
         let table = Table::new(
             test_file_io(),
             Identifier::new("default", "test_blob_table"),
             "memory:/test_blob_table".to_string(),
             test_blob_table_schema(),
-            None,
-        );
-
-        assert!(TableWrite::new(&table, "test-user".to_string(), false).is_ok());
-    }
-
-    #[test]
-    fn test_allows_nested_blob_table() {
-        let table = Table::new(
-            test_file_io(),
-            Identifier::new("default", "test_nested_blob_table"),
-            "memory:/test_nested_blob_table".to_string(),
-            test_nested_blob_table_schema(),
             None,
         );
 

--- a/crates/paimon/src/table/table_write.rs
+++ b/crates/paimon/src/table/table_write.rs
@@ -20,11 +20,13 @@
 //! Reference: [pypaimon TableWrite](https://github.com/apache/paimon/blob/master/paimon-python/pypaimon/write/table_write.py)
 //! and [pypaimon FileStoreWrite](https://github.com/apache/paimon/blob/master/paimon-python/pypaimon/write/file_store_write.py)
 
+use crate::arrow::build_target_arrow_schema;
 use crate::spec::DataFileMeta;
 use crate::spec::PartitionComputer;
 use crate::spec::{
     BinaryRow, CoreOptions, DataField, DataType, MergeEngine, EMPTY_SERIALIZED_ROW, POSTPONE_BUCKET,
 };
+use crate::table::blob_file_writer::AppendBlobFileWriter;
 use crate::table::bucket_assigner::{BucketAssignerEnum, PartitionBucketKey};
 use crate::table::bucket_assigner_constant::ConstantBucketAssigner;
 use crate::table::bucket_assigner_cross::CrossPartitionAssigner;
@@ -50,6 +52,7 @@ fn schema_contains_blob_type(fields: &[DataField]) -> bool {
 /// Enum to hold either an append-only writer, a key-value writer, or a postpone writer.
 enum FileWriter {
     Append(DataFileWriter),
+    AppendBlob(AppendBlobFileWriter),
     KeyValue(KeyValueFileWriter),
     Postpone(PostponeFileWriter),
 }
@@ -58,6 +61,7 @@ impl FileWriter {
     async fn write(&mut self, batch: &RecordBatch) -> Result<()> {
         match self {
             FileWriter::Append(w) => w.write(batch).await,
+            FileWriter::AppendBlob(w) => w.write(batch).await,
             FileWriter::KeyValue(w) => w.write(batch).await,
             FileWriter::Postpone(w) => w.write(batch).await,
         }
@@ -66,6 +70,7 @@ impl FileWriter {
     async fn prepare_commit(mut self) -> Result<Vec<DataFileMeta>> {
         match self {
             FileWriter::Append(ref mut w) => w.prepare_commit().await,
+            FileWriter::AppendBlob(ref mut w) => w.prepare_commit().await,
             FileWriter::KeyValue(ref mut w) => w.prepare_commit().await,
             FileWriter::Postpone(ref mut w) => w.prepare_commit().await,
         }
@@ -88,6 +93,7 @@ pub struct TableWrite {
     partition_keys: Vec<String>,
     schema_id: i64,
     target_file_size: i64,
+    blob_target_file_size: i64,
     file_compression: String,
     file_compression_zstd_level: i32,
     write_buffer_size: i64,
@@ -102,6 +108,10 @@ pub struct TableWrite {
     bucket_assigner: BucketAssignerEnum,
     /// Whether this is an overwrite operation (skip seq/index restore).
     is_overwrite: bool,
+    /// Blob descriptor fields (stored inline in parquet, not as separate .blob files).
+    blob_descriptor_fields: HashSet<String>,
+    /// Whether the table has non-descriptor blob fields requiring AppendBlobFileWriter.
+    has_blob_fields: bool,
 }
 
 impl TableWrite {
@@ -113,13 +123,13 @@ impl TableWrite {
         let schema = table.schema();
         let core_options = CoreOptions::new(schema.options());
 
-        if schema_contains_blob_type(schema.fields()) {
+        if schema_contains_blob_type(schema.fields()) && !schema.primary_keys().is_empty() {
             return Err(crate::Error::Unsupported {
-                message:
-                    "TableWrite does not support BlobType yet; blob write path is out of scope"
-                        .to_string(),
+                message: "TableWrite does not support BlobType with primary keys".to_string(),
             });
         }
+
+        let blob_descriptor_fields = core_options.blob_descriptor_fields();
 
         let total_buckets = core_options.bucket();
         let has_primary_keys = !schema.primary_keys().is_empty();
@@ -161,6 +171,7 @@ impl TableWrite {
             });
         }
         let target_file_size = core_options.target_file_size();
+        let blob_target_file_size = core_options.blob_target_file_size();
         let file_compression = core_options.file_compression().to_string();
         let file_compression_zstd_level = core_options.file_compression_zstd_level();
         let file_format = core_options.file_format().to_string();
@@ -249,6 +260,10 @@ impl TableWrite {
             ))
         };
 
+        let has_blob_fields = schema.fields().iter().any(|f| {
+            f.data_type().contains_blob_type() && !blob_descriptor_fields.contains(f.name())
+        });
+
         Ok(Self {
             table: table.clone(),
             partition_writers: HashMap::new(),
@@ -256,6 +271,7 @@ impl TableWrite {
             partition_keys,
             schema_id: schema.id(),
             target_file_size,
+            blob_target_file_size,
             file_compression,
             file_compression_zstd_level,
             write_buffer_size,
@@ -268,6 +284,8 @@ impl TableWrite {
             commit_user,
             bucket_assigner,
             is_overwrite,
+            blob_descriptor_fields,
+            has_blob_fields,
         })
     }
 
@@ -522,7 +540,7 @@ impl TableWrite {
         let partition_path = self.resolve_partition_path(&partition_bytes)?;
 
         let writer = if self.primary_key_indices.is_empty() {
-            self.create_append_writer(partition_path, bucket)
+            self.create_append_writer(partition_path, bucket)?
         } else if bucket == POSTPONE_BUCKET {
             self.create_postpone_writer(partition_path, bucket)
         } else {
@@ -545,22 +563,43 @@ impl TableWrite {
     }
 
     /// Create an append-only writer for non-PK tables.
-    fn create_append_writer(&self, partition_path: String, bucket: i32) -> FileWriter {
-        FileWriter::Append(DataFileWriter::new(
-            self.table.file_io().clone(),
-            self.table.location().to_string(),
-            partition_path,
-            bucket,
-            self.schema_id,
-            self.target_file_size,
-            self.file_compression.clone(),
-            self.file_compression_zstd_level,
-            self.write_buffer_size,
-            self.file_format.clone(),
-            Some(0), // file_source: APPEND
-            None,    // first_row_id: assigned by commit
-            None,    // write_cols: full-row write
-        ))
+    fn create_append_writer(&self, partition_path: String, bucket: i32) -> Result<FileWriter> {
+        if self.has_blob_fields {
+            let fields = self.table.schema().fields();
+            let input_schema = build_target_arrow_schema(fields)?;
+            Ok(FileWriter::AppendBlob(AppendBlobFileWriter::new(
+                self.table.file_io().clone(),
+                self.table.location().to_string(),
+                partition_path,
+                bucket,
+                self.schema_id,
+                self.target_file_size,
+                self.blob_target_file_size,
+                self.file_compression.clone(),
+                self.file_compression_zstd_level,
+                self.write_buffer_size,
+                self.file_format.clone(),
+                &input_schema,
+                fields,
+                &self.blob_descriptor_fields,
+            )))
+        } else {
+            Ok(FileWriter::Append(DataFileWriter::new(
+                self.table.file_io().clone(),
+                self.table.location().to_string(),
+                partition_path,
+                bucket,
+                self.schema_id,
+                self.target_file_size,
+                self.file_compression.clone(),
+                self.file_compression_zstd_level,
+                self.write_buffer_size,
+                self.file_format.clone(),
+                Some(0),
+                None,
+                None,
+            )))
+        }
     }
 
     /// Create a postpone writer (KV format, no sorting/dedup, special file naming).
@@ -781,12 +820,20 @@ mod tests {
     }
 
     #[test]
-    fn test_rejects_blob_table() {
+    fn test_rejects_pk_blob_table() {
+        let schema = Schema::builder()
+            .column("id", DataType::Int(IntType::new()))
+            .column("payload", DataType::Blob(BlobType::new()))
+            .primary_key(["id"])
+            .option("bucket", "1")
+            .option("data-evolution.enabled", "true")
+            .build()
+            .unwrap();
         let table = Table::new(
             test_file_io(),
             Identifier::new("default", "test_blob_table"),
             "memory:/test_blob_table".to_string(),
-            test_blob_table_schema(),
+            TableSchema::new(0, &schema),
             None,
         );
 
@@ -799,7 +846,20 @@ mod tests {
     }
 
     #[test]
-    fn test_rejects_nested_blob_table() {
+    fn test_allows_append_blob_table() {
+        let table = Table::new(
+            test_file_io(),
+            Identifier::new("default", "test_blob_table"),
+            "memory:/test_blob_table".to_string(),
+            test_blob_table_schema(),
+            None,
+        );
+
+        assert!(TableWrite::new(&table, "test-user".to_string(), false).is_ok());
+    }
+
+    #[test]
+    fn test_allows_nested_blob_table() {
         let table = Table::new(
             test_file_io(),
             Identifier::new("default", "test_nested_blob_table"),
@@ -808,12 +868,73 @@ mod tests {
             None,
         );
 
-        let err = TableWrite::new(&table, "test-user".to_string(), false)
-            .err()
-            .unwrap();
-        assert!(
-            matches!(err, crate::Error::Unsupported { message } if message.contains("BlobType"))
+        assert!(TableWrite::new(&table, "test-user".to_string(), false).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_blob_write_and_commit() {
+        let file_io = test_file_io();
+        let table_path = "memory:/test_blob_write";
+        setup_dirs(&file_io, table_path).await;
+
+        let table = Table::new(
+            file_io.clone(),
+            Identifier::new("default", "test_blob_table"),
+            table_path.to_string(),
+            test_blob_table_schema(),
+            None,
         );
+
+        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, false),
+            ArrowField::new("payload", ArrowDataType::Binary, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(arrow_array::BinaryArray::from(vec![
+                    Some(b"hello" as &[u8]),
+                    None,
+                    Some(b"world"),
+                ])),
+            ],
+        )
+        .unwrap();
+
+        table_write.write_arrow_batch(&batch).await.unwrap();
+        let messages = table_write.prepare_commit().await.unwrap();
+
+        assert_eq!(messages.len(), 1);
+        // Should have 2 files: 1 parquet (normal cols) + 1 blob (payload)
+        assert_eq!(messages[0].new_files.len(), 2);
+
+        let parquet_files: Vec<_> = messages[0]
+            .new_files
+            .iter()
+            .filter(|f| f.file_name.ends_with(".parquet"))
+            .collect();
+        let blob_files: Vec<_> = messages[0]
+            .new_files
+            .iter()
+            .filter(|f| f.file_name.ends_with(".blob"))
+            .collect();
+        assert_eq!(parquet_files.len(), 1);
+        assert_eq!(blob_files.len(), 1);
+
+        assert_eq!(parquet_files[0].row_count, 3);
+        assert_eq!(blob_files[0].row_count, 3);
+        assert_eq!(blob_files[0].write_cols, Some(vec!["payload".to_string()]));
+
+        // Commit and verify snapshot
+        let commit = TableCommit::new(table, "test-user".to_string());
+        commit.commit(messages).await.unwrap();
+
+        let snap_manager = SnapshotManager::new(file_io.clone(), table_path.to_string());
+        let snapshot = snap_manager.get_latest_snapshot().await.unwrap().unwrap();
+        assert_eq!(snapshot.id(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Introduce BlobDescriptor serialization/deserialization, AppendBlobFileWriter for writing blob format files, blob format writer implementation, and descriptor mode in the reader that returns BlobDescriptor references instead of inline data. Update row tracking in commit to use per-column counters for blob files. Allow BlobType in append-only tables (still unsupported with primary keys).

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
