### PR TITLE
fix: replace serde_avro_fast with apache-avro

### DIFF
--- a/crates/paimon/Cargo.toml
+++ b/crates/paimon/Cargo.toml
@@ -55,7 +55,7 @@ snafu = "0.9.0"
 typed-builder = "^0.19"
 opendal = { version = "0.55", features = ["services-fs"] }
 pretty_assertions = "1"
-serde_avro_fast = { version = "2.0.2", features = ["snappy", "zstandard"] }
+apache-avro = { version = "0.17", features = ["snappy", "zstandard"] }
 indexmap = "2.5.0"
 roaring = "0.11"
 crc32fast = "1"

--- a/crates/paimon/src/arrow/format/avro.rs
+++ b/crates/paimon/src/arrow/format/avro.rs
@@ -21,6 +21,8 @@ use crate::io::FileRead;
 use crate::spec::{DataField, DataType, MapType, RowType};
 use crate::table::{ArrowRecordBatchStream, RowRange};
 use crate::Error;
+use apache_avro::types::Value;
+use apache_avro::Reader;
 use arrow_array::{
     BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
     Int16Array, Int32Array, Int64Array, Int8Array, ListArray, MapArray, RecordBatch, StringArray,
@@ -50,7 +52,7 @@ enum AvroValue {
     Bytes(Vec<u8>),
     /// Avro array / sequence.
     Array(Vec<AvroValue>),
-    /// Union wrapper or record: `{"type": value}` produced by serde_avro_fast.
+    /// Nested record-like object.
     Object(HashMap<String, AvroValue>),
 }
 
@@ -213,21 +215,16 @@ impl FormatFileReader for AvroFormatReader {
         let target_schema = build_target_arrow_schema(&read_fields)?;
         let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
 
-        // Deserialize all Avro records from the OCF file.
-        let mut reader =
-            serde_avro_fast::object_container_file_encoding::Reader::from_slice(&file_bytes)
-                .map_err(|e| Error::UnexpectedError {
-                    message: format!("Failed to open Avro file: {e}"),
-                    source: Some(Box::new(e)),
-                })?;
-
         let mut all_records: Vec<HashMap<String, AvroValue>> = Vec::new();
-        for result in reader.deserialize_borrowed::<HashMap<String, AvroValue>>() {
+        for result in Reader::new(&file_bytes[..]).map_err(|e| Error::UnexpectedError {
+            message: format!("Failed to open Avro file: {e}"),
+            source: Some(Box::new(e)),
+        })? {
             let record = result.map_err(|e| Error::UnexpectedError {
                 message: format!("Failed to deserialize Avro record: {e}"),
                 source: Some(Box::new(e)),
             })?;
-            all_records.push(record);
+            all_records.push(avro_record_to_hash_map(record)?);
         }
 
         // Apply row selection filtering.
@@ -252,6 +249,65 @@ impl FormatFileReader for AvroFormatReader {
             }
         }
         .boxed())
+    }
+}
+
+fn avro_record_to_hash_map(value: Value) -> crate::Result<HashMap<String, AvroValue>> {
+    match value {
+        Value::Record(fields) => Ok(fields
+            .into_iter()
+            .map(|(name, value)| Ok((name, avro_value_from_value(value)?)))
+            .collect::<crate::Result<HashMap<_, _>>>()?),
+        other => Err(Error::UnexpectedError {
+            message: format!("Expected Avro record, got {other:?}"),
+            source: None,
+        }),
+    }
+}
+
+fn avro_value_from_value(value: Value) -> crate::Result<AvroValue> {
+    match value {
+        Value::Null => Ok(AvroValue::Null),
+        Value::Boolean(v) => Ok(AvroValue::Bool(v)),
+        Value::Int(v) => Ok(AvroValue::Int(i64::from(v))),
+        Value::Long(v) => Ok(AvroValue::Int(v)),
+        Value::Float(v) => Ok(AvroValue::Float(f64::from(v))),
+        Value::Double(v) => Ok(AvroValue::Float(v)),
+        Value::Bytes(v) => Ok(AvroValue::Bytes(v)),
+        Value::String(v) => Ok(AvroValue::String(v)),
+        Value::Fixed(_, v) => Ok(AvroValue::Bytes(v)),
+        Value::Enum(_, v) => Ok(AvroValue::String(v)),
+        Value::Union(_, v) => avro_value_from_value(*v),
+        Value::Array(values) => values
+            .into_iter()
+            .map(avro_value_from_value)
+            .collect::<crate::Result<Vec<_>>>()
+            .map(AvroValue::Array),
+        Value::Map(values) => values
+            .into_iter()
+            .map(|(name, value)| Ok((name, avro_value_from_value(value)?)))
+            .collect::<crate::Result<HashMap<_, _>>>()
+            .map(AvroValue::Object),
+        Value::Record(fields) => fields
+            .into_iter()
+            .map(|(name, value)| Ok((name, avro_value_from_value(value)?)))
+            .collect::<crate::Result<HashMap<_, _>>>()
+            .map(AvroValue::Object),
+        Value::Date(v) => Ok(AvroValue::Int(i64::from(v))),
+        Value::Decimal(v) => Vec::<u8>::try_from(v)
+            .map(AvroValue::Bytes)
+            .map_err(crate::Error::from),
+        Value::BigDecimal(v) => Ok(AvroValue::String(v.to_string())),
+        Value::TimeMillis(v) => Ok(AvroValue::Int(i64::from(v))),
+        Value::TimeMicros(v) => Ok(AvroValue::Int(v)),
+        Value::TimestampMillis(v) => Ok(AvroValue::Int(v)),
+        Value::TimestampMicros(v) => Ok(AvroValue::Int(v)),
+        Value::TimestampNanos(v) => Ok(AvroValue::Int(v)),
+        Value::LocalTimestampMillis(v) => Ok(AvroValue::Int(v)),
+        Value::LocalTimestampMicros(v) => Ok(AvroValue::Int(v)),
+        Value::LocalTimestampNanos(v) => Ok(AvroValue::Int(v)),
+        Value::Duration(v) => Ok(AvroValue::Bytes(<[u8; 12]>::from(v).to_vec())),
+        Value::Uuid(v) => Ok(AvroValue::String(v.to_string())),
     }
 }
 

