### PR TITLE
fix(datafusion): add error logging to catalog methods that silently swallow errors

### DIFF
--- a/crates/integrations/datafusion/Cargo.toml
+++ b/crates/integrations/datafusion/Cargo.toml
@@ -35,6 +35,7 @@ async-trait = "0.1"
 chrono = "0.4"
 constant_time_eq = { workspace = true }
 datafusion = { workspace = true }
+log = "0.4"
 paimon = { path = "../../paimon" }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/crates/integrations/datafusion/src/catalog.rs
+++ b/crates/integrations/datafusion/src/catalog.rs
@@ -66,7 +66,15 @@ impl CatalogProvider for PaimonCatalogProvider {
     fn schema_names(&self) -> Vec<String> {
         let catalog = Arc::clone(&self.catalog);
         block_on_with_runtime(
-            async move { catalog.list_databases().await.unwrap_or_default() },
+            async move {
+                match catalog.list_databases().await {
+                    Ok(names) => names,
+                    Err(e) => {
+                        log::error!("failed to list databases: {e}");
+                        vec![]
+                    }
+                }
+            },
             "paimon catalog access thread panicked",
         )
     }
@@ -82,7 +90,10 @@ impl CatalogProvider for PaimonCatalogProvider {
                             as Arc<dyn SchemaProvider>,
                     ),
                     Err(paimon::Error::DatabaseNotExist { .. }) => None,
-                    Err(_) => None,
+                    Err(e) => {
+                        log::error!("failed to get database '{}': {e}", name);
+                        None
+                    }
                 }
             },
             "paimon catalog access thread panicked",
@@ -170,7 +181,15 @@ impl SchemaProvider for PaimonSchemaProvider {
         let catalog = Arc::clone(&self.catalog);
         let database = self.database.clone();
         block_on_with_runtime(
-            async move { catalog.list_tables(&database).await.unwrap_or_default() },
+            async move {
+                match catalog.list_tables(&database).await {
+                    Ok(names) => names,
+                    Err(e) => {
+                        log::error!("failed to list tables in '{}': {e}", database);
+                        vec![]
+                    }
+                }
+            },
             "paimon catalog access thread panicked",
         )
     }
@@ -217,7 +236,10 @@ impl SchemaProvider for PaimonSchemaProvider {
                 match catalog.get_table(&identifier).await {
                     Ok(_) => true,
                     Err(paimon::Error::TableNotExist { .. }) => false,
-                    Err(_) => false,
+                    Err(e) => {
+                        log::error!("failed to check table '{}': {e}", identifier);
+                        false
+                    }
                 }
             },
             "paimon catalog access thread panicked",


### PR DESCRIPTION
…wallow errors

The CatalogProvider/SchemaProvider trait methods schema_names(), schema(), table_names(), and table_exist() have no Result return type, so errors from remote catalog operations were silently discarded. Add log::error! to surface these failures for debugging.

<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose
  Linked issue: N/A (no existing issue — upstream trait limitation)

  Add `log::error!` to 4 `CatalogProvider`/`SchemaProvider` trait methods that silently discard errors from remote catalog operations, making failures visible for debugging.

  ### Brief change log

  - `schema_names()`: replace `unwrap_or_default()` with `match` + `log::error!` on `Err`
  - `schema()`: replace `Err(_) => None` with `log::error!` before returning `None`
  - `table_names()`: replace `unwrap_or_default()` with `match` + `log::error!` on `Err`
  - `table_exist()`: replace `Err(_) => false` with `log::error!` before returning `false`
  - Add `log = "0.4"` dependency to `paimon-datafusion`

  These 4 methods have no `Result` return type in the upstream DataFusion trait, so logging is the best we can do. A proper fix requires changing the upstream trait signatures (to
  be proposed separately as a breaking API change on apache/datafusion).

  ### Tests

  - Existing tests pass (`cargo test -p paimon-datafusion`)
  - Manual: set `RUST_LOG=error` and trigger a catalog error to verify log output

  ### API and Format

  No API or format changes.

  ### Documentation

  No documentation changes needed.
