### PR TITLE
feat(datafusion): reject typed columns in PARTITIONED BY clause

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -52,6 +52,6 @@ include = [
 dev = [
     "maturin>=1.9.4,<2.0",
     "pytest>=8.0",
-    "pyarrow>=17.0",
+    "pyarrow>=17.0,<24.0",
     "datafusion==53.0.0",
 ]

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -24,7 +24,7 @@
 //! SCHEMA, DROP TABLE, etc.) to the underlying [`SessionContext`].
 //!
 //! Supported DDL:
-//! - `CREATE TABLE db.t (col TYPE, ..., PRIMARY KEY (col, ...)) [PARTITIONED BY (col TYPE, ...)] [WITH ('key' = 'val')]`
+//! - `CREATE TABLE db.t (col TYPE, ..., PRIMARY KEY (col, ...)) [PARTITIONED BY (col, ...)] [WITH ('key' = 'val')]`
 //! - `ALTER TABLE db.t ADD COLUMN col TYPE`
 //! - `ALTER TABLE db.t DROP COLUMN col`
 //! - `ALTER TABLE db.t RENAME COLUMN old TO new`
@@ -38,9 +38,8 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::sql::sqlparser::ast::{
-    AlterTableOperation, ColumnDef, CreateTable, CreateTableOptions, Delete, FromTable,
-    HiveDistributionStyle, Merge, ObjectName, RenameTableNameKind, SqlOption, Statement,
-    TableFactor, Update,
+    AlterTableOperation, ColumnDef, CreateTable, CreateTableOptions, Delete, FromTable, Merge,
+    ObjectName, RenameTableNameKind, SqlOption, Statement, TableFactor, Update,
 };
 use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
@@ -92,8 +91,9 @@ impl PaimonSqlHandler {
     /// Execute a SQL statement. ALTER TABLE is handled by Paimon directly;
     /// everything else is delegated to DataFusion.
     pub async fn sql(&self, sql: &str) -> DFResult<DataFrame> {
+        let (rewritten_sql, partition_keys) = extract_partition_by(sql)?;
         let dialect = GenericDialect {};
-        let statements = Parser::parse_sql(&dialect, sql)
+        let statements = Parser::parse_sql(&dialect, &rewritten_sql)
             .map_err(|e| DataFusionError::Plan(format!("SQL parse error: {e}")))?;
 
         if statements.len() != 1 {
@@ -103,7 +103,9 @@ impl PaimonSqlHandler {
         }
 
         match &statements[0] {
-            Statement::CreateTable(create_table) => self.handle_create_table(create_table).await,
+            Statement::CreateTable(create_table) => {
+                self.handle_create_table(create_table, partition_keys).await
+            }
             Statement::AlterTable(alter_table) => {
                 self.handle_alter_table(
                     &alter_table.name,
@@ -119,7 +121,11 @@ impl PaimonSqlHandler {
         }
     }
 
-    async fn handle_create_table(&self, ct: &CreateTable) -> DFResult<DataFrame> {
+    async fn handle_create_table(
+        &self,
+        ct: &CreateTable,
+        partition_keys: Vec<String>,
+    ) -> DFResult<DataFrame> {
         if ct.external {
             return Err(DataFusionError::Plan(
                 "CREATE EXTERNAL TABLE is not supported. Use CREATE TABLE instead.".to_string(),
@@ -158,10 +164,8 @@ impl PaimonSqlHandler {
             }
         }
 
-        // Partition keys from PARTITIONED BY (col, ...)
-        if let HiveDistributionStyle::PARTITIONED { columns } = &ct.hive_distribution {
-            let partition_keys: Vec<String> =
-                columns.iter().map(|c| c.name.value.clone()).collect();
+        // Partition keys (already extracted and validated before parsing)
+        if !partition_keys.is_empty() {
             builder = builder.partition_keys(partition_keys);
         }
 
@@ -359,6 +363,90 @@ impl PaimonSqlHandler {
             ))),
         }
     }
+}
+
+/// Extract `PARTITIONED BY (col1, col2, ...)` from SQL before parsing.
+///
+/// Paimon only allows column references (no types) in PARTITIONED BY.
+/// Since sqlparser's GenericDialect requires types in column definitions,
+/// we extract and validate the clause ourselves, then strip it from the SQL
+/// so sqlparser can parse the rest.
+fn extract_partition_by(sql: &str) -> DFResult<(String, Vec<String>)> {
+    let upper = sql.to_uppercase();
+    let Some(kw_start) = upper.find("PARTITIONED") else {
+        return Ok((sql.to_string(), vec![]));
+    };
+
+    let after_partitioned = &upper[kw_start + "PARTITIONED".len()..];
+    let after_trimmed = after_partitioned.trim_start();
+    if !after_trimmed.starts_with("BY") {
+        return Ok((sql.to_string(), vec![]));
+    }
+
+    let by_offset =
+        kw_start + "PARTITIONED".len() + (after_partitioned.len() - after_trimmed.len()) + 2;
+    let after_by = sql[by_offset..].trim_start();
+    let by_ws = by_offset + (sql[by_offset..].len() - after_by.len());
+
+    if !after_by.starts_with('(') {
+        return Err(DataFusionError::Plan(
+            "Expected '(' after PARTITIONED BY".to_string(),
+        ));
+    }
+
+    let paren_start = by_ws;
+    let inner_start = paren_start + 1;
+    let mut depth = 1;
+    let mut paren_end = None;
+    for (i, ch) in sql[inner_start..].char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    paren_end = Some(inner_start + i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let paren_end = paren_end.ok_or_else(|| {
+        DataFusionError::Plan("Unmatched '(' in PARTITIONED BY clause".to_string())
+    })?;
+
+    let inner = sql[inner_start..paren_end].trim();
+    if inner.is_empty() {
+        return Err(DataFusionError::Plan(
+            "PARTITIONED BY must specify at least one column".to_string(),
+        ));
+    }
+
+    let mut partition_keys = Vec::new();
+    for token in inner.split(',') {
+        let parts: Vec<&str> = token.split_whitespace().collect();
+        match parts.len() {
+            1 => partition_keys.push(parts[0].to_string()),
+            0 => {
+                return Err(DataFusionError::Plan(
+                    "Empty column name in PARTITIONED BY".to_string(),
+                ))
+            }
+            _ => {
+                return Err(DataFusionError::Plan(format!(
+                    "PARTITIONED BY column '{}' should not specify a type. \
+                     Use column references only, e.g. PARTITIONED BY ({})",
+                    parts[0], parts[0]
+                )));
+            }
+        }
+    }
+
+    let clause_end = paren_end + 1;
+    let mut rewritten = String::with_capacity(sql.len());
+    rewritten.push_str(&sql[..kw_start]);
+    rewritten.push_str(&sql[clause_end..]);
+    Ok((rewritten, partition_keys))
 }
 
 /// Convert a sqlparser [`ColumnDef`] to a Paimon [`SchemaChange::AddColumn`].

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -164,8 +164,16 @@ impl PaimonSqlHandler {
             }
         }
 
-        // Partition keys (already extracted and validated before parsing)
+        // Partition keys (extracted and validated before parsing)
         if !partition_keys.is_empty() {
+            let col_names: Vec<&str> = ct.columns.iter().map(|c| c.name.value.as_str()).collect();
+            for pk in &partition_keys {
+                if !col_names.contains(&pk.as_str()) {
+                    return Err(DataFusionError::Plan(format!(
+                        "PARTITIONED BY column '{pk}' is not defined in the table"
+                    )));
+                }
+            }
             builder = builder.partition_keys(partition_keys);
         }
 
@@ -365,6 +373,84 @@ impl PaimonSqlHandler {
     }
 }
 
+/// Find `PARTITIONED BY` keyword position, skipping string literals and comments.
+/// All offsets are byte-safe because SQL keywords and quote/comment delimiters are ASCII.
+fn find_partitioned_by(sql: &str) -> Option<(usize, usize)> {
+    let bytes = sql.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    while i < len {
+        match bytes[i] {
+            b'\'' => {
+                i += 1;
+                while i < len {
+                    if bytes[i] == b'\'' {
+                        i += 1;
+                        if i < len && bytes[i] == b'\'' {
+                            i += 1;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            b'-' if i + 1 < len && bytes[i + 1] == b'-' => {
+                i += 2;
+                while i < len && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            _ => {
+                if sql[i..].len() >= 11 && sql[i..i + 11].eq_ignore_ascii_case("PARTITIONED") {
+                    let after = sql[i + 11..].trim_start();
+                    if after.len() >= 2 && after[..2].eq_ignore_ascii_case("BY") {
+                        let by_end = i + 11 + (sql[i + 11..].len() - after.len()) + 2;
+                        return Some((i, by_end));
+                    }
+                }
+                i += 1;
+            }
+        }
+    }
+    None
+}
+
+/// Parse a single partition column token, handling quoted identifiers.
+fn parse_partition_column(token: &str) -> DFResult<String> {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        return Err(DataFusionError::Plan(
+            "Empty column name in PARTITIONED BY".to_string(),
+        ));
+    }
+
+    let first = trimmed.as_bytes()[0];
+    if first == b'"' || first == b'`' {
+        let close = if first == b'"' { b'"' } else { b'`' };
+        if let Some(end) = trimmed[1..].find(close as char) {
+            let after_quote = trimmed[1 + end + 1..].trim();
+            if after_quote.is_empty() {
+                return Ok(trimmed[1..1 + end].to_string());
+            }
+        }
+        return Err(DataFusionError::Plan(format!(
+            "Invalid quoted identifier in PARTITIONED BY: {trimmed}"
+        )));
+    }
+
+    let parts: Vec<&str> = trimmed.split_whitespace().collect();
+    match parts.len() {
+        1 => Ok(parts[0].to_string()),
+        _ => Err(DataFusionError::Plan(format!(
+            "PARTITIONED BY column '{}' should not specify a type. \
+             Use column references only, e.g. PARTITIONED BY ({})",
+            parts[0], parts[0]
+        ))),
+    }
+}
+
 /// Extract `PARTITIONED BY (col1, col2, ...)` from SQL before parsing.
 ///
 /// Paimon only allows column references (no types) in PARTITIONED BY.
@@ -372,21 +458,12 @@ impl PaimonSqlHandler {
 /// we extract and validate the clause ourselves, then strip it from the SQL
 /// so sqlparser can parse the rest.
 fn extract_partition_by(sql: &str) -> DFResult<(String, Vec<String>)> {
-    let upper = sql.to_uppercase();
-    let Some(kw_start) = upper.find("PARTITIONED") else {
+    let Some((kw_start, by_end)) = find_partitioned_by(sql) else {
         return Ok((sql.to_string(), vec![]));
     };
 
-    let after_partitioned = &upper[kw_start + "PARTITIONED".len()..];
-    let after_trimmed = after_partitioned.trim_start();
-    if !after_trimmed.starts_with("BY") {
-        return Ok((sql.to_string(), vec![]));
-    }
-
-    let by_offset =
-        kw_start + "PARTITIONED".len() + (after_partitioned.len() - after_trimmed.len()) + 2;
-    let after_by = sql[by_offset..].trim_start();
-    let by_ws = by_offset + (sql[by_offset..].len() - after_by.len());
+    let after_by = sql[by_end..].trim_start();
+    let paren_start = by_end + (sql[by_end..].len() - after_by.len());
 
     if !after_by.starts_with('(') {
         return Err(DataFusionError::Plan(
@@ -394,7 +471,6 @@ fn extract_partition_by(sql: &str) -> DFResult<(String, Vec<String>)> {
         ));
     }
 
-    let paren_start = by_ws;
     let inner_start = paren_start + 1;
     let mut depth = 1;
     let mut paren_end = None;
@@ -424,22 +500,7 @@ fn extract_partition_by(sql: &str) -> DFResult<(String, Vec<String>)> {
 
     let mut partition_keys = Vec::new();
     for token in inner.split(',') {
-        let parts: Vec<&str> = token.split_whitespace().collect();
-        match parts.len() {
-            1 => partition_keys.push(parts[0].to_string()),
-            0 => {
-                return Err(DataFusionError::Plan(
-                    "Empty column name in PARTITIONED BY".to_string(),
-                ))
-            }
-            _ => {
-                return Err(DataFusionError::Plan(format!(
-                    "PARTITIONED BY column '{}' should not specify a type. \
-                     Use column references only, e.g. PARTITIONED BY ({})",
-                    parts[0], parts[0]
-                )));
-            }
-        }
+        partition_keys.push(parse_partition_column(token)?);
     }
 
     let clause_end = paren_end + 1;
@@ -1485,5 +1546,134 @@ mod tests {
         assert_eq!(batches[0].num_rows(), 1);
         // No catalog calls
         assert!(catalog.take_calls().is_empty());
+    }
+
+    // ==================== extract_partition_by tests ====================
+
+    #[test]
+    fn test_extract_partition_by_no_clause() {
+        let (rewritten, keys) = extract_partition_by("CREATE TABLE t (id INT)").unwrap();
+        assert_eq!(rewritten, "CREATE TABLE t (id INT)");
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn test_extract_partition_by_single_column() {
+        let (rewritten, keys) = extract_partition_by(
+            "CREATE TABLE t (id INT, dt STRING) PARTITIONED BY (dt) WITH ('k'='v')",
+        )
+        .unwrap();
+        assert_eq!(keys, vec!["dt"]);
+        assert!(!rewritten.contains("PARTITIONED"));
+        assert!(rewritten.contains("WITH"));
+    }
+
+    #[test]
+    fn test_extract_partition_by_multiple_columns() {
+        let (_, keys) =
+            extract_partition_by("CREATE TABLE t (a INT, b INT, c INT) PARTITIONED BY (a, b)")
+                .unwrap();
+        assert_eq!(keys, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_extract_partition_by_mixed_case() {
+        let (_, keys) =
+            extract_partition_by("CREATE TABLE t (dt INT) Partitioned by (dt)").unwrap();
+        assert_eq!(keys, vec!["dt"]);
+    }
+
+    #[test]
+    fn test_extract_partition_by_rejects_typed_column() {
+        let err = extract_partition_by("CREATE TABLE t (dt STRING) PARTITIONED BY (dt STRING)")
+            .unwrap_err();
+        assert!(err.to_string().contains("should not specify a type"));
+    }
+
+    #[test]
+    fn test_extract_partition_by_empty_parens() {
+        let err = extract_partition_by("CREATE TABLE t (id INT) PARTITIONED BY ()").unwrap_err();
+        assert!(err.to_string().contains("at least one column"));
+    }
+
+    #[test]
+    fn test_extract_partition_by_unmatched_paren() {
+        let err = extract_partition_by("CREATE TABLE t (id INT) PARTITIONED BY (dt").unwrap_err();
+        assert!(err.to_string().contains("Unmatched"));
+    }
+
+    #[test]
+    fn test_extract_partition_by_skips_string_literal() {
+        let sql =
+            "CREATE TABLE t (id INT) WITH ('note' = 'PARTITIONED BY (x)') PARTITIONED BY (id)";
+        let (rewritten, keys) = extract_partition_by(sql).unwrap();
+        assert_eq!(keys, vec!["id"]);
+        assert!(rewritten.contains("WITH"));
+        assert!(rewritten.contains("'PARTITIONED BY (x)'"));
+    }
+
+    #[test]
+    fn test_extract_partition_by_skips_line_comment() {
+        let sql = "CREATE TABLE t (id INT) -- PARTITIONED BY (x)\nPARTITIONED BY (id)";
+        let (_, keys) = extract_partition_by(sql).unwrap();
+        assert_eq!(keys, vec!["id"]);
+    }
+
+    #[test]
+    fn test_extract_partition_by_double_quoted_identifier() {
+        let (_, keys) =
+            extract_partition_by("CREATE TABLE t (\"order\" INT) PARTITIONED BY (\"order\")")
+                .unwrap();
+        assert_eq!(keys, vec!["order"]);
+    }
+
+    #[test]
+    fn test_extract_partition_by_backtick_quoted_identifier() {
+        let (_, keys) =
+            extract_partition_by("CREATE TABLE t (`order` INT) PARTITIONED BY (`order`)").unwrap();
+        assert_eq!(keys, vec!["order"]);
+    }
+
+    #[test]
+    fn test_extract_partition_by_no_paren_after_by() {
+        let err = extract_partition_by("CREATE TABLE t (id INT) PARTITIONED BY dt").unwrap_err();
+        assert!(err.to_string().contains("Expected '('"));
+    }
+
+    #[test]
+    fn test_extract_partition_by_only_partitioned_no_by() {
+        let (rewritten, keys) = extract_partition_by("CREATE TABLE partitioned (id INT)").unwrap();
+        assert_eq!(rewritten, "CREATE TABLE partitioned (id INT)");
+        assert!(keys.is_empty());
+    }
+
+    // ==================== partition key validation tests ====================
+
+    #[tokio::test]
+    async fn test_create_table_partition_key_not_in_columns() {
+        let catalog = Arc::new(MockCatalog::new());
+        let handler = make_handler(catalog);
+        let err = handler
+            .sql("CREATE TABLE mydb.t (id INT, dt STRING) PARTITIONED BY (nonexistent)")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("is not defined in the table"));
+    }
+
+    #[tokio::test]
+    async fn test_create_table_partition_key_matches_column() {
+        let catalog = Arc::new(MockCatalog::new());
+        let handler = make_handler(catalog.clone());
+        handler
+            .sql("CREATE TABLE mydb.t (id INT, dt STRING) PARTITIONED BY (dt)")
+            .await
+            .unwrap();
+        let calls = catalog.take_calls();
+        assert_eq!(calls.len(), 1);
+        if let CatalogCall::CreateTable { schema, .. } = &calls[0] {
+            assert_eq!(schema.partition_keys(), &["dt"]);
+        } else {
+            panic!("expected CreateTable call");
+        }
     }
 }

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -379,15 +379,48 @@ impl PaimonSqlHandler {
 }
 
 /// Quick check whether the SQL looks like a CREATE TABLE statement.
+/// Skips leading whitespace, `--` line comments, and `/* */` block comments.
 fn looks_like_create_table(sql: &str) -> bool {
-    let trimmed = sql.trim_start();
-    let upper = &trimmed[..trimmed.len().min(30)];
-    let mut it = upper.split_ascii_whitespace();
-    matches!(
-        (it.next(), it.next()),
-        (Some(c), Some(t))
-        if c.eq_ignore_ascii_case("CREATE") && t.eq_ignore_ascii_case("TABLE")
-    )
+    let bytes = sql.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    // Skip leading whitespace and comments
+    loop {
+        while i < len && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i + 1 < len && bytes[i] == b'-' && bytes[i + 1] == b'-' {
+            i += 2;
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        if i + 1 < len && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < len {
+                if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                    i += 2;
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        break;
+    }
+    // Match "CREATE" then whitespace then "TABLE" (all ASCII, byte-safe)
+    if i + 6 > len || !bytes[i..i + 6].eq_ignore_ascii_case(b"CREATE") {
+        return false;
+    }
+    i += 6;
+    if i >= len || !bytes[i].is_ascii_whitespace() {
+        return false;
+    }
+    while i < len && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    i + 5 <= len && bytes[i..i + 5].eq_ignore_ascii_case(b"TABLE")
 }
 
 /// Find `PARTITIONED BY` keyword position, skipping string literals and comments.
@@ -1693,10 +1726,22 @@ mod tests {
         assert!(looks_like_create_table("CREATE TABLE t (id INT)"));
         assert!(looks_like_create_table("  create  table t (id INT)"));
         assert!(looks_like_create_table(
-            "CREATE TABLE IF NOT EXISTS t (id INT)"
+            "CREATE TABLE IF NOT EXISTS t (id INT)",
+        ));
+        assert!(looks_like_create_table(
+            "/* note */ CREATE TABLE t (id INT)",
+        ));
+        assert!(looks_like_create_table(
+            "-- comment\nCREATE TABLE t (id INT)",
+        ));
+        assert!(looks_like_create_table(
+            "/* a */ /* b */ CREATE TABLE t (id INT)",
         ));
         assert!(!looks_like_create_table("ALTER TABLE t ADD COLUMN x INT"));
         assert!(!looks_like_create_table("SELECT 1"));
+        assert!(!looks_like_create_table(
+            "SELECT aaaaaaaaaaaaaaaaaaaa中文 FROM t",
+        ));
     }
 
     // ==================== partition key validation tests ====================

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -91,7 +91,12 @@ impl PaimonSqlHandler {
     /// Execute a SQL statement. ALTER TABLE is handled by Paimon directly;
     /// everything else is delegated to DataFusion.
     pub async fn sql(&self, sql: &str) -> DFResult<DataFrame> {
-        let (rewritten_sql, partition_keys) = extract_partition_by(sql)?;
+        let is_create_table = looks_like_create_table(sql);
+        let (rewritten_sql, partition_keys) = if is_create_table {
+            extract_partition_by(sql)?
+        } else {
+            (sql.to_string(), vec![])
+        };
         let dialect = GenericDialect {};
         let statements = Parser::parse_sql(&dialect, &rewritten_sql)
             .map_err(|e| DataFusionError::Plan(format!("SQL parse error: {e}")))?;
@@ -373,8 +378,19 @@ impl PaimonSqlHandler {
     }
 }
 
+/// Quick check whether the SQL looks like a CREATE TABLE statement.
+fn looks_like_create_table(sql: &str) -> bool {
+    let trimmed = sql.trim_start();
+    let upper = &trimmed[..trimmed.len().min(30)];
+    let mut it = upper.split_ascii_whitespace();
+    matches!(
+        (it.next(), it.next()),
+        (Some(c), Some(t))
+        if c.eq_ignore_ascii_case("CREATE") && t.eq_ignore_ascii_case("TABLE")
+    )
+}
+
 /// Find `PARTITIONED BY` keyword position, skipping string literals and comments.
-/// All offsets are byte-safe because SQL keywords and quote/comment delimiters are ASCII.
 fn find_partitioned_by(sql: &str) -> Option<(usize, usize)> {
     let bytes = sql.as_bytes();
     let len = bytes.len();
@@ -402,14 +418,31 @@ fn find_partitioned_by(sql: &str) -> Option<(usize, usize)> {
                     i += 1;
                 }
             }
-            _ => {
-                if sql[i..].len() >= 11 && sql[i..i + 11].eq_ignore_ascii_case("PARTITIONED") {
-                    let after = sql[i + 11..].trim_start();
-                    if after.len() >= 2 && after[..2].eq_ignore_ascii_case("BY") {
-                        let by_end = i + 11 + (sql[i + 11..].len() - after.len()) + 2;
+            b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < len {
+                    if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            b if b.is_ascii_alphabetic() && i + 11 <= len => {
+                if bytes[i..i + 11].eq_ignore_ascii_case(b"PARTITIONED") {
+                    let rest = &bytes[i + 11..];
+                    let ws = rest.iter().take_while(|b| b.is_ascii_whitespace()).count();
+                    if ws > 0
+                        && i + 11 + ws + 2 <= len
+                        && rest[ws..ws + 2].eq_ignore_ascii_case(b"BY")
+                    {
+                        let by_end = i + 11 + ws + 2;
                         return Some((i, by_end));
                     }
                 }
+                i += 1;
+            }
+            _ => {
                 i += 1;
             }
         }
@@ -1645,6 +1678,25 @@ mod tests {
         let (rewritten, keys) = extract_partition_by("CREATE TABLE partitioned (id INT)").unwrap();
         assert_eq!(rewritten, "CREATE TABLE partitioned (id INT)");
         assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn test_extract_partition_by_skips_block_comment() {
+        let sql = "CREATE TABLE t (id INT) /* PARTITIONED BY (x) */ PARTITIONED BY (id)";
+        let (rewritten, keys) = extract_partition_by(sql).unwrap();
+        assert_eq!(keys, vec!["id"]);
+        assert!(rewritten.contains("/* PARTITIONED BY (x) */"));
+    }
+
+    #[test]
+    fn test_looks_like_create_table() {
+        assert!(looks_like_create_table("CREATE TABLE t (id INT)"));
+        assert!(looks_like_create_table("  create  table t (id INT)"));
+        assert!(looks_like_create_table(
+            "CREATE TABLE IF NOT EXISTS t (id INT)"
+        ));
+        assert!(!looks_like_create_table("ALTER TABLE t ADD COLUMN x INT"));
+        assert!(!looks_like_create_table("SELECT 1"));
     }
 
     // ==================== partition key validation tests ====================

--- a/crates/integrations/datafusion/tests/append_merge_into.rs
+++ b/crates/integrations/datafusion/tests/append_merge_into.rs
@@ -57,7 +57,7 @@ async fn setup_abc() -> (tempfile::TempDir, PaimonSqlHandler) {
 
 async fn setup_partitioned() -> (tempfile::TempDir, PaimonSqlHandler) {
     let (tmp, handler) =
-        setup("CREATE TABLE paimon.test_db.target (a INT, b INT, pt INT) PARTITIONED BY (pt INT)")
+        setup("CREATE TABLE paimon.test_db.target (a INT, b INT, pt INT) PARTITIONED BY (pt)")
             .await;
     exec(
         &handler,

--- a/crates/integrations/datafusion/tests/blob_tests.rs
+++ b/crates/integrations/datafusion/tests/blob_tests.rs
@@ -461,7 +461,7 @@ async fn test_blob_with_partition() {
             id INT, \
             picture BLOB, \
             pt STRING \
-         ) PARTITIONED BY (pt STRING) WITH (\
+         ) PARTITIONED BY (pt) WITH (\
             'data-evolution.enabled' = 'true', \
             'row-tracking.enabled' = 'true'\
          )",

--- a/crates/integrations/datafusion/tests/count_pushdown.rs
+++ b/crates/integrations/datafusion/tests/count_pushdown.rs
@@ -245,8 +245,7 @@ async fn test_count_star_empty_table_pushes_down() {
 
 #[tokio::test]
 async fn test_count_star_with_partition_filter_pushes_down() {
-    let (_tmp, handler) =
-        setup_partitioned_table("id INT, value INT, dt STRING", "dt STRING").await;
+    let (_tmp, handler) = setup_partitioned_table("id INT, value INT, dt STRING", "dt").await;
 
     handler
         .sql("INSERT INTO paimon.test_db.t VALUES (1, 10, '2024-01-01'), (2, 20, '2024-01-01'), (3, 30, '2024-01-02')")
@@ -277,8 +276,7 @@ async fn test_count_star_with_partition_filter_pushes_down() {
 
 #[tokio::test]
 async fn test_count_star_with_mixed_partition_data_filter_does_not_push_down() {
-    let (_tmp, handler) =
-        setup_partitioned_table("id INT, value INT, dt STRING", "dt STRING").await;
+    let (_tmp, handler) = setup_partitioned_table("id INT, value INT, dt STRING", "dt").await;
 
     handler
         .sql("INSERT INTO paimon.test_db.t VALUES (1, 10, '2024-01-01'), (2, 20, '2024-01-01'), (3, 30, '2024-01-02')")
@@ -313,8 +311,7 @@ async fn test_count_star_with_mixed_partition_data_filter_does_not_push_down() {
 
 #[tokio::test]
 async fn test_count_star_with_partition_in_filter_pushes_down() {
-    let (_tmp, handler) =
-        setup_partitioned_table("id INT, value INT, dt STRING", "dt STRING").await;
+    let (_tmp, handler) = setup_partitioned_table("id INT, value INT, dt STRING", "dt").await;
 
     handler
         .sql("INSERT INTO paimon.test_db.t VALUES (1, 10, '2024-01-01'), (2, 20, '2024-01-02'), (3, 30, '2024-01-03')")
@@ -345,8 +342,7 @@ async fn test_count_star_with_partition_in_filter_pushes_down() {
 
 #[tokio::test]
 async fn test_count_star_partitioned_no_filter_pushes_down() {
-    let (_tmp, handler) =
-        setup_partitioned_table("id INT, value INT, dt STRING", "dt STRING").await;
+    let (_tmp, handler) = setup_partitioned_table("id INT, value INT, dt STRING", "dt").await;
 
     handler
         .sql("INSERT INTO paimon.test_db.t VALUES (1, 10, '2024-01-01'), (2, 20, '2024-01-02')")

--- a/crates/integrations/datafusion/tests/cross_partition_tables.rs
+++ b/crates/integrations/datafusion/tests/cross_partition_tables.rs
@@ -40,7 +40,7 @@ async fn test_cross_partition_update_basic() {
             "CREATE TABLE paimon.test_db.t_cross_pt (
                 dt STRING, id INT NOT NULL, value INT,
                 PRIMARY KEY (id)
-            ) PARTITIONED BY (dt STRING)",
+            ) PARTITIONED BY (dt)",
         )
         .await
         .unwrap();
@@ -92,7 +92,7 @@ async fn test_cross_partition_update_multiple_keys() {
             "CREATE TABLE paimon.test_db.t_cross_multi (
                 dt STRING, id INT NOT NULL, name STRING,
                 PRIMARY KEY (id)
-            ) PARTITIONED BY (dt STRING)",
+            ) PARTITIONED BY (dt)",
         )
         .await
         .unwrap();
@@ -147,7 +147,7 @@ async fn test_cross_partition_update_three_commits() {
             "CREATE TABLE paimon.test_db.t_cross_3c (
                 dt STRING, id INT NOT NULL, value INT,
                 PRIMARY KEY (id)
-            ) PARTITIONED BY (dt STRING)",
+            ) PARTITIONED BY (dt)",
         )
         .await
         .unwrap();
@@ -207,7 +207,7 @@ async fn test_cross_partition_new_keys_no_migration() {
             "CREATE TABLE paimon.test_db.t_cross_new (
                 dt STRING, id INT NOT NULL, value INT,
                 PRIMARY KEY (id)
-            ) PARTITIONED BY (dt STRING)",
+            ) PARTITIONED BY (dt)",
         )
         .await
         .unwrap();
@@ -269,7 +269,7 @@ async fn test_cross_partition_delete_file_in_old_partition() {
             "CREATE TABLE paimon.test_db.t_cross_dv (
                 dt STRING, id INT NOT NULL, value INT,
                 PRIMARY KEY (id)
-            ) PARTITIONED BY (dt STRING)",
+            ) PARTITIONED BY (dt)",
         )
         .await
         .unwrap();
@@ -451,7 +451,7 @@ async fn test_cross_partition_first_row_skip() {
             "CREATE TABLE paimon.test_db.t_cross_fr (
                 dt STRING, id INT NOT NULL, value INT,
                 PRIMARY KEY (id)
-            ) PARTITIONED BY (dt STRING)
+            ) PARTITIONED BY (dt)
             WITH ('merge-engine' = 'first-row')",
         )
         .await
@@ -551,7 +551,7 @@ async fn test_cross_partition_partial_pk_partition_overlap() {
             "CREATE TABLE paimon.test_db.t_cross_partial (
                 pt1 STRING, pt2 STRING, id INT NOT NULL, value INT,
                 PRIMARY KEY (pt1, id)
-            ) PARTITIONED BY (pt1 STRING, pt2 STRING)",
+            ) PARTITIONED BY (pt1, pt2)",
         )
         .await
         .unwrap();
@@ -616,7 +616,7 @@ async fn test_cross_partition_value_kind_schema_stability() {
             "CREATE TABLE paimon.test_db.t_cross_vk (
                 dt STRING, id INT NOT NULL, value INT,
                 PRIMARY KEY (id)
-            ) PARTITIONED BY (dt STRING)",
+            ) PARTITIONED BY (dt)",
         )
         .await
         .unwrap();

--- a/crates/integrations/datafusion/tests/delete_tests.rs
+++ b/crates/integrations/datafusion/tests/delete_tests.rs
@@ -48,7 +48,7 @@ async fn setup_partitioned() -> (tempfile::TempDir, PaimonSqlHandler) {
     let handler = create_handler(catalog);
     handler.sql("CREATE SCHEMA paimon.test_db").await.unwrap();
     handler
-        .sql("CREATE TABLE paimon.test_db.t (id INT, name VARCHAR, pt INT) PARTITIONED BY (pt INT)")
+        .sql("CREATE TABLE paimon.test_db.t (id INT, name VARCHAR, pt INT) PARTITIONED BY (pt)")
         .await
         .unwrap();
     exec(

--- a/crates/integrations/datafusion/tests/dynamic_bucket_tables.rs
+++ b/crates/integrations/datafusion/tests/dynamic_bucket_tables.rs
@@ -90,7 +90,7 @@ async fn test_pk_dynamic_bucket_partitioned() {
             "CREATE TABLE paimon.test_db.t_dyn_part (
                 dt STRING, id INT NOT NULL, value INT,
                 PRIMARY KEY (dt, id)
-            ) PARTITIONED BY (dt STRING)",
+            ) PARTITIONED BY (dt)",
         )
         .await
         .unwrap();
@@ -349,7 +349,7 @@ async fn test_pk_dynamic_bucket_partitioned_insert_overwrite() {
             "CREATE TABLE paimon.test_db.t_dyn_part_ow (
                 dt STRING, id INT NOT NULL, value INT,
                 PRIMARY KEY (dt, id)
-            ) PARTITIONED BY (dt STRING)",
+            ) PARTITIONED BY (dt)",
         )
         .await
         .unwrap();

--- a/crates/integrations/datafusion/tests/merge_into_tests.rs
+++ b/crates/integrations/datafusion/tests/merge_into_tests.rs
@@ -877,7 +877,7 @@ async fn test_rejects_partition_column_in_set() {
         .sql(
             "CREATE TABLE paimon.test_db.part_target (\
                 pt STRING, id INT NOT NULL, name STRING\
-            ) PARTITIONED BY (pt STRING) WITH (\
+            ) PARTITIONED BY (pt) WITH (\
                 'row-tracking.enabled' = 'true'\
             )",
         )
@@ -1144,7 +1144,7 @@ async fn test_merge_insert_reordered_columns_on_partitioned_table() {
         .sql(
             "CREATE TABLE paimon.test_db.part_tbl (\
                 dt STRING, id INT NOT NULL, name STRING\
-            ) PARTITIONED BY (dt STRING) WITH (\
+            ) PARTITIONED BY (dt) WITH (\
                 'row-tracking.enabled' = 'true'\
             )",
         )

--- a/crates/integrations/datafusion/tests/pk_tables.rs
+++ b/crates/integrations/datafusion/tests/pk_tables.rs
@@ -224,7 +224,7 @@ async fn test_pk_partitioned_write_read() {
             "CREATE TABLE paimon.test_db.t_part (
                 dt STRING, id INT NOT NULL, name STRING,
                 PRIMARY KEY (dt, id)
-            ) PARTITIONED BY (dt STRING)
+            ) PARTITIONED BY (dt)
             WITH ('bucket' = '1')",
         )
         .await
@@ -269,7 +269,7 @@ async fn test_pk_partitioned_dedup_across_commits() {
             "CREATE TABLE paimon.test_db.t_part_dedup (
                 dt STRING, id INT NOT NULL, name STRING,
                 PRIMARY KEY (dt, id)
-            ) PARTITIONED BY (dt STRING)
+            ) PARTITIONED BY (dt)
             WITH ('bucket' = '1')",
         )
         .await
@@ -351,7 +351,7 @@ async fn test_pk_partitioned_filter() {
             "CREATE TABLE paimon.test_db.t_part_filter (
                 dt STRING, id INT NOT NULL, name STRING,
                 PRIMARY KEY (dt, id)
-            ) PARTITIONED BY (dt STRING)
+            ) PARTITIONED BY (dt)
             WITH ('bucket' = '1')",
         )
         .await
@@ -564,7 +564,7 @@ async fn test_pk_insert_overwrite_partitioned() {
             "CREATE TABLE paimon.test_db.t_overwrite (
                 dt STRING, id INT NOT NULL, name STRING,
                 PRIMARY KEY (dt, id)
-            ) PARTITIONED BY (dt STRING)
+            ) PARTITIONED BY (dt)
             WITH ('bucket' = '1')",
         )
         .await
@@ -797,7 +797,7 @@ async fn test_pk_partitioned_multi_bucket() {
             "CREATE TABLE paimon.test_db.t_part_mb (
                 dt STRING, id INT NOT NULL, value INT,
                 PRIMARY KEY (dt, id)
-            ) PARTITIONED BY (dt STRING)
+            ) PARTITIONED BY (dt)
             WITH ('bucket' = '2')",
         )
         .await
@@ -1069,7 +1069,7 @@ async fn test_pk_first_row_insert_overwrite() {
             "CREATE TABLE paimon.test_db.t_fr_ow (
                 dt STRING, id INT NOT NULL, name STRING,
                 PRIMARY KEY (dt, id)
-            ) PARTITIONED BY (dt STRING)
+            ) PARTITIONED BY (dt)
             WITH ('bucket' = '1', 'merge-engine' = 'first-row')",
         )
         .await
@@ -1295,7 +1295,7 @@ async fn test_pk_partitioned_fixed_bucket_predicate_query() {
             "CREATE TABLE paimon.test_db.t_bk_pred (
                 pt STRING, id INT NOT NULL, value INT,
                 PRIMARY KEY (pt, id)
-            ) PARTITIONED BY (pt STRING)
+            ) PARTITIONED BY (pt)
             WITH ('bucket' = '2')",
         )
         .await

--- a/crates/integrations/datafusion/tests/sql_handler_tests.rs
+++ b/crates/integrations/datafusion/tests/sql_handler_tests.rs
@@ -198,7 +198,7 @@ async fn test_create_table_with_partition() {
                 name STRING,
                 dt STRING,
                 PRIMARY KEY (id, dt)
-            ) PARTITIONED BY (dt STRING)
+            ) PARTITIONED BY (dt)
             WITH ('bucket' = '2')",
         )
         .await
@@ -215,6 +215,33 @@ async fn test_create_table_with_partition() {
         schema.options().get("bucket"),
         Some(&"2".to_string()),
         "Table option 'bucket' should be preserved"
+    );
+}
+
+#[tokio::test]
+async fn test_create_table_partitioned_by_rejects_typed_columns() {
+    let (_tmp, catalog) = create_test_env();
+    let handler = create_handler(catalog.clone());
+
+    catalog
+        .create_database("mydb", false, Default::default())
+        .await
+        .unwrap();
+
+    let err = handler
+        .sql(
+            "CREATE TABLE paimon.mydb.events (
+                id INT NOT NULL,
+                dt STRING
+            ) PARTITIONED BY (dt STRING)",
+        )
+        .await
+        .expect_err("PARTITIONED BY with typed columns should fail");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("should not specify a type"),
+        "unexpected error: {msg}"
     );
 }
 

--- a/crates/integrations/datafusion/tests/update_tests.rs
+++ b/crates/integrations/datafusion/tests/update_tests.rs
@@ -48,7 +48,7 @@ async fn setup_partitioned() -> (tempfile::TempDir, PaimonSqlHandler) {
     let handler = create_handler(catalog);
     handler.sql("CREATE SCHEMA paimon.test_db").await.unwrap();
     handler
-        .sql("CREATE TABLE paimon.test_db.t (id INT, name VARCHAR, pt INT) PARTITIONED BY (pt INT)")
+        .sql("CREATE TABLE paimon.test_db.t (id INT, name VARCHAR, pt INT) PARTITIONED BY (pt)")
         .await
         .unwrap();
     exec(


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
PARTITIONED BY should only accept column references, not column definitions with types. Extract and validate the clause before sqlparser parsing since GenericDialect requires types in column defs.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