--- a/crates/paimon/src/error.rs
+++ b/crates/paimon/src/error.rs
@@ -70,6 +70,14 @@ pub enum Error {
     ConfigInvalid { message: String },
     #[snafu(
         visibility(pub(crate)),
+        display("Paimon hitting unexpected avro error {}: {:?}", message, source)
+    )]
+    DataUnexpected {
+        message: String,
+        source: Box<apache_avro::Error>,
+    },
+    #[snafu(
+        visibility(pub(crate)),
         display("Paimon hitting invalid file index format: {}", message)
     )]
     FileIndexFormatInvalid { message: String },
@@ -114,6 +122,15 @@ impl From<opendal::Error> for Error {
         // TODO: Simple use IoUnexpected for now
         Error::IoUnexpected {
             message: "IO operation failed on underlying storage".to_string(),
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<apache_avro::Error> for Error {
+    fn from(source: apache_avro::Error) -> Self {
+        Error::DataUnexpected {
+            message: "".to_string(),
             source: Box::new(source),
         }
     }

--- a/crates/paimon/src/spec/index_manifest.rs
+++ b/crates/paimon/src/spec/index_manifest.rs
@@ -18,9 +18,9 @@
 use crate::io::FileIO;
 use crate::spec::manifest_common::FileKind;
 use crate::spec::IndexFileMeta;
+use apache_avro::types::Value;
+use apache_avro::{from_avro_datum, from_value, to_avro_datum, to_value, Reader, Schema};
 use serde::{Deserialize, Serialize};
-use serde_avro_fast::object_container_file_encoding::Reader;
-use snafu::ResultExt;
 use std::fmt::{Display, Formatter};
 
 use crate::Result;
@@ -74,12 +74,12 @@ impl IndexManifest {
 
     /// Read index manifest entries from Avro-encoded bytes.
     pub fn read_from_bytes(bytes: &[u8]) -> Result<Vec<IndexManifestEntry>> {
-        let mut reader = Reader::from_slice(bytes)
-            .whatever_context::<_, crate::Error>("read index manifest avro")?;
-        reader
-            .deserialize::<IndexManifestEntry>()
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .whatever_context::<_, crate::Error>("deserialize index manifest entry")
+        let reader = Reader::new(bytes).map_err(crate::Error::from)?;
+        let records = reader
+            .collect::<std::result::Result<Vec<Value>, _>>()
+            .map_err(crate::Error::from)?;
+        let values = Value::Array(records);
+        from_value::<Vec<IndexManifestEntry>>(&values).map_err(crate::Error::from)
     }
 }
 
@@ -148,7 +148,7 @@ mod tests {
             },
         };
 
-        let schema: serde_avro_fast::Schema = r#"["null", {
+        let schema = Schema::parse_str(r#"["null", {
             "type": "record", 
             "name": "org.apache.paimon.avro.generated.record", 
             "fields": [
@@ -179,12 +179,16 @@ mod tests {
                 }
             ]
             }]"#
-            .parse().unwrap();
+        )
+        .unwrap();
 
