### PR TITLE
fix: replace serde_avro_fast with apache-avro and optimize Avro reading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install cargo-deny
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deny@0.14.22
+          tool: cargo-deny@0.19.0
 
       - name: Check dependency licenses (Apache-compatible)
         run: cargo deny check licenses

--- a/crates/paimon/Cargo.toml
+++ b/crates/paimon/Cargo.toml
@@ -56,7 +56,7 @@ snafu = "0.9.0"
 typed-builder = "^0.19"
 opendal = { version = "0.55", features = ["services-fs"] }
 pretty_assertions = "1"
-serde_avro_fast = { version = "2.0.2", features = ["snappy", "zstandard"] }
+apache-avro = { version = "0.17", features = ["snappy", "zstandard"] }
 indexmap = "2.5.0"
 roaring = "0.11"
 crc32fast = "1"

--- a/crates/paimon/Cargo.toml
+++ b/crates/paimon/Cargo.toml
@@ -56,7 +56,7 @@ snafu = "0.9.0"
 typed-builder = "^0.19"
 opendal = { version = "0.55", features = ["services-fs"] }
 pretty_assertions = "1"
-apache-avro = { version = "0.17", features = ["snappy", "zstandard"] }
+apache-avro = { version = "0.21", features = ["snappy", "zstandard"] }
 indexmap = "2.5.0"
 roaring = "0.11"
 crc32fast = "1"

--- a/crates/paimon/src/arrow/format/avro.rs
+++ b/crates/paimon/src/arrow/format/avro.rs
@@ -109,15 +109,12 @@ fn field_index(records: &[Value], name: &str) -> Option<usize> {
     }
 }
 
