### PR TITLE
feat(datafusion): add session-scoped dynamic options via SET/RESET

### DIFF
--- a/bindings/python/src/context.rs
+++ b/bindings/python/src/context.rs
@@ -37,7 +37,10 @@ fn build_paimon_catalog_provider(
         let options = Options::from_map(catalog_options);
         let catalog = CatalogFactory::create(options).await.map_err(to_py_err)?;
         let dynamic_options = Arc::new(RwLock::new(HashMap::new()));
-        Ok::<_, PyErr>(Arc::new(PaimonCatalogProvider::new(catalog, dynamic_options)))
+        Ok::<_, PyErr>(Arc::new(PaimonCatalogProvider::new(
+            catalog,
+            dynamic_options,
+        )))
     })
 }
 

--- a/bindings/python/src/context.rs
+++ b/bindings/python/src/context.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use datafusion::catalog::CatalogProvider;
 use datafusion_ffi::catalog_provider::FFI_CatalogProvider;
@@ -36,7 +36,8 @@ fn build_paimon_catalog_provider(
     rt.block_on(async {
         let options = Options::from_map(catalog_options);
         let catalog = CatalogFactory::create(options).await.map_err(to_py_err)?;
-        Ok::<_, PyErr>(Arc::new(PaimonCatalogProvider::new(catalog)))
+        let dynamic_options = Arc::new(RwLock::new(HashMap::new()));
+        Ok::<_, PyErr>(Arc::new(PaimonCatalogProvider::new(catalog, dynamic_options)))
     })
 }
 