-        let serializer_config = &mut serde_avro_fast::ser::SerializerConfig::new(&schema);
-        let encoded = serde_avro_fast::to_single_object_vec(&sample, serializer_config).unwrap();
-        let decoded: IndexManifestEntry =
-            serde_avro_fast::from_single_object_slice(encoded.as_slice(), &schema).unwrap();
+        let value = to_value(&sample).unwrap().resolve(&schema).unwrap();
+        let encoded = to_avro_datum(&schema, value).unwrap();
+        let decoded_value = from_avro_datum(&schema, &mut encoded.as_slice(), None).unwrap();
+        let decoded: IndexManifestEntry = match decoded_value {
+            Value::Union(_, inner) => from_value(inner.as_ref()).unwrap(),
+            other => from_value(&other).unwrap(),
+        };
         assert_eq!(sample, decoded);
     }
 }

--- a/crates/paimon/src/spec/manifest.rs
+++ b/crates/paimon/src/spec/manifest.rs
@@ -18,8 +18,8 @@
 use crate::io::FileIO;
 use crate::spec::manifest_entry::ManifestEntry;
 use crate::spec::manifest_entry::MANIFEST_ENTRY_SCHEMA;
-use serde_avro_fast::object_container_file_encoding::Reader;
-use snafu::ResultExt;
+use apache_avro::types::Value;
+use apache_avro::{from_value, Reader};
 
 use crate::Result;
 