-/// Look up a field by cached index with name-based fallback, unwrapping unions.
-fn get_field_at<'a>(record: &'a Value, name: &str, idx: Option<usize>) -> Option<&'a Value> {
-    match record {
-        Value::Record(fields) => if let Some(i) = idx {
-            fields.get(i).map(|(_, v)| v)
-        } else {
-            fields.iter().find(|(n, _)| n == name).map(|(_, v)| v)
-        }
-        .and_then(unwrap_value),
+/// Look up a field by cached index, unwrapping unions.
+/// If `idx` is `None` (field not in schema or empty records), returns `None` directly
+/// without linear search, since all records share the same schema.
+fn get_field_at(record: &Value, idx: Option<usize>) -> Option<&Value> {
+    match (record, idx) {
+        (Value::Record(fields), Some(i)) => fields.get(i).map(|(_, v)| v).and_then(unwrap_value),
         _ => None,
     }
 }
@@ -244,14 +241,14 @@ fn build_column(
     Ok(match data_type {
         DataType::Boolean(_) => {
             let arr: BooleanArray = (0..num_rows)
-                .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_bool))
+                .map(|i| get_field_at(&records[i], idx).and_then(value_as_bool))
                 .collect();
             Arc::new(arr)
         }
         DataType::TinyInt(_) => {
             let arr: Int8Array = (0..num_rows)
                 .map(|i| {
-                    get_field_at(&records[i], name, idx)
+                    get_field_at(&records[i], idx)
                         .and_then(value_as_i64)
                         .map(|v| v as i8)
                 })
@@ -261,7 +258,7 @@ fn build_column(
         DataType::SmallInt(_) => {
             let arr: Int16Array = (0..num_rows)
                 .map(|i| {
-                    get_field_at(&records[i], name, idx)
+                    get_field_at(&records[i], idx)
                         .and_then(value_as_i64)
                         .map(|v| v as i16)
                 })
@@ -271,7 +268,7 @@ fn build_column(
         DataType::Int(_) => {
             let arr: Int32Array = (0..num_rows)
                 .map(|i| {
-                    get_field_at(&records[i], name, idx)
+                    get_field_at(&records[i], idx)
                         .and_then(value_as_i64)
                         .map(|v| v as i32)
                 })
@@ -280,14 +277,14 @@ fn build_column(
         }
         DataType::BigInt(_) => {
             let arr: Int64Array = (0..num_rows)
-                .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_i64))
+                .map(|i| get_field_at(&records[i], idx).and_then(value_as_i64))
                 .collect();
             Arc::new(arr)
         }
         DataType::Float(_) => {
             let arr: Float32Array = (0..num_rows)
                 .map(|i| {
-                    get_field_at(&records[i], name, idx)
+                    get_field_at(&records[i], idx)
                         .and_then(value_as_f64)
                         .map(|v| v as f32)
                 })
@@ -296,19 +293,19 @@ fn build_column(
         }
         DataType::Double(_) => {
             let arr: Float64Array = (0..num_rows)
-                .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_f64))
+                .map(|i| get_field_at(&records[i], idx).and_then(value_as_f64))
                 .collect();
             Arc::new(arr)
         }
         DataType::Char(_) | DataType::VarChar(_) => {
             let arr: StringArray = (0..num_rows)
-                .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_str))
+                .map(|i| get_field_at(&records[i], idx).and_then(value_as_str))
                 .collect();
             Arc::new(arr)
         }
         DataType::Binary(_) | DataType::VarBinary(_) => {
             let values: Vec<Option<&[u8]>> = (0..num_rows)
-                .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_bytes))
+                .map(|i| get_field_at(&records[i], idx).and_then(value_as_bytes))
                 .collect();
             let arr: BinaryArray = values.into_iter().collect();
             Arc::new(arr)
@@ -316,7 +313,7 @@ fn build_column(
         DataType::Date(_) => {
             let arr: Date32Array = (0..num_rows)
                 .map(|i| {
-                    get_field_at(&records[i], name, idx)
+                    get_field_at(&records[i], idx)
                         .and_then(value_as_i64)
                         .map(|v| v as i32)
                 })
@@ -332,7 +329,7 @@ fn build_column(
             })?;
             let arr: Decimal128Array = (0..num_rows)
                 .map(|i| {
-                    get_field_at(&records[i], name, idx).and_then(|v| match v {
+                    get_field_at(&records[i], idx).and_then(|v| match v {
                         Value::Bytes(b) | Value::Fixed(_, b) => Some(bytes_to_i128_be(b)),
                         Value::Decimal(d) => Vec::<u8>::try_from(d.clone())
                             .ok()
@@ -381,7 +378,7 @@ fn build_timestamp_column(
 ) -> Arc<dyn arrow_array::Array> {
     let idx = field_index(records, name);
     let values: Vec<Option<i64>> = (0..num_rows)
-        .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_i64))
+        .map(|i| get_field_at(&records[i], idx).and_then(value_as_i64))
         .collect();
     match precision {
         0..=3 => Arc::new(TimestampMillisecondArray::from(values).with_timezone_opt(tz)),
@@ -405,7 +402,7 @@ fn build_array_column(
     let mut element_records: Vec<Value> = Vec::new();
 
     for record in records.iter().take(num_rows) {
-        match get_field_at(record, name, idx) {
+        match get_field_at(record, idx) {
             Some(Value::Array(arr)) => {
                 for elem in arr {
                     element_records
@@ -429,7 +426,7 @@ fn build_array_column(
     let offsets_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
     let nulls = NullBuffer::new(BooleanBuffer::from(
         (0..num_rows)
-            .map(|i| get_field_at(&records[i], name, idx).is_some())
+            .map(|i| get_field_at(&records[i], idx).is_some())
             .collect::<Vec<_>>(),
     ));
 
@@ -461,7 +458,7 @@ fn build_map_column(
     let mut value_records: Vec<Value> = Vec::new();
 
     for record in records.iter().take(num_rows) {
-        match get_field_at(record, name, idx) {
+        match get_field_at(record, idx) {
             Some(Value::Map(map)) => {
                 for (k, v) in map {
                     key_records.push(Value::Record(vec![(
@@ -513,7 +510,7 @@ fn build_map_column(
     let offsets_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
     let nulls = NullBuffer::new(BooleanBuffer::from(
         (0..num_rows)
-            .map(|i| get_field_at(&records[i], name, idx).is_some())
+            .map(|i| get_field_at(&records[i], idx).is_some())
             .collect::<Vec<_>>(),
     ));
 
@@ -539,7 +536,7 @@ fn build_row_column(
 ) -> crate::Result<Arc<dyn arrow_array::Array>> {
     let idx = field_index(records, name);
     let sub_records: Vec<Value> = (0..num_rows)
-        .map(|i| match get_field_at(&records[i], name, idx) {
+        .map(|i| match get_field_at(&records[i], idx) {
             Some(v @ Value::Record(_)) => v.clone(),
             _ => Value::Record(vec![]),
         })
@@ -561,7 +558,7 @@ fn build_row_column(
 
     let nulls = NullBuffer::new(BooleanBuffer::from(
         (0..num_rows)
-            .map(|i| get_field_at(&records[i], name, idx).is_some())
+            .map(|i| get_field_at(&records[i], idx).is_some())
             .collect::<Vec<_>>(),
     ));
 
@@ -685,7 +682,7 @@ mod tests {
     fn test_get_field_at_present() {
         let record = make_record(vec![("name", av_str("alice"))]);
         assert_eq!(
-            get_field_at(&record, "name", Some(0)),
+            get_field_at(&record, Some(0)),
             Some(&Value::String("alice".to_string()))
         );
     }
@@ -693,23 +690,20 @@ mod tests {
     #[test]
     fn test_get_field_at_missing() {
         let record = make_record(vec![]);
-        assert!(get_field_at(&record, "name", None).is_none());
+        assert!(get_field_at(&record, None).is_none());
     }
 
     #[test]
     fn test_get_field_at_union_wrapped() {
         let record = make_record(vec![("age", av_union(av_int(30)))]);
-        assert_eq!(
-            get_field_at(&record, "age", Some(0)),
-            Some(&Value::Long(30))
-        );
+        assert_eq!(get_field_at(&record, Some(0)), Some(&Value::Long(30)));
     }
 
     #[test]
-    fn test_get_field_at_fallback() {
+    fn test_get_field_at_no_index() {
         let record = make_record(vec![("x", av_int(1)), ("y", av_int(2))]);
-        // No cached index — falls back to linear search.
-        assert_eq!(get_field_at(&record, "y", None), Some(&Value::Long(2)));
+        // idx is None — returns None directly without linear search.
+        assert!(get_field_at(&record, None).is_none());
     }
 
     // -----------------------------------------------------------------------
@@ -886,6 +880,35 @@ mod tests {
         assert_eq!(bytes_to_i128_be(&[0xFF]), -1);
         assert_eq!(bytes_to_i128_be(&[]), 0);
         assert_eq!(bytes_to_i128_be(&[0x00, 0x01]), 1);
+    }
+
+    #[test]
+    fn test_build_column_map_with_union() {
+        use std::collections::HashMap;
+        // Map field wrapped in a union (nullable map), as Avro encodes nullable types.
+        let mut map1 = HashMap::new();
+        map1.insert("k1".to_string(), av_int(10));
+        map1.insert("k2".to_string(), av_int(20));
+        let records = vec![
+            Value::Record(vec![(
+                "m".to_string(),
+                Value::Union(1, Box::new(Value::Map(map1))),
+            )]),
+            Value::Record(vec![(
+                "m".to_string(),
+                Value::Union(0, Box::new(av_null())),
+            )]),
+        ];
+        let map_type = MapType::new(
+            DataType::VarChar(VarCharType::new(100).unwrap()),
+            DataType::Int(IntType::new()),
+        );
+        let col = build_map_column(&records, "m", &map_type, 2).unwrap();
+        let arr = col.as_any().downcast_ref::<MapArray>().unwrap();
+        assert_eq!(arr.len(), 2);
+        // First row has 2 entries, second row is null.
+        assert!(!arr.is_null(0));
+        assert!(arr.is_null(1));
     }
 
     #[test]

--- a/crates/paimon/src/arrow/format/avro.rs
+++ b/crates/paimon/src/arrow/format/avro.rs
@@ -112,14 +112,12 @@ fn field_index(records: &[Value], name: &str) -> Option<usize> {
 /// Look up a field by cached index with name-based fallback, unwrapping unions.
 fn get_field_at<'a>(record: &'a Value, name: &str, idx: Option<usize>) -> Option<&'a Value> {
     match record {
-        Value::Record(fields) => {
-            if let Some(i) = idx {
-                fields.get(i).map(|(_, v)| v)
-            } else {
-                fields.iter().find(|(n, _)| n == name).map(|(_, v)| v)
-            }
-            .and_then(unwrap_value)
+        Value::Record(fields) => if let Some(i) = idx {
+            fields.get(i).map(|(_, v)| v)
+        } else {
+            fields.iter().find(|(n, _)| n == name).map(|(_, v)| v)
         }
+        .and_then(unwrap_value),
         _ => None,
     }
 }
@@ -335,15 +333,11 @@ fn build_column(
             let arr: Decimal128Array = (0..num_rows)
                 .map(|i| {
                     get_field_at(&records[i], name, idx).and_then(|v| match v {
-                        // Avro decimal is encoded as big-endian two's complement bytes.
                         Value::Bytes(b) | Value::Fixed(_, b) => Some(bytes_to_i128_be(b)),
-                        Value::Int(n) => Some(i64::from(*n) as i128),
-                        Value::Long(n) => Some(*n as i128),
                         Value::Decimal(d) => Vec::<u8>::try_from(d.clone())
                             .ok()
                             .map(|b| bytes_to_i128_be(&b)),
                         Value::BigDecimal(bd) => parse_decimal_string(&bd.to_string(), scale),
-                        Value::String(s) => parse_decimal_string(s, scale),
                         _ => None,
                     })
                 })
@@ -589,7 +583,7 @@ fn parse_decimal_string(s: &str, scale: i8) -> Option<i128> {
         None => (s, ""),
     };
     let frac_len = frac_part.len() as i8;
-    let combined = format!("{}{}", integer_part, frac_part);
+    let combined = format!("{integer_part}{frac_part}");
     let unscaled: i128 = combined.parse().ok()?;
     // Adjust if the fractional digits differ from the target scale.
     let result = if frac_len < scale {
@@ -705,7 +699,10 @@ mod tests {
     #[test]
     fn test_get_field_at_union_wrapped() {
         let record = make_record(vec![("age", av_union(av_int(30)))]);
-        assert_eq!(get_field_at(&record, "age", Some(0)), Some(&Value::Long(30)));
+        assert_eq!(
+            get_field_at(&record, "age", Some(0)),
+            Some(&Value::Long(30))
+        );
     }
 
     #[test]

--- a/crates/paimon/src/arrow/format/avro.rs
+++ b/crates/paimon/src/arrow/format/avro.rs
@@ -33,164 +33,7 @@ use arrow_schema::SchemaRef;
 use async_stream::try_stream;
 use async_trait::async_trait;
 use futures::StreamExt;
-use std::collections::HashMap;
 use std::sync::Arc;
-
-// ---------------------------------------------------------------------------
-// AvroValue: a serde_json::Value replacement that handles Avro bytes
-// ---------------------------------------------------------------------------
-
-/// Lightweight value type that can represent all Avro primitives including bytes.
-/// `serde_json::Value` rejects byte arrays, so we need our own.
-#[derive(Debug, Clone, PartialEq)]
-enum AvroValue {
-    Null,
-    Bool(bool),
-    Int(i64),
-    Float(f64),
-    String(String),
-    Bytes(Vec<u8>),
-    /// Avro array / sequence.
-    Array(Vec<AvroValue>),
-    /// Nested record-like object.
-    Object(HashMap<String, AvroValue>),
-}
-
-impl AvroValue {
-    fn as_bool(&self) -> Option<bool> {
-        match self {
-            AvroValue::Bool(b) => Some(*b),
-            _ => None,
-        }
-    }
-
-    fn as_i64(&self) -> Option<i64> {
-        match self {
-            AvroValue::Int(n) => Some(*n),
-            _ => None,
-        }
-    }
-
-    fn as_f64(&self) -> Option<f64> {
-        match self {
-            AvroValue::Float(f) => Some(*f),
-            AvroValue::Int(n) => Some(*n as f64),
-            _ => None,
-        }
-    }
-
-    fn as_str(&self) -> Option<&str> {
-        match self {
-            AvroValue::String(s) => Some(s),
-            _ => None,
-        }
-    }
-
-    fn as_bytes(&self) -> Option<&[u8]> {
-        match self {
-            AvroValue::Bytes(b) => Some(b),
-            AvroValue::String(s) => Some(s.as_bytes()),
-            _ => None,
-        }
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for AvroValue {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct AvroValueVisitor;
-
-        impl<'de> serde::de::Visitor<'de> for AvroValueVisitor {
-            type Value = AvroValue;
-
-            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                f.write_str("any Avro value")
-            }
-
-            fn visit_bool<E>(self, v: bool) -> Result<AvroValue, E> {
-                Ok(AvroValue::Bool(v))
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<AvroValue, E> {
-                Ok(AvroValue::Int(v as i64))
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<AvroValue, E> {
-                Ok(AvroValue::Int(v as i64))
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<AvroValue, E> {
-                Ok(AvroValue::Int(v as i64))
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<AvroValue, E> {
-                Ok(AvroValue::Int(v))
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<AvroValue, E> {
-                Ok(AvroValue::Int(v as i64))
-            }
-
-            fn visit_f32<E>(self, v: f32) -> Result<AvroValue, E> {
-                Ok(AvroValue::Float(v as f64))
-            }
-
-            fn visit_f64<E>(self, v: f64) -> Result<AvroValue, E> {
-                Ok(AvroValue::Float(v))
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<AvroValue, E> {
-                Ok(AvroValue::String(v.to_owned()))
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<AvroValue, E> {
-                Ok(AvroValue::String(v))
-            }
-
-            fn visit_bytes<E>(self, v: &[u8]) -> Result<AvroValue, E> {
-                Ok(AvroValue::Bytes(v.to_vec()))
-            }
-
-            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<AvroValue, E> {
-                Ok(AvroValue::Bytes(v))
-            }
-
-            fn visit_none<E>(self) -> Result<AvroValue, E> {
-                Ok(AvroValue::Null)
-            }
-
-            fn visit_unit<E>(self) -> Result<AvroValue, E> {
-                Ok(AvroValue::Null)
-            }
-
-            fn visit_map<A>(self, mut map: A) -> Result<AvroValue, A::Error>
-            where
-                A: serde::de::MapAccess<'de>,
-            {
-                let mut m = HashMap::new();
-                while let Some((k, v)) = map.next_entry::<String, AvroValue>()? {
-                    m.insert(k, v);
-                }
-                Ok(AvroValue::Object(m))
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<AvroValue, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
-            {
-                let mut v = Vec::new();
-                while let Some(elem) = seq.next_element::<AvroValue>()? {
-                    v.push(elem);
-                }
-                Ok(AvroValue::Array(v))
-            }
-        }
-
-        deserializer.deserialize_any(AvroValueVisitor)
-    }
-}
 
 pub(crate) struct AvroFormatReader;
 
@@ -215,20 +58,20 @@ impl FormatFileReader for AvroFormatReader {
         let target_schema = build_target_arrow_schema(&read_fields)?;
         let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
 
-        let mut all_records: Vec<HashMap<String, AvroValue>> = Vec::new();
-        for result in Reader::new(&file_bytes[..]).map_err(|e| Error::UnexpectedError {
-            message: format!("Failed to open Avro file: {e}"),
-            source: Some(Box::new(e)),
-        })? {
-            let record = result.map_err(|e| Error::UnexpectedError {
+        // Collect Avro records directly as apache_avro::Value, avoiding intermediate conversion.
+        let all_records: Vec<Value> = Reader::new(&file_bytes[..])
+            .map_err(|e| Error::UnexpectedError {
+                message: format!("Failed to open Avro file: {e}"),
+                source: Some(Box::new(e)),
+            })?
+            .collect::<std::result::Result<Vec<Value>, _>>()
+            .map_err(|e| Error::UnexpectedError {
                 message: format!("Failed to deserialize Avro record: {e}"),
                 source: Some(Box::new(e)),
             })?;
-            all_records.push(avro_record_to_hash_map(record)?);
-        }
 
         // Apply row selection filtering.
-        let records: Vec<HashMap<String, AvroValue>> = match row_selection {
+        let records: Vec<Value> = match row_selection {
             Some(ref ranges) => {
                 let total_rows = all_records.len();
                 let mask = ranges_to_mask(total_rows, ranges);
@@ -252,62 +95,90 @@ impl FormatFileReader for AvroFormatReader {
     }
 }
 
-fn avro_record_to_hash_map(value: Value) -> crate::Result<HashMap<String, AvroValue>> {
-    match value {
-        Value::Record(fields) => Ok(fields
-            .into_iter()
-            .map(|(name, value)| Ok((name, avro_value_from_value(value)?)))
-            .collect::<crate::Result<HashMap<_, _>>>()?),
-        other => Err(Error::UnexpectedError {
-            message: format!("Expected Avro record, got {other:?}"),
-            source: None,
-        }),
+// ---------------------------------------------------------------------------
+// Value access helpers — work directly with apache_avro::types::Value
+// ---------------------------------------------------------------------------
+
+/// Find the position of a named field from the first record.
+/// All records in an Avro file share the same schema, so the index is valid
+/// for every record.
+fn field_index(records: &[Value], name: &str) -> Option<usize> {
+    match records.first() {
+        Some(Value::Record(fields)) => fields.iter().position(|(n, _)| n == name),
+        _ => None,
     }
 }
 
-fn avro_value_from_value(value: Value) -> crate::Result<AvroValue> {
-    match value {
-        Value::Null => Ok(AvroValue::Null),
-        Value::Boolean(v) => Ok(AvroValue::Bool(v)),
-        Value::Int(v) => Ok(AvroValue::Int(i64::from(v))),
-        Value::Long(v) => Ok(AvroValue::Int(v)),
-        Value::Float(v) => Ok(AvroValue::Float(f64::from(v))),
-        Value::Double(v) => Ok(AvroValue::Float(v)),
-        Value::Bytes(v) => Ok(AvroValue::Bytes(v)),
-        Value::String(v) => Ok(AvroValue::String(v)),
-        Value::Fixed(_, v) => Ok(AvroValue::Bytes(v)),
-        Value::Enum(_, v) => Ok(AvroValue::String(v)),
-        Value::Union(_, v) => avro_value_from_value(*v),
-        Value::Array(values) => values
-            .into_iter()
-            .map(avro_value_from_value)
-            .collect::<crate::Result<Vec<_>>>()
-            .map(AvroValue::Array),
-        Value::Map(values) => values
-            .into_iter()
-            .map(|(name, value)| Ok((name, avro_value_from_value(value)?)))
-            .collect::<crate::Result<HashMap<_, _>>>()
-            .map(AvroValue::Object),
-        Value::Record(fields) => fields
-            .into_iter()
-            .map(|(name, value)| Ok((name, avro_value_from_value(value)?)))
-            .collect::<crate::Result<HashMap<_, _>>>()
-            .map(AvroValue::Object),
-        Value::Date(v) => Ok(AvroValue::Int(i64::from(v))),
-        Value::Decimal(v) => Vec::<u8>::try_from(v)
-            .map(AvroValue::Bytes)
-            .map_err(crate::Error::from),
-        Value::BigDecimal(v) => Ok(AvroValue::String(v.to_string())),
-        Value::TimeMillis(v) => Ok(AvroValue::Int(i64::from(v))),
-        Value::TimeMicros(v) => Ok(AvroValue::Int(v)),
-        Value::TimestampMillis(v) => Ok(AvroValue::Int(v)),
-        Value::TimestampMicros(v) => Ok(AvroValue::Int(v)),
-        Value::TimestampNanos(v) => Ok(AvroValue::Int(v)),
-        Value::LocalTimestampMillis(v) => Ok(AvroValue::Int(v)),
-        Value::LocalTimestampMicros(v) => Ok(AvroValue::Int(v)),
-        Value::LocalTimestampNanos(v) => Ok(AvroValue::Int(v)),
-        Value::Duration(v) => Ok(AvroValue::Bytes(<[u8; 12]>::from(v).to_vec())),
-        Value::Uuid(v) => Ok(AvroValue::String(v.to_string())),
+/// Look up a field by cached index with name-based fallback, unwrapping unions.
+fn get_field_at<'a>(record: &'a Value, name: &str, idx: Option<usize>) -> Option<&'a Value> {
+    match record {
+        Value::Record(fields) => {
+            if let Some(i) = idx {
+                fields.get(i).map(|(_, v)| v)
+            } else {
+                fields.iter().find(|(n, _)| n == name).map(|(_, v)| v)
+            }
+            .and_then(unwrap_value)
+        }
+        _ => None,
+    }
+}
+
+/// Unwrap Avro union/null values, returning `None` for null.
+fn unwrap_value(v: &Value) -> Option<&Value> {
+    match v {
+        Value::Null => None,
+        Value::Union(_, inner) => unwrap_value(inner),
+        other => Some(other),
+    }
+}
+
+fn value_as_bool(v: &Value) -> Option<bool> {
+    match v {
+        Value::Boolean(b) => Some(*b),
+        _ => None,
+    }
+}
+
+fn value_as_i64(v: &Value) -> Option<i64> {
+    match v {
+        Value::Int(n) => Some(i64::from(*n)),
+        Value::Long(n) => Some(*n),
+        Value::Date(n) | Value::TimeMillis(n) => Some(i64::from(*n)),
+        Value::TimeMicros(n)
+        | Value::TimestampMillis(n)
+        | Value::TimestampMicros(n)
+        | Value::TimestampNanos(n)
+        | Value::LocalTimestampMillis(n)
+        | Value::LocalTimestampMicros(n)
+        | Value::LocalTimestampNanos(n) => Some(*n),
+        _ => None,
+    }
+}
+
+fn value_as_f64(v: &Value) -> Option<f64> {
+    match v {
+        Value::Float(f) => Some(f64::from(*f)),
+        Value::Double(f) => Some(*f),
+        Value::Int(n) => Some(f64::from(*n)),
+        Value::Long(n) => Some(*n as f64),
+        _ => None,
+    }
+}
+
+fn value_as_str(v: &Value) -> Option<&str> {
+    match v {
+        Value::String(s) => Some(s),
+        Value::Enum(_, s) => Some(s),
+        _ => None,
+    }
+}
+
+fn value_as_bytes(v: &Value) -> Option<&[u8]> {
+    match v {
+        Value::Bytes(b) | Value::Fixed(_, b) => Some(b),
+        Value::String(s) => Some(s.as_bytes()),
+        _ => None,
     }
 }
 
@@ -336,7 +207,7 @@ fn ranges_to_mask(total_rows: usize, ranges: &[RowRange]) -> Vec<bool> {
 // ---------------------------------------------------------------------------
 
 fn records_to_batch(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     fields: &[DataField],
     schema: &SchemaRef,
 ) -> crate::Result<RecordBatch> {
@@ -364,23 +235,26 @@ fn records_to_batch(
 }
 
 fn build_column(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     name: &str,
     data_type: &DataType,
     num_rows: usize,
 ) -> crate::Result<Arc<dyn arrow_array::Array>> {
+    // Pre-compute field position once; O(1) per-row access thereafter.
+    let idx = field_index(records, name);
+
     Ok(match data_type {
         DataType::Boolean(_) => {
             let arr: BooleanArray = (0..num_rows)
-                .map(|i| get_field(&records[i], name).and_then(|v| v.as_bool()))
+                .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_bool))
                 .collect();
             Arc::new(arr)
         }
         DataType::TinyInt(_) => {
             let arr: Int8Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name)
-                        .and_then(|v| v.as_i64())
+                    get_field_at(&records[i], name, idx)
+                        .and_then(value_as_i64)
                         .map(|v| v as i8)
                 })
                 .collect();
@@ -389,8 +263,8 @@ fn build_column(
         DataType::SmallInt(_) => {
             let arr: Int16Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name)
-                        .and_then(|v| v.as_i64())
+                    get_field_at(&records[i], name, idx)
+                        .and_then(value_as_i64)
                         .map(|v| v as i16)
                 })
                 .collect();
@@ -399,8 +273,8 @@ fn build_column(
         DataType::Int(_) => {
             let arr: Int32Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name)
-                        .and_then(|v| v.as_i64())
+                    get_field_at(&records[i], name, idx)
+                        .and_then(value_as_i64)
                         .map(|v| v as i32)
                 })
                 .collect();
@@ -408,15 +282,15 @@ fn build_column(
         }
         DataType::BigInt(_) => {
             let arr: Int64Array = (0..num_rows)
-                .map(|i| get_field(&records[i], name).and_then(|v| v.as_i64()))
+                .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_i64))
                 .collect();
             Arc::new(arr)
         }
         DataType::Float(_) => {
             let arr: Float32Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name)
-                        .and_then(|v| v.as_f64())
+                    get_field_at(&records[i], name, idx)
+                        .and_then(value_as_f64)
                         .map(|v| v as f32)
                 })
                 .collect();
@@ -424,19 +298,19 @@ fn build_column(
         }
         DataType::Double(_) => {
             let arr: Float64Array = (0..num_rows)
-                .map(|i| get_field(&records[i], name).and_then(|v| v.as_f64()))
+                .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_f64))
                 .collect();
             Arc::new(arr)
         }
         DataType::Char(_) | DataType::VarChar(_) => {
             let arr: StringArray = (0..num_rows)
-                .map(|i| get_field(&records[i], name).and_then(|v| v.as_str()))
+                .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_str))
                 .collect();
             Arc::new(arr)
         }
         DataType::Binary(_) | DataType::VarBinary(_) => {
             let values: Vec<Option<&[u8]>> = (0..num_rows)
-                .map(|i| get_field(&records[i], name).and_then(|v| v.as_bytes()))
+                .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_bytes))
                 .collect();
             let arr: BinaryArray = values.into_iter().collect();
             Arc::new(arr)
@@ -444,8 +318,8 @@ fn build_column(
         DataType::Date(_) => {
             let arr: Date32Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name)
-                        .and_then(|v| v.as_i64())
+                    get_field_at(&records[i], name, idx)
+                        .and_then(value_as_i64)
                         .map(|v| v as i32)
                 })
                 .collect();
@@ -460,12 +334,16 @@ fn build_column(
             })?;
             let arr: Decimal128Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name).and_then(|v| match v {
+                    get_field_at(&records[i], name, idx).and_then(|v| match v {
                         // Avro decimal is encoded as big-endian two's complement bytes.
-                        AvroValue::Bytes(b) => Some(bytes_to_i128_be(b)),
-                        AvroValue::Int(n) => Some(*n as i128),
-                        // serde_avro_fast may deserialize decimal as string representation.
-                        AvroValue::String(s) => parse_decimal_string(s, scale),
+                        Value::Bytes(b) | Value::Fixed(_, b) => Some(bytes_to_i128_be(b)),
+                        Value::Int(n) => Some(i64::from(*n) as i128),
+                        Value::Long(n) => Some(*n as i128),
+                        Value::Decimal(d) => Vec::<u8>::try_from(d.clone())
+                            .ok()
+                            .map(|b| bytes_to_i128_be(&b)),
+                        Value::BigDecimal(bd) => parse_decimal_string(&bd.to_string(), scale),
+                        Value::String(s) => parse_decimal_string(s, scale),
                         _ => None,
                     })
                 })
@@ -501,14 +379,15 @@ fn build_column(
 }
 
 fn build_timestamp_column(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     name: &str,
     num_rows: usize,
     precision: u32,
     tz: Option<Arc<str>>,
 ) -> Arc<dyn arrow_array::Array> {
+    let idx = field_index(records, name);
     let values: Vec<Option<i64>> = (0..num_rows)
-        .map(|i| get_field(&records[i], name).and_then(|v| v.as_i64()))
+        .map(|i| get_field_at(&records[i], name, idx).and_then(value_as_i64))
         .collect();
     match precision {
         0..=3 => Arc::new(TimestampMillisecondArray::from(values).with_timezone_opt(tz)),
@@ -518,7 +397,7 @@ fn build_timestamp_column(
 }
 
 fn build_array_column(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     name: &str,
     element_type: &DataType,
     num_rows: usize,
@@ -527,16 +406,16 @@ fn build_array_column(
     let arrow_element_field =
         arrow_schema::Field::new("element", arrow_element_type, element_type.is_nullable());
 
+    let idx = field_index(records, name);
     let mut offsets = vec![0i32];
-    let mut element_records: Vec<HashMap<String, AvroValue>> = Vec::new();
+    let mut element_records: Vec<Value> = Vec::new();
 
     for record in records.iter().take(num_rows) {
-        match get_field(record, name) {
-            Some(AvroValue::Array(arr)) => {
+        match get_field_at(record, name, idx) {
+            Some(Value::Array(arr)) => {
                 for elem in arr {
-                    let mut m = HashMap::new();
-                    m.insert("element".to_string(), elem.clone());
-                    element_records.push(m);
+                    element_records
+                        .push(Value::Record(vec![("element".to_string(), elem.clone())]));
                 }
                 offsets.push(offsets.last().unwrap() + arr.len() as i32);
             }
@@ -556,7 +435,7 @@ fn build_array_column(
     let offsets_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
     let nulls = NullBuffer::new(BooleanBuffer::from(
         (0..num_rows)
-            .map(|i| get_field(&records[i], name).is_some())
+            .map(|i| get_field_at(&records[i], name, idx).is_some())
             .collect::<Vec<_>>(),
     ));
 
@@ -574,7 +453,7 @@ fn build_array_column(
 }
 
 fn build_map_column(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     name: &str,
     map_type: &MapType,
     num_rows: usize,
@@ -582,20 +461,20 @@ fn build_map_column(
     let arrow_key_type = crate::arrow::paimon_type_to_arrow(map_type.key_type())?;
     let arrow_value_type = crate::arrow::paimon_type_to_arrow(map_type.value_type())?;
 
+    let idx = field_index(records, name);
     let mut offsets = vec![0i32];
-    let mut key_records: Vec<HashMap<String, AvroValue>> = Vec::new();
-    let mut value_records: Vec<HashMap<String, AvroValue>> = Vec::new();
+    let mut key_records: Vec<Value> = Vec::new();
+    let mut value_records: Vec<Value> = Vec::new();
 
     for record in records.iter().take(num_rows) {
-        match get_field_raw(record, name) {
-            Some(AvroValue::Object(map)) => {
+        match get_field_at(record, name, idx) {
+            Some(Value::Map(map)) => {
                 for (k, v) in map {
-                    let mut km = HashMap::new();
-                    km.insert("key".to_string(), AvroValue::String(k.clone()));
-                    key_records.push(km);
-                    let mut vm = HashMap::new();
-                    vm.insert("value".to_string(), v.clone());
-                    value_records.push(vm);
+                    key_records.push(Value::Record(vec![(
+                        "key".to_string(),
+                        Value::String(k.clone()),
+                    )]));
+                    value_records.push(Value::Record(vec![("value".to_string(), v.clone())]));
                 }
                 offsets.push(offsets.last().unwrap() + map.len() as i32);
             }
@@ -640,7 +519,7 @@ fn build_map_column(
     let offsets_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
     let nulls = NullBuffer::new(BooleanBuffer::from(
         (0..num_rows)
-            .map(|i| get_field_raw(&records[i], name).is_some())
+            .map(|i| get_field_at(&records[i], name, idx).is_some())
             .collect::<Vec<_>>(),
     ));
 
@@ -659,15 +538,16 @@ fn build_map_column(
 }
 
 fn build_row_column(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     name: &str,
     row_type: &RowType,
     num_rows: usize,
 ) -> crate::Result<Arc<dyn arrow_array::Array>> {
-    let sub_records: Vec<HashMap<String, AvroValue>> = (0..num_rows)
-        .map(|i| match get_field_raw(&records[i], name) {
-            Some(AvroValue::Object(obj)) => obj.clone(),
-            _ => HashMap::new(),
+    let idx = field_index(records, name);
+    let sub_records: Vec<Value> = (0..num_rows)
+        .map(|i| match get_field_at(&records[i], name, idx) {
+            Some(v @ Value::Record(_)) => v.clone(),
+            _ => Value::Record(vec![]),
         })
         .collect();
 
@@ -687,7 +567,7 @@ fn build_row_column(
 
     let nulls = NullBuffer::new(BooleanBuffer::from(
         (0..num_rows)
-            .map(|i| get_field_raw(&records[i], name).is_some())
+            .map(|i| get_field_at(&records[i], name, idx).is_some())
             .collect::<Vec<_>>(),
     ));
 
@@ -735,36 +615,6 @@ fn bytes_to_i128_be(bytes: &[u8]) -> i128 {
     i128::from_be_bytes(buf)
 }
 
-/// Look up a field in an Avro record, unwrapping union encoding.
-fn get_field<'a>(record: &'a HashMap<String, AvroValue>, name: &str) -> Option<&'a AvroValue> {
-    record.get(name).and_then(unwrap_avro_union)
-}
-
-/// Look up a field without union unwrapping — for Map/Row types whose Object
-/// shape overlaps with union wrappers.
-fn get_field_raw<'a>(record: &'a HashMap<String, AvroValue>, name: &str) -> Option<&'a AvroValue> {
-    record.get(name).and_then(|v| match v {
-        AvroValue::Null => None,
-        other => Some(other),
-    })
-}
-
-/// Unwrap Avro union encoding: `{"type": value}` → `value`, or `"null"` → `None`.
-fn unwrap_avro_union(v: &AvroValue) -> Option<&AvroValue> {
-    match v {
-        AvroValue::Null => None,
-        AvroValue::Object(map) if map.len() == 1 => {
-            let (key, inner) = map.iter().next().unwrap();
-            if key == "null" {
-                None
-            } else {
-                Some(inner)
-            }
-        }
-        other => Some(other),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -774,78 +624,95 @@ mod tests {
     };
     use arrow_array::Array;
 
-    // Helper to build AvroValue variants concisely in tests.
-    fn av_int(v: i64) -> AvroValue {
-        AvroValue::Int(v)
+    // Helper to build Value variants concisely in tests.
+    fn av_int(v: i64) -> Value {
+        Value::Long(v)
     }
-    fn av_float(v: f64) -> AvroValue {
-        AvroValue::Float(v)
+    fn av_float(v: f64) -> Value {
+        Value::Double(v)
     }
-    fn av_bool(v: bool) -> AvroValue {
-        AvroValue::Bool(v)
+    fn av_bool(v: bool) -> Value {
+        Value::Boolean(v)
     }
-    fn av_str(v: &str) -> AvroValue {
-        AvroValue::String(v.to_string())
+    fn av_str(v: &str) -> Value {
+        Value::String(v.to_string())
     }
-    fn av_bytes(v: &[u8]) -> AvroValue {
-        AvroValue::Bytes(v.to_vec())
+    fn av_bytes(v: &[u8]) -> Value {
+        Value::Bytes(v.to_vec())
     }
-    fn av_null() -> AvroValue {
-        AvroValue::Null
+    fn av_null() -> Value {
+        Value::Null
     }
-    fn av_union(key: &str, val: AvroValue) -> AvroValue {
-        AvroValue::Object(HashMap::from([(key.to_string(), val)]))
+    fn av_union(val: Value) -> Value {
+        Value::Union(1, Box::new(val))
     }
 
     // -----------------------------------------------------------------------
-    // unwrap_avro_union
+    // unwrap_value
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_unwrap_avro_union_null() {
-        assert!(unwrap_avro_union(&av_null()).is_none());
+    fn test_unwrap_value_null() {
+        assert!(unwrap_value(&av_null()).is_none());
     }
 
     #[test]
-    fn test_unwrap_avro_union_plain_value() {
+    fn test_unwrap_value_plain() {
         let v = av_int(42);
-        assert_eq!(unwrap_avro_union(&v), Some(&av_int(42)));
+        assert_eq!(unwrap_value(&v), Some(&Value::Long(42)));
     }
 
     #[test]
-    fn test_unwrap_avro_union_wrapped_value() {
-        let v = av_union("int", av_int(42));
-        assert_eq!(unwrap_avro_union(&v), Some(&av_int(42)));
+    fn test_unwrap_value_union() {
+        let v = av_union(av_int(42));
+        assert_eq!(unwrap_value(&v), Some(&Value::Long(42)));
     }
 
     #[test]
-    fn test_unwrap_avro_union_null_key() {
-        let v = av_union("null", av_null());
-        assert!(unwrap_avro_union(&v).is_none());
+    fn test_unwrap_value_union_null() {
+        let v = Value::Union(0, Box::new(Value::Null));
+        assert!(unwrap_value(&v).is_none());
     }
 
     // -----------------------------------------------------------------------
-    // get_field
+    // get_field_at
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn test_get_field_present() {
-        let mut record = HashMap::new();
-        record.insert("name".to_string(), av_str("alice"));
-        assert_eq!(get_field(&record, "name"), Some(&av_str("alice")));
+    fn make_record(fields: Vec<(&str, Value)>) -> Value {
+        Value::Record(
+            fields
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+        )
     }
 
     #[test]
-    fn test_get_field_missing() {
-        let record: HashMap<String, AvroValue> = HashMap::new();
-        assert!(get_field(&record, "name").is_none());
+    fn test_get_field_at_present() {
+        let record = make_record(vec![("name", av_str("alice"))]);
+        assert_eq!(
+            get_field_at(&record, "name", Some(0)),
+            Some(&Value::String("alice".to_string()))
+        );
     }
 
     #[test]
-    fn test_get_field_union_wrapped() {
-        let mut record = HashMap::new();
-        record.insert("age".to_string(), av_union("int", av_int(30)));
-        assert_eq!(get_field(&record, "age"), Some(&av_int(30)));
+    fn test_get_field_at_missing() {
+        let record = make_record(vec![]);
+        assert!(get_field_at(&record, "name", None).is_none());
+    }
+
+    #[test]
+    fn test_get_field_at_union_wrapped() {
+        let record = make_record(vec![("age", av_union(av_int(30)))]);
+        assert_eq!(get_field_at(&record, "age", Some(0)), Some(&Value::Long(30)));
+    }
+
+    #[test]
+    fn test_get_field_at_fallback() {
+        let record = make_record(vec![("x", av_int(1)), ("y", av_int(2))]);
+        // No cached index — falls back to linear search.
+        assert_eq!(get_field_at(&record, "y", None), Some(&Value::Long(2)));
     }
 
     // -----------------------------------------------------------------------
@@ -877,13 +744,15 @@ mod tests {
     // build_column + records_to_batch
     // -----------------------------------------------------------------------
 
-    fn make_records(rows: Vec<Vec<(&str, AvroValue)>>) -> Vec<HashMap<String, AvroValue>> {
+    fn make_records(rows: Vec<Vec<(&str, Value)>>) -> Vec<Value> {
         rows.into_iter()
             .map(|fields| {
-                fields
-                    .into_iter()
-                    .map(|(k, v)| (k.to_string(), v))
-                    .collect()
+                Value::Record(
+                    fields
+                        .into_iter()
+                        .map(|(k, v)| (k.to_string(), v))
+                        .collect(),
+                )
             })
             .collect()
     }
@@ -1050,7 +919,7 @@ mod tests {
             DataType::Int(IntType::new()),
         )];
         let schema = crate::arrow::build_target_arrow_schema(&fields).unwrap();
-        let records: Vec<HashMap<String, AvroValue>> = vec![];
+        let records: Vec<Value> = vec![];
         let batch = records_to_batch(&records, &fields, &schema).unwrap();
         assert_eq!(batch.num_rows(), 0);
     }

--- a/crates/paimon/src/arrow/format/avro.rs
+++ b/crates/paimon/src/arrow/format/avro.rs
@@ -21,6 +21,8 @@ use crate::io::FileRead;
 use crate::spec::{DataField, DataType, MapType, RowType};
 use crate::table::{ArrowRecordBatchStream, RowRange};
 use crate::Error;
+use apache_avro::types::Value;
+use apache_avro::Reader;
 use arrow_array::{
     BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
     Int16Array, Int32Array, Int64Array, Int8Array, ListArray, MapArray, RecordBatch, StringArray,
@@ -50,7 +52,7 @@ enum AvroValue {
     Bytes(Vec<u8>),
     /// Avro array / sequence.
     Array(Vec<AvroValue>),
-    /// Union wrapper or record: `{"type": value}` produced by serde_avro_fast.
+    /// Nested record-like object.
     Object(HashMap<String, AvroValue>),
 }
 
@@ -213,21 +215,16 @@ impl FormatFileReader for AvroFormatReader {
         let target_schema = build_target_arrow_schema(&read_fields)?;
         let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
 
-        // Deserialize all Avro records from the OCF file.
-        let mut reader =
-            serde_avro_fast::object_container_file_encoding::Reader::from_slice(&file_bytes)
-                .map_err(|e| Error::UnexpectedError {
-                    message: format!("Failed to open Avro file: {e}"),
-                    source: Some(Box::new(e)),
-                })?;
-
         let mut all_records: Vec<HashMap<String, AvroValue>> = Vec::new();
-        for result in reader.deserialize_borrowed::<HashMap<String, AvroValue>>() {
+        for result in Reader::new(&file_bytes[..]).map_err(|e| Error::UnexpectedError {
+            message: format!("Failed to open Avro file: {e}"),
+            source: Some(Box::new(e)),
+        })? {
             let record = result.map_err(|e| Error::UnexpectedError {
                 message: format!("Failed to deserialize Avro record: {e}"),
                 source: Some(Box::new(e)),
             })?;
-            all_records.push(record);
+            all_records.push(avro_record_to_hash_map(record)?);
         }
 
         // Apply row selection filtering.
@@ -252,6 +249,65 @@ impl FormatFileReader for AvroFormatReader {
             }
         }
         .boxed())
+    }
+}
+
+fn avro_record_to_hash_map(value: Value) -> crate::Result<HashMap<String, AvroValue>> {
+    match value {
+        Value::Record(fields) => Ok(fields
+            .into_iter()
+            .map(|(name, value)| Ok((name, avro_value_from_value(value)?)))
+            .collect::<crate::Result<HashMap<_, _>>>()?),
+        other => Err(Error::UnexpectedError {
+            message: format!("Expected Avro record, got {other:?}"),
+            source: None,
+        }),
+    }
+}
+
+fn avro_value_from_value(value: Value) -> crate::Result<AvroValue> {
+    match value {
+        Value::Null => Ok(AvroValue::Null),
+        Value::Boolean(v) => Ok(AvroValue::Bool(v)),
+        Value::Int(v) => Ok(AvroValue::Int(i64::from(v))),
+        Value::Long(v) => Ok(AvroValue::Int(v)),
+        Value::Float(v) => Ok(AvroValue::Float(f64::from(v))),
+        Value::Double(v) => Ok(AvroValue::Float(v)),
+        Value::Bytes(v) => Ok(AvroValue::Bytes(v)),
+        Value::String(v) => Ok(AvroValue::String(v)),
+        Value::Fixed(_, v) => Ok(AvroValue::Bytes(v)),
+        Value::Enum(_, v) => Ok(AvroValue::String(v)),
+        Value::Union(_, v) => avro_value_from_value(*v),
+        Value::Array(values) => values
+            .into_iter()
+            .map(avro_value_from_value)
+            .collect::<crate::Result<Vec<_>>>()
+            .map(AvroValue::Array),
+        Value::Map(values) => values
+            .into_iter()
+            .map(|(name, value)| Ok((name, avro_value_from_value(value)?)))
+            .collect::<crate::Result<HashMap<_, _>>>()
+            .map(AvroValue::Object),
+        Value::Record(fields) => fields
+            .into_iter()
+            .map(|(name, value)| Ok((name, avro_value_from_value(value)?)))
+            .collect::<crate::Result<HashMap<_, _>>>()
+            .map(AvroValue::Object),
+        Value::Date(v) => Ok(AvroValue::Int(i64::from(v))),
+        Value::Decimal(v) => Vec::<u8>::try_from(v)
+            .map(AvroValue::Bytes)
+            .map_err(crate::Error::from),
+        Value::BigDecimal(v) => Ok(AvroValue::String(v.to_string())),
+        Value::TimeMillis(v) => Ok(AvroValue::Int(i64::from(v))),
+        Value::TimeMicros(v) => Ok(AvroValue::Int(v)),
+        Value::TimestampMillis(v) => Ok(AvroValue::Int(v)),
+        Value::TimestampMicros(v) => Ok(AvroValue::Int(v)),
+        Value::TimestampNanos(v) => Ok(AvroValue::Int(v)),
+        Value::LocalTimestampMillis(v) => Ok(AvroValue::Int(v)),
+        Value::LocalTimestampMicros(v) => Ok(AvroValue::Int(v)),
+        Value::LocalTimestampNanos(v) => Ok(AvroValue::Int(v)),
+        Value::Duration(v) => Ok(AvroValue::Bytes(<[u8; 12]>::from(v).to_vec())),
+        Value::Uuid(v) => Ok(AvroValue::String(v.to_string())),
     }
 }
 

--- a/crates/paimon/src/error.rs
+++ b/crates/paimon/src/error.rs
@@ -70,6 +70,14 @@ pub enum Error {
     ConfigInvalid { message: String },
     #[snafu(
         visibility(pub(crate)),
+        display("Paimon hitting unexpected avro error {}: {:?}", message, source)
+    )]
+    DataUnexpected {
+        message: String,
+        source: Box<apache_avro::Error>,
+    },
+    #[snafu(
+        visibility(pub(crate)),
         display("Paimon hitting invalid file index format: {}", message)
     )]
     FileIndexFormatInvalid { message: String },
@@ -114,6 +122,15 @@ impl From<opendal::Error> for Error {
         // TODO: Simple use IoUnexpected for now
         Error::IoUnexpected {
             message: "IO operation failed on underlying storage".to_string(),
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<apache_avro::Error> for Error {
+    fn from(source: apache_avro::Error) -> Self {
+        Error::DataUnexpected {
+            message: "".to_string(),
             source: Box::new(source),
         }
     }

--- a/crates/paimon/src/error.rs
+++ b/crates/paimon/src/error.rs
@@ -130,7 +130,7 @@ impl From<opendal::Error> for Error {
 impl From<apache_avro::Error> for Error {
     fn from(source: apache_avro::Error) -> Self {
         Error::DataUnexpected {
-            message: "".to_string(),
+            message: "Failed to process Avro data".to_string(),
             source: Box::new(source),
         }
     }

--- a/crates/paimon/src/spec/index_manifest.rs
+++ b/crates/paimon/src/spec/index_manifest.rs
@@ -19,7 +19,7 @@ use crate::io::FileIO;
 use crate::spec::manifest_common::FileKind;
 use crate::spec::IndexFileMeta;
 use apache_avro::types::Value;
-use apache_avro::{from_avro_datum, from_value, to_avro_datum, to_value, Reader, Schema};
+use apache_avro::{from_value, Reader};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
@@ -147,6 +147,7 @@ impl IndexManifest {
 
 #[cfg(test)]
 mod tests {
+    use apache_avro::{from_avro_datum, to_avro_datum, to_value, Schema};
     use indexmap::IndexMap;
 
     use super::*;

--- a/crates/paimon/src/spec/index_manifest.rs
+++ b/crates/paimon/src/spec/index_manifest.rs
@@ -18,8 +18,6 @@
 use crate::io::FileIO;
 use crate::spec::manifest_common::FileKind;
 use crate::spec::IndexFileMeta;
-use apache_avro::types::Value;
-use apache_avro::{from_value, Reader};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
@@ -129,12 +127,7 @@ impl IndexManifest {
 
     /// Read index manifest entries from Avro-encoded bytes.
     pub fn read_from_bytes(bytes: &[u8]) -> Result<Vec<IndexManifestEntry>> {
-        let reader = Reader::new(bytes).map_err(crate::Error::from)?;
-        let records = reader
-            .collect::<std::result::Result<Vec<Value>, _>>()
-            .map_err(crate::Error::from)?;
-        let values = Value::Array(records);
-        from_value::<Vec<IndexManifestEntry>>(&values).map_err(crate::Error::from)
+        crate::spec::from_avro_bytes(bytes)
     }
 
     /// Write index manifest entries to a file.
@@ -147,7 +140,7 @@ impl IndexManifest {
 
 #[cfg(test)]
 mod tests {
-    use apache_avro::{from_avro_datum, to_avro_datum, to_value, Schema};
+    use apache_avro::{from_avro_datum, from_value, to_avro_datum, to_value, types::Value, Schema};
     use indexmap::IndexMap;
 
     use super::*;

--- a/crates/paimon/src/spec/index_manifest.rs
+++ b/crates/paimon/src/spec/index_manifest.rs
@@ -18,9 +18,9 @@
 use crate::io::FileIO;
 use crate::spec::manifest_common::FileKind;
 use crate::spec::IndexFileMeta;
+use apache_avro::types::Value;
+use apache_avro::{from_avro_datum, from_value, to_avro_datum, to_value, Reader, Schema};
 use serde::{Deserialize, Serialize};
-use serde_avro_fast::object_container_file_encoding::Reader;
-use snafu::ResultExt;
 use std::fmt::{Display, Formatter};
 
 use crate::Result;
@@ -129,12 +129,12 @@ impl IndexManifest {
 
     /// Read index manifest entries from Avro-encoded bytes.
     pub fn read_from_bytes(bytes: &[u8]) -> Result<Vec<IndexManifestEntry>> {
-        let mut reader = Reader::from_slice(bytes)
-            .whatever_context::<_, crate::Error>("read index manifest avro")?;
-        reader
-            .deserialize::<IndexManifestEntry>()
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .whatever_context::<_, crate::Error>("deserialize index manifest entry")
+        let reader = Reader::new(bytes).map_err(crate::Error::from)?;
+        let records = reader
+            .collect::<std::result::Result<Vec<Value>, _>>()
+            .map_err(crate::Error::from)?;
+        let values = Value::Array(records);
+        from_value::<Vec<IndexManifestEntry>>(&values).map_err(crate::Error::from)
     }
 
     /// Write index manifest entries to a file.
@@ -210,7 +210,7 @@ mod tests {
             },
         };
 
-        let schema: serde_avro_fast::Schema = r#"["null", {
+        let schema = Schema::parse_str(r#"["null", {
             "type": "record", 
             "name": "org.apache.paimon.avro.generated.record", 
             "fields": [
@@ -241,12 +241,16 @@ mod tests {
                 }
             ]
             }]"#
-            .parse().unwrap();
+        )
+        .unwrap();
 
-        let serializer_config = &mut serde_avro_fast::ser::SerializerConfig::new(&schema);
-        let encoded = serde_avro_fast::to_single_object_vec(&sample, serializer_config).unwrap();
-        let decoded: IndexManifestEntry =
-            serde_avro_fast::from_single_object_slice(encoded.as_slice(), &schema).unwrap();
+        let value = to_value(&sample).unwrap().resolve(&schema).unwrap();
+        let encoded = to_avro_datum(&schema, value).unwrap();
+        let decoded_value = from_avro_datum(&schema, &mut encoded.as_slice(), None).unwrap();
+        let decoded: IndexManifestEntry = match decoded_value {
+            Value::Union(_, inner) => from_value(inner.as_ref()).unwrap(),
+            other => from_value(&other).unwrap(),
+        };
         assert_eq!(sample, decoded);
     }
 }

--- a/crates/paimon/src/spec/manifest.rs
+++ b/crates/paimon/src/spec/manifest.rs
@@ -18,8 +18,8 @@
 use crate::io::FileIO;
 use crate::spec::manifest_entry::ManifestEntry;
 use crate::spec::manifest_entry::MANIFEST_ENTRY_SCHEMA;
-use serde_avro_fast::object_container_file_encoding::Reader;
-use snafu::ResultExt;
+use apache_avro::types::Value;
+use apache_avro::{from_value, Reader};
 
 use crate::Result;
 
@@ -46,12 +46,12 @@ impl Manifest {
 
     /// Read manifest entries from bytes.
     fn read_from_bytes(bytes: &[u8]) -> Result<Vec<ManifestEntry>> {
-        let mut reader =
-            Reader::from_slice(bytes).whatever_context::<_, crate::Error>("read manifest avro")?;
-        reader
-            .deserialize::<ManifestEntry>()
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .whatever_context::<_, crate::Error>("deserialize manifest entry")
+        let reader = Reader::new(bytes).map_err(crate::Error::from)?;
+        let records = reader
+            .collect::<std::result::Result<Vec<Value>, _>>()
+            .map_err(crate::Error::from)?;
+        let values = Value::Array(records);
+        from_value::<Vec<ManifestEntry>>(&values).map_err(crate::Error::from)
     }
 
     /// Write manifest entries to a file.

--- a/crates/paimon/src/spec/manifest.rs
+++ b/crates/paimon/src/spec/manifest.rs
@@ -18,8 +18,6 @@
 use crate::io::FileIO;
 use crate::spec::manifest_entry::ManifestEntry;
 use crate::spec::manifest_entry::MANIFEST_ENTRY_SCHEMA;
-use apache_avro::types::Value;
-use apache_avro::{from_value, Reader};
 
 use crate::Result;
 
@@ -46,12 +44,7 @@ impl Manifest {
 
     /// Read manifest entries from bytes.
     fn read_from_bytes(bytes: &[u8]) -> Result<Vec<ManifestEntry>> {
-        let reader = Reader::new(bytes).map_err(crate::Error::from)?;
-        let records = reader
-            .collect::<std::result::Result<Vec<Value>, _>>()
-            .map_err(crate::Error::from)?;
-        let values = Value::Array(records);
-        from_value::<Vec<ManifestEntry>>(&values).map_err(crate::Error::from)
+        crate::spec::from_avro_bytes(bytes)
     }
 
     /// Write manifest entries to a file.

--- a/crates/paimon/src/spec/objects_file.rs
+++ b/crates/paimon/src/spec/objects_file.rs
@@ -31,33 +31,13 @@ pub fn from_avro_bytes<T: DeserializeOwned>(bytes: &[u8]) -> crate::Result<Vec<T
 /// The `schema_json` must be a valid Avro schema JSON string that matches
 /// the serde serialization layout of `T`.
 pub fn to_avro_bytes<T: Serialize>(schema_json: &str, records: &[T]) -> crate::Result<Vec<u8>> {
-    let schema = Schema::parse_str(schema_json).map_err(|e| crate::Error::DataInvalid {
-        message: format!("invalid avro schema: {e}"),
-        source: Some(Box::new(e)),
-    })?;
+    let schema = Schema::parse_str(schema_json)?;
     let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
     for record in records {
-        let value = to_value(record)
-            .and_then(|value| value.resolve(&schema))
-            .map_err(|e| crate::Error::DataInvalid {
-                message: format!("avro serialization failed: {e}"),
-                source: Some(Box::new(e)),
-            })?;
-        writer
-            .append(value)
-            .map_err(|e| crate::Error::DataInvalid {
-                message: format!("avro serialization failed: {e}"),
-                source: Some(Box::new(e)),
-            })?;
+        let value = to_value(record).and_then(|v| v.resolve(&schema))?;
+        writer.append(value)?;
     }
-    writer.flush().map_err(|e| crate::Error::DataInvalid {
-        message: format!("avro serialization failed: {e}"),
-        source: Some(Box::new(e)),
-    })?;
-    writer.into_inner().map_err(|e| crate::Error::DataInvalid {
-        message: format!("avro serialization failed: {e}"),
-        source: Some(Box::new(e)),
-    })
+    Ok(writer.into_inner()?)
 }
 
 #[cfg(test)]

--- a/crates/paimon/src/spec/objects_file.rs
+++ b/crates/paimon/src/spec/objects_file.rs
@@ -15,15 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use apache_avro::{from_value, to_value, types::Value, Codec, Reader, Schema, Writer};
+use apache_avro::{from_value, to_value, Codec, Reader, Schema, Writer};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 pub fn from_avro_bytes<T: DeserializeOwned>(bytes: &[u8]) -> crate::Result<Vec<T>> {
-    let reader = Reader::new(bytes)?;
-    let records = reader.collect::<std::result::Result<Vec<Value>, _>>()?;
-    let values = Value::Array(records);
-    from_value::<Vec<T>>(&values).map_err(crate::Error::from)
+    Reader::new(bytes)?
+        .map(|r| {
+            let value = r?;
+            from_value::<T>(&value).map_err(crate::Error::from)
+        })
+        .collect()
 }
 
 /// Serialize records into Avro Object Container File bytes.

--- a/crates/paimon/src/spec/objects_file.rs
+++ b/crates/paimon/src/spec/objects_file.rs
@@ -15,18 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use apache_avro::{from_value, to_value, types::Value, Codec, Reader, Schema, Writer};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use serde_avro_fast::object_container_file_encoding::{Compression, Reader};
-use snafu::ResultExt;
 
 pub fn from_avro_bytes<T: DeserializeOwned>(bytes: &[u8]) -> crate::Result<Vec<T>> {
-    let mut reader = Reader::from_slice(bytes)
-        .whatever_context::<_, crate::Error>("read avro object container")?;
-    reader
-        .deserialize::<T>()
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .whatever_context::<_, crate::Error>("deserialize avro records")
+    let reader = Reader::new(bytes)?;
+    let records = reader.collect::<std::result::Result<Vec<Value>, _>>()?;
+    let values = Value::Array(records);
+    from_value::<Vec<T>>(&values).map_err(crate::Error::from)
 }
 
 /// Serialize records into Avro Object Container File bytes.
@@ -34,22 +31,30 @@ pub fn from_avro_bytes<T: DeserializeOwned>(bytes: &[u8]) -> crate::Result<Vec<T
 /// The `schema_json` must be a valid Avro schema JSON string that matches
 /// the serde serialization layout of `T`.
 pub fn to_avro_bytes<T: Serialize>(schema_json: &str, records: &[T]) -> crate::Result<Vec<u8>> {
-    let schema: serde_avro_fast::Schema =
-        schema_json
-            .parse()
-            .map_err(
-                |e: serde_avro_fast::schema::SchemaError| crate::Error::DataInvalid {
-                    message: format!("invalid avro schema: {e}"),
-                    source: Some(Box::new(e)),
-                },
-            )?;
-    serde_avro_fast::object_container_file_encoding::write_all(
-        &schema,
-        Compression::Null,
-        Vec::new(),
-        records.iter(),
-    )
-    .map_err(|e| crate::Error::DataInvalid {
+    let schema = Schema::parse_str(schema_json).map_err(|e| crate::Error::DataInvalid {
+        message: format!("invalid avro schema: {e}"),
+        source: Some(Box::new(e)),
+    })?;
+    let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
+    for record in records {
+        let value = to_value(record)
+            .and_then(|value| value.resolve(&schema))
+            .map_err(|e| crate::Error::DataInvalid {
+                message: format!("avro serialization failed: {e}"),
+                source: Some(Box::new(e)),
+            })?;
+        writer
+            .append(value)
+            .map_err(|e| crate::Error::DataInvalid {
+                message: format!("avro serialization failed: {e}"),
+                source: Some(Box::new(e)),
+            })?;
+    }
+    writer.flush().map_err(|e| crate::Error::DataInvalid {
+        message: format!("avro serialization failed: {e}"),
+        source: Some(Box::new(e)),
+    })?;
+    writer.into_inner().map_err(|e| crate::Error::DataInvalid {
         message: format!("avro serialization failed: {e}"),
         source: Some(Box::new(e)),
     })


### PR DESCRIPTION
### Purpose

Linked issue: N/A

Replace `serde_avro_fast` (LGPL-3.0-only) with `apache-avro` to fix the license compatibility issue, and optimize the Avro reading path by eliminating the intermediate `AvroValue` conversion layer.

### Brief change log

- **License fix**: remove `serde_avro_fast` dependency (LGPL-3.0-only), use `apache-avro` for all Avro read/write paths
- **CI**: bump `cargo-deny` from 0.14.22 to 0.19.0 so incompatible licenses fail the workflow
- **Refactor `avro.rs`**: remove the custom `AvroValue` enum and `avro_record_to_hash_map` conversion, work directly with `apache_avro::types::Value`
- **Index caching**: pre-compute field position once via `field_index()` from the first record, use O(1) indexed access for all subsequent rows instead of per-row linear search or HashMap lookup
- **Simplify `to_avro_bytes`**: leverage the existing `From<apache_avro::Error>` impl to replace 4 repetitive `map_err` blocks with `?`
- **Upgrade `apache-avro`**: 0.17 → 0.21

### Tests

- All 482 existing tests pass
- No behavioral changes

### API and Format

No API or storage format changes.

### Documentation

No.