--- a/crates/integrations/datafusion/src/catalog.rs
+++ b/crates/integrations/datafusion/src/catalog.rs
@@ -53,18 +53,10 @@ impl Debug for PaimonCatalogProvider {
 }
 
 impl PaimonCatalogProvider {
-    /// Creates a new [`PaimonCatalogProvider`].
+    /// Creates a new [`PaimonCatalogProvider`] with shared dynamic options.
     ///
     /// All data is loaded lazily when accessed.
-    pub fn new(catalog: Arc<dyn Catalog>) -> Self {
-        Self::with_dynamic_options(catalog, Default::default())
-    }
-
-    /// Creates a new [`PaimonCatalogProvider`] with shared dynamic options.
-    pub fn with_dynamic_options(
-        catalog: Arc<dyn Catalog>,
-        dynamic_options: DynamicOptions,
-    ) -> Self {
+    pub fn new(catalog: Arc<dyn Catalog>, dynamic_options: DynamicOptions) -> Self {
         PaimonCatalogProvider {
             catalog,
             dynamic_options,
@@ -100,7 +92,7 @@ impl CatalogProvider for PaimonCatalogProvider {
         block_on_with_runtime(
             async move {
                 match catalog.get_database(&name).await {
-                    Ok(_) => Some(Arc::new(PaimonSchemaProvider::with_dynamic_options(
+                    Ok(_) => Some(Arc::new(PaimonSchemaProvider::new(
                         Arc::clone(&catalog),
                         name,
                         dynamic_options,
@@ -130,7 +122,7 @@ impl CatalogProvider for PaimonCatalogProvider {
                     .create_database(&name, false, HashMap::new())
                     .await
                     .map_err(to_datafusion_error)?;
-                Ok(Some(Arc::new(PaimonSchemaProvider::with_dynamic_options(
+                Ok(Some(Arc::new(PaimonSchemaProvider::new(
                     Arc::clone(&catalog),
                     name,
                     dynamic_options,
@@ -154,7 +146,7 @@ impl CatalogProvider for PaimonCatalogProvider {
                     .drop_database(&name, false, cascade)
                     .await
                     .map_err(to_datafusion_error)?;
-                Ok(Some(Arc::new(PaimonSchemaProvider::with_dynamic_options(
+                Ok(Some(Arc::new(PaimonSchemaProvider::new(
                     Arc::clone(&catalog),
                     name,
                     dynamic_options,
@@ -187,13 +179,8 @@ impl Debug for PaimonSchemaProvider {
 }
 
 impl PaimonSchemaProvider {
-    /// Creates a new [`PaimonSchemaProvider`] for the given database.
-    pub fn new(catalog: Arc<dyn Catalog>, database: String) -> Self {
-        Self::with_dynamic_options(catalog, database, Default::default())
-    }
-
     /// Creates a new [`PaimonSchemaProvider`] with shared dynamic options.
-    pub fn with_dynamic_options(
+    pub fn new(
         catalog: Arc<dyn Catalog>,
         database: String,
         dynamic_options: DynamicOptions,

--- a/crates/integrations/datafusion/src/catalog.rs
+++ b/crates/integrations/datafusion/src/catalog.rs
@@ -32,6 +32,7 @@ use crate::error::to_datafusion_error;
 use crate::runtime::{await_with_runtime, block_on_with_runtime};
 use crate::system_tables;
 use crate::table::PaimonTableProvider;
+use crate::DynamicOptions;
 
 /// Provides an interface to manage and access multiple schemas (databases)
 /// within a Paimon [`Catalog`].
@@ -41,6 +42,8 @@ use crate::table::PaimonTableProvider;
 pub struct PaimonCatalogProvider {
     /// Reference to the Paimon catalog.
     catalog: Arc<dyn Catalog>,
+    /// Session-scoped dynamic options shared with the SQL handler.
+    dynamic_options: DynamicOptions,
 }
 
 impl Debug for PaimonCatalogProvider {
@@ -54,7 +57,18 @@ impl PaimonCatalogProvider {
     ///
     /// All data is loaded lazily when accessed.
     pub fn new(catalog: Arc<dyn Catalog>) -> Self {
-        PaimonCatalogProvider { catalog }
+        Self::with_dynamic_options(catalog, Default::default())
+    }
+
+    /// Creates a new [`PaimonCatalogProvider`] with shared dynamic options.
+    pub fn with_dynamic_options(
+        catalog: Arc<dyn Catalog>,
+        dynamic_options: DynamicOptions,
+    ) -> Self {
+        PaimonCatalogProvider {
+            catalog,
+            dynamic_options,
+        }
     }
 }
 
@@ -81,14 +95,16 @@ impl CatalogProvider for PaimonCatalogProvider {
 
     fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
         let catalog = Arc::clone(&self.catalog);
+        let dynamic_options = Arc::clone(&self.dynamic_options);
         let name = name.to_string();
         block_on_with_runtime(
             async move {
                 match catalog.get_database(&name).await {
-                    Ok(_) => Some(
-                        Arc::new(PaimonSchemaProvider::new(Arc::clone(&catalog), name))
-                            as Arc<dyn SchemaProvider>,
-                    ),
+                    Ok(_) => Some(Arc::new(PaimonSchemaProvider::with_dynamic_options(
+                        Arc::clone(&catalog),
+                        name,
+                        dynamic_options,
+                    )) as Arc<dyn SchemaProvider>),
                     Err(paimon::Error::DatabaseNotExist { .. }) => None,
                     Err(e) => {
                         log::error!("failed to get database '{}': {e}", name);
@@ -106,6 +122,7 @@ impl CatalogProvider for PaimonCatalogProvider {
         _schema: Arc<dyn SchemaProvider>,
     ) -> DFResult<Option<Arc<dyn SchemaProvider>>> {
         let catalog = Arc::clone(&self.catalog);
+        let dynamic_options = Arc::clone(&self.dynamic_options);
         let name = name.to_string();
         block_on_with_runtime(
             async move {
@@ -113,10 +130,11 @@ impl CatalogProvider for PaimonCatalogProvider {
                     .create_database(&name, false, HashMap::new())
                     .await
                     .map_err(to_datafusion_error)?;
-                Ok(Some(
-                    Arc::new(PaimonSchemaProvider::new(Arc::clone(&catalog), name))
-                        as Arc<dyn SchemaProvider>,
-                ))
+                Ok(Some(Arc::new(PaimonSchemaProvider::with_dynamic_options(
+                    Arc::clone(&catalog),
+                    name,
+                    dynamic_options,
+                )) as Arc<dyn SchemaProvider>))
             },
             "paimon catalog access thread panicked",
         )
@@ -128,6 +146,7 @@ impl CatalogProvider for PaimonCatalogProvider {
         cascade: bool,
     ) -> DFResult<Option<Arc<dyn SchemaProvider>>> {
         let catalog = Arc::clone(&self.catalog);
+        let dynamic_options = Arc::clone(&self.dynamic_options);
         let name = name.to_string();
         block_on_with_runtime(
             async move {
@@ -135,10 +154,11 @@ impl CatalogProvider for PaimonCatalogProvider {
                     .drop_database(&name, false, cascade)
                     .await
                     .map_err(to_datafusion_error)?;
-                Ok(Some(
-                    Arc::new(PaimonSchemaProvider::new(Arc::clone(&catalog), name))
-                        as Arc<dyn SchemaProvider>,
-                ))
+                Ok(Some(Arc::new(PaimonSchemaProvider::with_dynamic_options(
+                    Arc::clone(&catalog),
+                    name,
+                    dynamic_options,
+                )) as Arc<dyn SchemaProvider>))
             },
             "paimon catalog access thread panicked",
         )
@@ -154,6 +174,8 @@ pub struct PaimonSchemaProvider {
     catalog: Arc<dyn Catalog>,
     /// Database name this schema represents.
     database: String,
+    /// Session-scoped dynamic options shared with the SQL handler.
+    dynamic_options: DynamicOptions,
 }
 
 impl Debug for PaimonSchemaProvider {
@@ -167,7 +189,20 @@ impl Debug for PaimonSchemaProvider {
 impl PaimonSchemaProvider {
     /// Creates a new [`PaimonSchemaProvider`] for the given database.
     pub fn new(catalog: Arc<dyn Catalog>, database: String) -> Self {
-        PaimonSchemaProvider { catalog, database }
+        Self::with_dynamic_options(catalog, database, Default::default())
+    }
+
+    /// Creates a new [`PaimonSchemaProvider`] with shared dynamic options.
+    pub fn with_dynamic_options(
+        catalog: Arc<dyn Catalog>,
+        database: String,
+        dynamic_options: DynamicOptions,
+    ) -> Self {
+        PaimonSchemaProvider {
+            catalog,
+            database,
+            dynamic_options,
+        }
     }
 }
 
@@ -207,10 +242,17 @@ impl SchemaProvider for PaimonSchemaProvider {
         }
 
         let catalog = Arc::clone(&self.catalog);
+        let dynamic_options = Arc::clone(&self.dynamic_options);
         let identifier = Identifier::new(self.database.clone(), base);
         await_with_runtime(async move {
             match catalog.get_table(&identifier).await {
                 Ok(table) => {
+                    let opts = dynamic_options.read().unwrap().clone();
+                    let table = if opts.is_empty() {
+                        table
+                    } else {
+                        table.copy_with_options(opts)
+                    };
                     let provider = PaimonTableProvider::try_new(table)?;
                     Ok(Some(Arc::new(provider) as Arc<dyn TableProvider>))
                 }

--- a/crates/integrations/datafusion/src/lib.rs
+++ b/crates/integrations/datafusion/src/lib.rs
@@ -51,6 +51,16 @@ mod system_tables;
 mod table;
 mod update;
 
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+/// Session-scoped dynamic options set via `SET 'paimon.key' = 'value'`.
+///
+/// Shared across [`PaimonSqlHandler`], [`PaimonCatalogProvider`], and
+/// [`PaimonSchemaProvider`] so that SET/RESET mutations are visible to
+/// subsequent table scans.
+pub type DynamicOptions = Arc<RwLock<HashMap<String, String>>>;
+
 pub use catalog::{PaimonCatalogProvider, PaimonSchemaProvider};
 pub use error::to_datafusion_error;
 #[cfg(feature = "fulltext")]

--- a/crates/integrations/datafusion/src/merge_into.rs
+++ b/crates/integrations/datafusion/src/merge_into.rs
@@ -1438,7 +1438,8 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::{
-        PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler, PaimonTableProvider,
+        DynamicOptions, PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler,
+        PaimonTableProvider,
     };
 
     async fn setup_handler() -> (TempDir, PaimonSqlHandler, Arc<FileSystemCatalog>) {
@@ -1448,14 +1449,18 @@ mod tests {
         options.set(CatalogOptions::WAREHOUSE, warehouse);
         let catalog = Arc::new(FileSystemCatalog::new(options).unwrap());
 
+        let dynamic_options: DynamicOptions = Default::default();
         let ctx = SessionContext::new();
         ctx.register_catalog(
             "paimon",
-            Arc::new(PaimonCatalogProvider::new(catalog.clone())),
+            Arc::new(PaimonCatalogProvider::new(
+                catalog.clone(),
+                dynamic_options.clone(),
+            )),
         );
         ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
             .unwrap();
-        let handler = PaimonSqlHandler::new(ctx, catalog.clone(), "paimon");
+        let handler = PaimonSqlHandler::new(ctx, catalog.clone(), "paimon", dynamic_options);
         handler.sql("CREATE SCHEMA paimon.test_db").await.unwrap();
 
         (temp_dir, handler, catalog)

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -39,7 +39,8 @@ use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::sql::sqlparser::ast::{
     AlterTableOperation, ColumnDef, CreateTable, CreateTableOptions, Delete, FromTable, Merge,
-    ObjectName, RenameTableNameKind, SqlOption, Statement, TableFactor, Update,
+    ObjectName, RenameTableNameKind, Reset, ResetStatement, Set, SqlOption, Statement, TableFactor,
+    Update,
 };
 use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
@@ -52,6 +53,7 @@ use paimon::spec::{
 };
 
 use crate::error::to_datafusion_error;
+use crate::DynamicOptions;
 
 /// Wraps a [`SessionContext`] and a Paimon [`Catalog`] to handle DDL statements
 /// that DataFusion does not natively support (e.g. ALTER TABLE).
@@ -68,6 +70,8 @@ pub struct PaimonSqlHandler {
     catalog: Arc<dyn Catalog>,
     /// The catalog name registered in the SessionContext (used to strip the catalog prefix).
     catalog_name: String,
+    /// Session-scoped dynamic options set via `SET 'paimon.key' = 'value'`.
+    dynamic_options: DynamicOptions,
 }
 
 impl PaimonSqlHandler {
@@ -76,16 +80,36 @@ impl PaimonSqlHandler {
         catalog: Arc<dyn Catalog>,
         catalog_name: impl Into<String>,
     ) -> Self {
+        Self::with_dynamic_options(ctx, catalog, catalog_name, Default::default())
+    }
+
+    /// Creates a new handler with shared dynamic options.
+    ///
+    /// Use this when the same `DynamicOptions` is also passed to
+    /// [`PaimonCatalogProvider::with_dynamic_options`] so that `SET` mutations
+    /// are visible to subsequent table scans.
+    pub fn with_dynamic_options(
+        ctx: SessionContext,
+        catalog: Arc<dyn Catalog>,
+        catalog_name: impl Into<String>,
+        dynamic_options: DynamicOptions,
+    ) -> Self {
         Self {
             ctx,
             catalog,
             catalog_name: catalog_name.into(),
+            dynamic_options,
         }
     }
 
     /// Returns a reference to the inner [`SessionContext`].
     pub fn ctx(&self) -> &SessionContext {
         &self.ctx
+    }
+
+    /// Returns a reference to the shared dynamic options.
+    pub fn dynamic_options(&self) -> &DynamicOptions {
+        &self.dynamic_options
     }
 
     /// Execute a SQL statement. ALTER TABLE is handled by Paimon directly;
@@ -122,6 +146,40 @@ impl PaimonSqlHandler {
             Statement::Merge(merge) => self.handle_merge_into(merge).await,
             Statement::Update(update) => self.handle_update(update).await,
             Statement::Delete(delete) => self.handle_delete(delete).await,
+            Statement::Set(Set::SingleAssignment {
+                variable, values, ..
+            }) => {
+                let key = variable.to_string();
+                let key = key.trim_matches('\'').trim_matches('"');
+                if let Some(paimon_key) = key.strip_prefix("paimon.") {
+                    let value = values
+                        .first()
+                        .ok_or_else(|| DataFusionError::Plan("SET requires a value".to_string()))?
+                        .to_string();
+                    let value = value
+                        .strip_prefix('\'')
+                        .and_then(|s| s.strip_suffix('\''))
+                        .unwrap_or(&value)
+                        .to_string();
+                    self.dynamic_options
+                        .write()
+                        .unwrap()
+                        .insert(paimon_key.to_string(), value);
+                    return ok_result(&self.ctx);
+                }
+                self.ctx.sql(sql).await
+            }
+            Statement::Reset(ResetStatement {
+                reset: Reset::ConfigurationParameter(name),
+            }) => {
+                let key = name.to_string();
+                let key = key.trim_matches('\'').trim_matches('"');
+                if let Some(paimon_key) = key.strip_prefix("paimon.") {
+                    self.dynamic_options.write().unwrap().remove(paimon_key);
+                    return ok_result(&self.ctx);
+                }
+                self.ctx.sql(sql).await
+            }
             _ => self.ctx.sql(sql).await,
         }
     }
@@ -1772,5 +1830,86 @@ mod tests {
         } else {
             panic!("expected CreateTable call");
         }
+    }
+
+    // ==================== SET / RESET dynamic options tests ====================
+
+    #[tokio::test]
+    async fn test_set_paimon_option() {
+        let catalog = Arc::new(MockCatalog::new());
+        let handler = make_handler(catalog);
+        handler
+            .sql("SET 'paimon.scan.version' = '1'")
+            .await
+            .unwrap();
+        let opts = handler.dynamic_options().read().unwrap();
+        assert_eq!(opts.get("scan.version").unwrap(), "1");
+    }
+
+    #[tokio::test]
+    async fn test_set_paimon_option_overwrites() {
+        let catalog = Arc::new(MockCatalog::new());
+        let handler = make_handler(catalog);
+        handler
+            .sql("SET 'paimon.scan.version' = '1'")
+            .await
+            .unwrap();
+        handler
+            .sql("SET 'paimon.scan.version' = '2'")
+            .await
+            .unwrap();
+        let opts = handler.dynamic_options().read().unwrap();
+        assert_eq!(opts.get("scan.version").unwrap(), "2");
+    }
+
+    #[tokio::test]
+    async fn test_reset_paimon_option() {
+        let catalog = Arc::new(MockCatalog::new());
+        let handler = make_handler(catalog);
+        handler
+            .sql("SET 'paimon.scan.version' = '1'")
+            .await
+            .unwrap();
+        handler.sql("RESET 'paimon.scan.version'").await.unwrap();
+        let opts = handler.dynamic_options().read().unwrap();
+        assert!(opts.get("scan.version").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_set_non_paimon_option_delegates() {
+        let catalog = Arc::new(MockCatalog::new());
+        let handler = make_handler(catalog);
+        // DataFusion handles non-paimon SET; should not error and should not
+        // appear in dynamic_options.
+        let _ = handler.sql("SET datafusion.optimizer.max_passes = 3").await;
+        let opts = handler.dynamic_options().read().unwrap();
+        assert!(opts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_set_multiple_paimon_options() {
+        let catalog = Arc::new(MockCatalog::new());
+        let handler = make_handler(catalog);
+        handler
+            .sql("SET 'paimon.scan.version' = '1'")
+            .await
+            .unwrap();
+        handler
+            .sql("SET 'paimon.scan.timestamp-millis' = '1000'")
+            .await
+            .unwrap();
+        let opts = handler.dynamic_options().read().unwrap();
+        assert_eq!(opts.len(), 2);
+        assert_eq!(opts.get("scan.version").unwrap(), "1");
+        assert_eq!(opts.get("scan.timestamp-millis").unwrap(), "1000");
+    }
+
+    #[tokio::test]
+    async fn test_reset_nonexistent_paimon_option_is_noop() {
+        let catalog = Arc::new(MockCatalog::new());
+        let handler = make_handler(catalog);
+        handler.sql("RESET 'paimon.scan.version'").await.unwrap();
+        let opts = handler.dynamic_options().read().unwrap();
+        assert!(opts.is_empty());
     }
 }

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -62,7 +62,8 @@ use crate::DynamicOptions;
 ///
 /// # Example
 /// ```ignore
-/// let handler = PaimonSqlHandler::new(ctx, catalog);
+/// let dynamic_options: DynamicOptions = Default::default();
+/// let handler = PaimonSqlHandler::new(ctx, catalog, "paimon", dynamic_options);
 /// let df = handler.sql("ALTER TABLE paimon.db.t ADD COLUMN age INT").await?;
 /// ```
 pub struct PaimonSqlHandler {
@@ -75,20 +76,12 @@ pub struct PaimonSqlHandler {
 }
 
 impl PaimonSqlHandler {
-    pub fn new(
-        ctx: SessionContext,
-        catalog: Arc<dyn Catalog>,
-        catalog_name: impl Into<String>,
-    ) -> Self {
-        Self::with_dynamic_options(ctx, catalog, catalog_name, Default::default())
-    }
-
     /// Creates a new handler with shared dynamic options.
     ///
-    /// Use this when the same `DynamicOptions` is also passed to
-    /// [`PaimonCatalogProvider::with_dynamic_options`] so that `SET` mutations
+    /// The same `DynamicOptions` should also be passed to
+    /// [`PaimonCatalogProvider::new`] so that `SET` mutations
     /// are visible to subsequent table scans.
-    pub fn with_dynamic_options(
+    pub fn new(
         ctx: SessionContext,
         catalog: Arc<dyn Catalog>,
         catalog_name: impl Into<String>,
@@ -966,7 +959,7 @@ mod tests {
     }
 
     fn make_handler(catalog: Arc<MockCatalog>) -> PaimonSqlHandler {
-        PaimonSqlHandler::new(SessionContext::new(), catalog, "paimon")
+        PaimonSqlHandler::new(SessionContext::new(), catalog, "paimon", Default::default())
     }
 
     fn assert_sql_type_to_paimon(

--- a/crates/integrations/datafusion/src/update.rs
+++ b/crates/integrations/datafusion/src/update.rs
@@ -336,7 +336,8 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::{
-        PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler, PaimonTableProvider,
+        DynamicOptions, PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler,
+        PaimonTableProvider,
     };
 
     async fn setup_handler() -> (TempDir, PaimonSqlHandler, Arc<FileSystemCatalog>) {
@@ -346,14 +347,18 @@ mod tests {
         options.set(CatalogOptions::WAREHOUSE, warehouse);
         let catalog = Arc::new(FileSystemCatalog::new(options).unwrap());
 
+        let dynamic_options: DynamicOptions = Default::default();
         let ctx = SessionContext::new();
         ctx.register_catalog(
             "paimon",
-            Arc::new(PaimonCatalogProvider::new(catalog.clone())),
+            Arc::new(PaimonCatalogProvider::new(
+                catalog.clone(),
+                dynamic_options.clone(),
+            )),
         );
         ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
             .unwrap();
-        let handler = PaimonSqlHandler::new(ctx, catalog.clone(), "paimon");
+        let handler = PaimonSqlHandler::new(ctx, catalog.clone(), "paimon", dynamic_options);
         handler.sql("CREATE SCHEMA paimon.test_db").await.unwrap();
 
         (temp_dir, handler, catalog)

--- a/crates/integrations/datafusion/tests/blob_tests.rs
+++ b/crates/integrations/datafusion/tests/blob_tests.rs
@@ -702,3 +702,63 @@ async fn test_blob_descriptor_field_resolve_descriptor_value() {
         ]
     );
 }
+
+/// SET 'paimon.blob-as-descriptor' = 'true' should return serialized BlobDescriptor
+/// bytes instead of the actual blob content.
+#[tokio::test]
+async fn test_blob_as_descriptor_dynamic_option() {
+    let (_tmp, handler) = setup(BLOB_TABLE_DDL).await;
+
+    exec(
+        &handler,
+        "INSERT INTO paimon.test_db.t (id, name, picture) VALUES \
+         (1, 'Alice', X'48656C6C6F'), \
+         (2, 'Bob', X'576F726C64')",
+    )
+    .await;
+
+    // Without the option, we get raw blob data.
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows[0].2, Some(b"Hello".to_vec()));
+
+    // Enable blob-as-descriptor via dynamic option.
+    handler
+        .sql("SET 'paimon.blob-as-descriptor' = 'true'")
+        .await
+        .unwrap();
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows.len(), 2);
+
+    // The returned bytes should be valid BlobDescriptors, not raw data.
+    let desc_bytes = rows[0].2.as_ref().expect("expected descriptor bytes");
+    assert!(
+        BlobDescriptor::is_blob_descriptor(desc_bytes),
+        "expected BlobDescriptor, got raw data"
+    );
+    let desc = BlobDescriptor::deserialize(desc_bytes).expect("failed to deserialize descriptor");
+    assert!(desc.uri().starts_with("file://"), "uri: {}", desc.uri());
+    assert!(desc.length() > 0);
+
+    // RESET should go back to raw data.
+    handler
+        .sql("RESET 'paimon.blob-as-descriptor'")
+        .await
+        .unwrap();
+
+    let rows = query_id_name_picture(
+        &handler,
+        "SELECT id, name, picture FROM paimon.test_db.t ORDER BY id",
+    )
+    .await;
+    assert_eq!(rows[0].2, Some(b"Hello".to_vec()));
+    assert_eq!(rows[1].2, Some(b"World".to_vec()));
+}

--- a/crates/integrations/datafusion/tests/common/mod.rs
+++ b/crates/integrations/datafusion/tests/common/mod.rs
@@ -17,12 +17,15 @@
 
 //! Shared test helpers for DataFusion integration tests.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use datafusion::arrow::array::{Int32Array, StringArray};
 use datafusion::prelude::SessionContext;
 use paimon::{CatalogOptions, FileSystemCatalog, Options};
-use paimon_datafusion::{PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler};
+use paimon_datafusion::{
+    DynamicOptions, PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler,
+};
 use tempfile::TempDir;
 
 use arrow_array::{Array, RecordBatch, UInt64Array};
@@ -37,14 +40,18 @@ pub fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
 }
 
 pub fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
+    let dynamic_options: DynamicOptions = Arc::new(RwLock::new(HashMap::new()));
     let ctx = SessionContext::new();
     ctx.register_catalog(
         "paimon",
-        Arc::new(PaimonCatalogProvider::new(catalog.clone())),
+        Arc::new(PaimonCatalogProvider::with_dynamic_options(
+            catalog.clone(),
+            dynamic_options.clone(),
+        )),
     );
     ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
         .expect("Failed to register relation planner");
-    PaimonSqlHandler::new(ctx, catalog, "paimon")
+    PaimonSqlHandler::with_dynamic_options(ctx, catalog, "paimon", dynamic_options)
 }
 
 #[allow(dead_code)]

--- a/crates/integrations/datafusion/tests/common/mod.rs
+++ b/crates/integrations/datafusion/tests/common/mod.rs
@@ -44,14 +44,14 @@ pub fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
     let ctx = SessionContext::new();
     ctx.register_catalog(
         "paimon",
-        Arc::new(PaimonCatalogProvider::with_dynamic_options(
+        Arc::new(PaimonCatalogProvider::new(
             catalog.clone(),
             dynamic_options.clone(),
         )),
     );
     ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
         .expect("Failed to register relation planner");
-    PaimonSqlHandler::with_dynamic_options(ctx, catalog, "paimon", dynamic_options)
+    PaimonSqlHandler::new(ctx, catalog, "paimon", dynamic_options)
 }
 
 #[allow(dead_code)]

--- a/crates/integrations/datafusion/tests/merge_into_tests.rs
+++ b/crates/integrations/datafusion/tests/merge_into_tests.rs
@@ -28,7 +28,9 @@ use datafusion::prelude::SessionContext;
 use paimon::catalog::Identifier;
 use paimon::table::SnapshotManager;
 use paimon::{Catalog, CatalogOptions, FileSystemCatalog, Options};
-use paimon_datafusion::{PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler};
+use paimon_datafusion::{
+    DynamicOptions, PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler,
+};
 use tempfile::TempDir;
 
 // ======================= Helpers =======================
@@ -43,14 +45,18 @@ fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
 }
 
 fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
+    let dynamic_options: DynamicOptions = Default::default();
     let ctx = SessionContext::new();
     ctx.register_catalog(
         "paimon",
-        Arc::new(PaimonCatalogProvider::new(catalog.clone())),
+        Arc::new(PaimonCatalogProvider::new(
+            catalog.clone(),
+            dynamic_options.clone(),
+        )),
     );
     ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
         .expect("Failed to register relation planner");
-    PaimonSqlHandler::new(ctx, catalog, "paimon")
+    PaimonSqlHandler::new(ctx, catalog, "paimon", dynamic_options)
 }
 
 async fn setup_data_evolution_table(handler: &PaimonSqlHandler) {

--- a/crates/integrations/datafusion/tests/read_tables.rs
+++ b/crates/integrations/datafusion/tests/read_tables.rs
@@ -507,7 +507,7 @@ async fn test_residual_filter_limit_keeps_connector_limit_and_correctness() {
 #[tokio::test]
 async fn test_query_via_catalog_provider() {
     let catalog = create_catalog();
-    let provider = PaimonCatalogProvider::new(Arc::new(catalog));
+    let provider = PaimonCatalogProvider::new(Arc::new(catalog), Default::default());
 
     let ctx = SessionContext::new();
     ctx.register_catalog("paimon", Arc::new(provider));
@@ -525,7 +525,7 @@ async fn test_query_via_catalog_provider() {
 #[tokio::test]
 async fn test_missing_database_returns_no_schema() {
     let catalog = create_catalog();
-    let provider = PaimonCatalogProvider::new(Arc::new(catalog));
+    let provider = PaimonCatalogProvider::new(Arc::new(catalog), Default::default());
 
     assert!(
         provider.schema("definitely_missing_database").is_none(),
@@ -543,7 +543,7 @@ async fn create_time_travel_context() -> SessionContext {
     let ctx = SessionContext::new_with_config(config);
     ctx.register_catalog(
         "paimon",
-        Arc::new(PaimonCatalogProvider::new(Arc::new(catalog))),
+        Arc::new(PaimonCatalogProvider::new(Arc::new(catalog), Default::default())),
     );
     ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
         .expect("Failed to register relation planner");
@@ -963,7 +963,7 @@ mod fulltext_tests {
         let ctx = SessionContext::new();
         ctx.register_catalog(
             "paimon",
-            Arc::new(PaimonCatalogProvider::new(Arc::clone(&catalog))),
+            Arc::new(PaimonCatalogProvider::new(Arc::clone(&catalog), Default::default())),
         );
         register_full_text_search(&ctx, catalog, "default");
         (ctx, tmp)

--- a/crates/integrations/datafusion/tests/read_tables.rs
+++ b/crates/integrations/datafusion/tests/read_tables.rs
@@ -543,7 +543,10 @@ async fn create_time_travel_context() -> SessionContext {
     let ctx = SessionContext::new_with_config(config);
     ctx.register_catalog(
         "paimon",
-        Arc::new(PaimonCatalogProvider::new(Arc::new(catalog), Default::default())),
+        Arc::new(PaimonCatalogProvider::new(
+            Arc::new(catalog),
+            Default::default(),
+        )),
     );
     ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
         .expect("Failed to register relation planner");
@@ -963,7 +966,10 @@ mod fulltext_tests {
         let ctx = SessionContext::new();
         ctx.register_catalog(
             "paimon",
-            Arc::new(PaimonCatalogProvider::new(Arc::clone(&catalog), Default::default())),
+            Arc::new(PaimonCatalogProvider::new(
+                Arc::clone(&catalog),
+                Default::default(),
+            )),
         );
         register_full_text_search(&ctx, catalog, "default");
         (ctx, tmp)

--- a/crates/integrations/datafusion/tests/sql_handler_tests.rs
+++ b/crates/integrations/datafusion/tests/sql_handler_tests.rs
@@ -24,7 +24,9 @@ use datafusion::prelude::SessionContext;
 use paimon::catalog::Identifier;
 use paimon::spec::{ArrayType, BlobType, DataType, IntType, MapType, VarCharType};
 use paimon::{Catalog, CatalogOptions, FileSystemCatalog, Options};
-use paimon_datafusion::{PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler};
+use paimon_datafusion::{
+    DynamicOptions, PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler,
+};
 use tempfile::TempDir;
 
 fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
@@ -37,14 +39,18 @@ fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
 }
 
 fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
+    let dynamic_options: DynamicOptions = Default::default();
     let ctx = SessionContext::new();
     ctx.register_catalog(
         "paimon",
-        Arc::new(PaimonCatalogProvider::new(catalog.clone())),
+        Arc::new(PaimonCatalogProvider::new(
+            catalog.clone(),
+            dynamic_options.clone(),
+        )),
     );
     ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
         .expect("Failed to register relation planner");
-    PaimonSqlHandler::new(ctx, catalog, "paimon")
+    PaimonSqlHandler::new(ctx, catalog, "paimon", dynamic_options)
 }
 
 // ======================= CREATE / DROP SCHEMA =======================
@@ -91,7 +97,7 @@ async fn test_drop_schema() {
 #[tokio::test]
 async fn test_schema_names_via_catalog_provider() {
     let (_tmp, catalog) = create_test_env();
-    let provider = PaimonCatalogProvider::new(catalog.clone());
+    let provider = PaimonCatalogProvider::new(catalog.clone(), Default::default());
 
     catalog
         .create_database("db_a", false, Default::default())

--- a/crates/integrations/datafusion/tests/system_tables.rs
+++ b/crates/integrations/datafusion/tests/system_tables.rs
@@ -56,7 +56,10 @@ async fn create_context() -> (SessionContext, Arc<dyn Catalog>, tempfile::TempDi
     let ctx = SessionContext::new();
     ctx.register_catalog(
         "paimon",
-        Arc::new(PaimonCatalogProvider::new(Arc::clone(&catalog), Default::default())),
+        Arc::new(PaimonCatalogProvider::new(
+            Arc::clone(&catalog),
+            Default::default(),
+        )),
     );
     (ctx, catalog, tmp)
 }

--- a/crates/integrations/datafusion/tests/system_tables.rs
+++ b/crates/integrations/datafusion/tests/system_tables.rs
@@ -56,7 +56,7 @@ async fn create_context() -> (SessionContext, Arc<dyn Catalog>, tempfile::TempDi
     let ctx = SessionContext::new();
     ctx.register_catalog(
         "paimon",
-        Arc::new(PaimonCatalogProvider::new(Arc::clone(&catalog))),
+        Arc::new(PaimonCatalogProvider::new(Arc::clone(&catalog), Default::default())),
     );
     (ctx, catalog, tmp)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Support `SET 'paimon.key' = 'value'` and `RESET 'paimon.key'` to set session-level dynamic options that are automatically merged into table scans via `copy_with_options`. Non-paimon-prefixed SET/RESET falls through to DataFusion.


<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