@@ -46,12 +46,12 @@ impl Manifest {
 
     /// Read manifest entries from bytes.
     fn read_from_bytes(bytes: &[u8]) -> Result<Vec<ManifestEntry>> {
-        let mut reader =
-            Reader::from_slice(bytes).whatever_context::<_, crate::Error>("read manifest avro")?;
-        reader
-            .deserialize::<ManifestEntry>()
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .whatever_context::<_, crate::Error>("deserialize manifest entry")
+        let reader = Reader::new(bytes).map_err(crate::Error::from)?;
+        let records = reader
+            .collect::<std::result::Result<Vec<Value>, _>>()
+            .map_err(crate::Error::from)?;
+        let values = Value::Array(records);
+        from_value::<Vec<ManifestEntry>>(&values).map_err(crate::Error::from)
     }
 
     /// Write manifest entries to a file.

--- a/crates/paimon/src/spec/objects_file.rs
+++ b/crates/paimon/src/spec/objects_file.rs
@@ -15,18 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use apache_avro::{from_value, to_value, types::Value, Codec, Reader, Schema, Writer};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use serde_avro_fast::object_container_file_encoding::{Compression, Reader};
-use snafu::ResultExt;
 
 pub fn from_avro_bytes<T: DeserializeOwned>(bytes: &[u8]) -> crate::Result<Vec<T>> {
-    let mut reader = Reader::from_slice(bytes)
-        .whatever_context::<_, crate::Error>("read avro object container")?;
-    reader
-        .deserialize::<T>()
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .whatever_context::<_, crate::Error>("deserialize avro records")
+    let reader = Reader::new(bytes)?;
+    let records = reader.collect::<std::result::Result<Vec<Value>, _>>()?;
+    let values = Value::Array(records);
+    from_value::<Vec<T>>(&values).map_err(crate::Error::from)
 }
 
 /// Serialize records into Avro Object Container File bytes.
@@ -34,22 +31,30 @@ pub fn from_avro_bytes<T: DeserializeOwned>(bytes: &[u8]) -> crate::Result<Vec<T
 /// The `schema_json` must be a valid Avro schema JSON string that matches
 /// the serde serialization layout of `T`.
 pub fn to_avro_bytes<T: Serialize>(schema_json: &str, records: &[T]) -> crate::Result<Vec<u8>> {
-    let schema: serde_avro_fast::Schema =
-        schema_json
-            .parse()
-            .map_err(
-                |e: serde_avro_fast::schema::SchemaError| crate::Error::DataInvalid {
-                    message: format!("invalid avro schema: {e}"),
-                    source: Some(Box::new(e)),
-                },
-            )?;
-    serde_avro_fast::object_container_file_encoding::write_all(
-        &schema,
-        Compression::Null,
-        Vec::new(),
-        records.iter(),
-    )
-    .map_err(|e| crate::Error::DataInvalid {
+    let schema = Schema::parse_str(schema_json).map_err(|e| crate::Error::DataInvalid {
+        message: format!("invalid avro schema: {e}"),
+        source: Some(Box::new(e)),
+    })?;
+    let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
+    for record in records {
+        let value = to_value(record)
+            .and_then(|value| value.resolve(&schema))
+            .map_err(|e| crate::Error::DataInvalid {
+                message: format!("avro serialization failed: {e}"),
+                source: Some(Box::new(e)),
+            })?;
+        writer
+            .append(value)
+            .map_err(|e| crate::Error::DataInvalid {
+                message: format!("avro serialization failed: {e}"),
+                source: Some(Box::new(e)),
+            })?;
+    }
+    writer.flush().map_err(|e| crate::Error::DataInvalid {
+        message: format!("avro serialization failed: {e}"),
+        source: Some(Box::new(e)),
+    })?;
+    writer.into_inner().map_err(|e| crate::Error::DataInvalid {
         message: format!("avro serialization failed: {e}"),
         source: Some(Box::new(e)),
     })


### PR DESCRIPTION
### Purpose

Linked issue: N/A

Replace `serde_avro_fast` with `apache-avro` so the release branch no longer pulls in LGPL-3.0-only transitive dependencies while keeping the manifest parallel-read behavior introduced later.

### Brief change log

- replace the `paimon` crate dependency on `serde_avro_fast` with `apache-avro`
- switch manifest/index-manifest/object-container Avro read-write helpers back to `apache-avro`
- adapt the Avro format reader to convert `apache_avro::types::Value` into the existing internal `AvroValue` representation instead of deserializing through `serde_avro_fast`
- restore `apache_avro::Error` mapping in the crate error type

### Tests

- `cargo test -p paimon --lib`
- `cargo deny check licenses`

### API and Format

No API or storage format changes intended. The change is limited to the Rust-side Avro implementation used to read and write the same schemas.

### Documentation

No.
