### PR TITLE
fix: cherry-pick serde_avro_fast replacement and update dependency list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install cargo-deny
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deny@0.14.22
+          tool: cargo-deny@0.19.0
 
       - name: Check dependency licenses (Apache-compatible)
         run: cargo deny check licenses

--- a/DEPENDENCIES.rust.tsv
+++ b/DEPENDENCIES.rust.tsv
@@ -1,479 +1,477 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
-abi_stable@0.11.3		X										X						
-abi_stable_derive@0.11.3		X										X						
-abi_stable_shared@0.11.0		X										X						
-adler2@2.0.1	X	X										X						
-aes@0.8.4		X										X						
-ahash@0.8.12		X										X						
-aho-corasick@1.1.4												X				X		
-alloc-no-stdlib@2.0.4					X													
-alloc-stdlib@0.2.2					X													
-allocator-api2@0.2.21		X										X						
-android_system_properties@0.1.5		X										X						
-anyhow@1.0.102		X										X						
-ar_archive_writer@0.5.1			X															
-arrayref@0.3.9				X														
-arrayvec@0.7.6		X										X						
-arrow@58.1.0		X																
-arrow-arith@58.1.0		X																
-arrow-array@58.1.0		X																
-arrow-buffer@58.1.0		X																
-arrow-cast@58.1.0		X																
-arrow-csv@58.1.0		X																
-arrow-data@58.1.0		X																
-arrow-ipc@58.1.0		X																
-arrow-json@58.1.0		X																
-arrow-ord@58.1.0		X																
-arrow-pyarrow@58.1.0		X																
-arrow-row@58.1.0		X																
-arrow-schema@58.1.0		X																
-arrow-select@58.1.0		X																
-arrow-string@58.1.0		X																
-as_derive_utils@0.11.0		X										X						
-async-compression@0.4.41		X										X						
-async-ffi@0.5.0												X						
-async-stream@0.3.6												X						
-async-stream-impl@0.3.6												X						
-async-trait@0.1.89		X										X						
-atoi@2.0.0												X						
-atomic-waker@1.1.2		X										X						
-autocfg@1.5.0		X										X						
-backon@1.6.0		X																
-base64@0.22.1		X										X						
-bigdecimal@0.4.10		X										X						
-bitflags@2.9.1		X										X						
-blake2@0.10.6		X										X						
-blake3@1.8.3		X	X				X											
-block-buffer@0.10.4		X										X						
-block-padding@0.3.3		X										X						
-brotli@8.0.2					X							X						
-brotli-decompressor@5.0.0					X							X						
-bumpalo@3.19.0		X										X						
-bytemuck@1.25.0		X										X					X	
-byteorder@1.5.0												X				X		
-bytes@1.11.1												X						
-bzip2@0.6.1		X										X						
-cbc@0.1.2		X										X						
-cc@1.2.56		X										X						
-cfg-if@1.0.1		X										X						
-chacha20@0.10.0		X										X						
-chrono@0.4.44		X										X						
-chrono-tz@0.10.4		X										X						
-cipher@0.4.4		X										X						
-comfy-table@7.2.2												X						
-compression-codecs@0.4.37		X										X						
-compression-core@0.4.31		X										X						
-const-oid@0.9.6		X										X						
-const-random@0.1.18		X										X						
-const-random-macro@0.1.16		X										X						
-const_panic@0.2.15																	X	
-constant_time_eq@0.4.2		X					X						X					
-core-foundation@0.10.1		X										X						
-core-foundation@0.9.4		X										X						
-core-foundation-sys@0.8.7		X										X						
-core_extensions@1.5.4		X										X						
-core_extensions_proc_macros@1.5.4		X										X						
-cpufeatures@0.2.17		X										X						
-cpufeatures@0.3.0		X										X						
-crc@3.4.0		X										X						
-crc-catalog@2.4.0		X										X						
-crc32c@0.6.8		X										X						
-crc32fast@1.5.0		X										X						
-crossbeam-channel@0.5.15		X										X						
-crossbeam-utils@0.8.21		X										X						
-crunchy@0.2.4												X						
-crypto-common@0.1.6		X										X						
-csv@1.4.0												X				X		
-csv-core@0.1.13												X				X		
-ctr@0.9.2		X										X						
-darling@0.20.11												X						
-darling_core@0.20.11												X						
-darling_macro@0.20.11												X						
-dashmap@6.1.0												X						
-datafusion@53.0.0		X																
-datafusion-catalog@53.0.0		X																
-datafusion-catalog-listing@53.0.0		X																
-datafusion-common@53.0.0		X																
-datafusion-common-runtime@53.0.0		X																
-datafusion-datasource@53.0.0		X																
-datafusion-datasource-arrow@53.0.0		X																
-datafusion-datasource-csv@53.0.0		X																
-datafusion-datasource-json@53.0.0		X																
-datafusion-datasource-parquet@53.0.0		X																
-datafusion-doc@53.0.0		X																
-datafusion-execution@53.0.0		X																
-datafusion-expr@53.0.0		X																
-datafusion-expr-common@53.0.0		X																
-datafusion-ffi@53.0.0		X																
-datafusion-functions@53.0.0		X																
-datafusion-functions-aggregate@53.0.0		X																
-datafusion-functions-aggregate-common@53.0.0		X																
-datafusion-functions-nested@53.0.0		X																
-datafusion-functions-table@53.0.0		X																
-datafusion-functions-window@53.0.0		X																
-datafusion-functions-window-common@53.0.0		X																
-datafusion-macros@53.0.0		X																
-datafusion-optimizer@53.0.0		X																
-datafusion-physical-expr@53.0.0		X																
-datafusion-physical-expr-adapter@53.0.0		X																
-datafusion-physical-expr-common@53.0.0		X																
-datafusion-physical-optimizer@53.0.0		X																
-datafusion-physical-plan@53.0.0		X																
-datafusion-proto@53.0.0		X																
-datafusion-proto-common@53.0.0		X																
-datafusion-pruning@53.0.0		X																
-datafusion-session@53.0.0		X																
-datafusion-sql@53.0.0		X																
-des@0.8.1		X										X						
-diff@0.1.13		X										X						
-digest@0.10.7		X										X						
-displaydoc@0.2.5		X										X						
-dns-lookup@3.0.1		X										X						
-either@1.15.0		X										X						
-encoding_rs@0.8.35		X			X							X						
-equivalent@1.0.2		X										X						
-errno@0.3.14		X										X						
-fallible-streaming-iterator@0.1.9		X										X						
-fastrand@2.3.0		X										X						
-find-msvc-tools@0.1.9		X										X						
-fixedbitset@0.5.7		X										X						
-flatbuffers@25.12.19		X																
-flate2@1.1.9		X										X						
-fnv@1.0.7		X										X						
-foldhash@0.1.5																	X	
-foldhash@0.2.0																	X	
-foreign-types@0.3.2		X										X						
-foreign-types-shared@0.1.1		X										X						
-form_urlencoded@1.2.2		X										X						
-futures@0.3.31		X										X						
-futures-channel@0.3.31		X										X						
-futures-core@0.3.31		X										X						
-futures-executor@0.3.31		X										X						
-futures-io@0.3.31		X										X						
-futures-macro@0.3.31		X										X						
-futures-sink@0.3.31		X										X						
-futures-task@0.3.31		X										X						
-futures-util@0.3.31		X										X						
-g2gen@1.2.2		X										X						
-g2p@1.2.2		X										X						
-g2poly@1.2.2		X										X						
-generational-arena@0.2.9														X				
-generic-array@0.14.7												X						
-getrandom@0.2.16		X										X						
-getrandom@0.3.3		X										X						
-getrandom@0.4.1		X										X						
-glob@0.3.3		X										X						
-gloo-timers@0.3.0		X										X						
-h2@0.4.13												X						
-half@2.7.1		X										X						
-hashbrown@0.14.5		X										X						
-hashbrown@0.15.4		X										X						
-hashbrown@0.16.1		X										X						
-hdfs-native@0.13.5		X																
-heck@0.5.0		X										X						
-hex@0.4.3		X										X						
-hmac@0.12.1		X										X						
-home@0.5.12		X										X						
-http@1.3.1		X										X						
-http-body@1.0.1												X						
-http-body-util@0.1.3												X						
-httparse@1.10.1		X										X						
-httpdate@1.0.3		X										X						
-humantime@2.3.0		X										X						
-hyper@1.6.0												X						
-hyper-rustls@0.27.7		X							X			X						
-hyper-tls@0.6.0		X										X						
-hyper-util@0.1.15												X						
-iana-time-zone@0.1.63		X										X						
-iana-time-zone-haiku@0.1.2		X										X						
-icu_collections@2.0.0															X			
-icu_locale_core@2.0.0															X			
-icu_normalizer@2.0.0															X			
-icu_normalizer_data@2.0.0															X			
-icu_properties@2.0.1															X			
-icu_properties_data@2.0.1															X			
-icu_provider@2.0.0															X			
-ident_case@1.0.1		X										X						
-idna@1.1.0		X										X						
-idna_adapter@1.2.1		X										X						
-indexmap@2.13.0		X										X						
-inout@0.1.4		X										X						
-integer-encoding@3.0.4												X						
-integer-encoding@4.1.0												X						
-ipnet@2.11.0		X										X						
-iri-string@0.7.8		X										X						
-itertools@0.14.0		X										X						
-itoa@1.0.15		X										X						
-jiff@0.2.23												X				X		
-jiff-tzdb@0.1.6												X				X		
-jiff-tzdb-platform@0.1.3												X				X		
-jobserver@0.1.34		X										X						
-js-sys@0.3.77		X										X						
-lexical-core@1.0.6		X										X						
-lexical-parse-float@1.0.6		X										X						
-lexical-parse-integer@1.0.6		X										X						
-lexical-util@1.0.7		X										X						
-lexical-write-float@1.0.6		X										X						
-lexical-write-integer@1.0.6		X										X						
-libbz2-rs-sys@0.2.2																		X
-libc@0.2.182		X										X						
-libloading@0.7.4									X									
-libloading@0.9.0									X									
-liblzma@0.4.6		X										X						
-liblzma-sys@0.4.5		X										X						
-libm@0.2.15												X						
-libredox@0.1.16												X						
-linux-raw-sys@0.12.1		X	X									X						
-litemap@0.8.0															X			
-lock_api@0.4.14		X										X						
-log@0.4.29		X										X						
-lz4_flex@0.11.6												X						
-lz4_flex@0.13.0												X						
-lzokay-native@0.1.0												X						
-md-5@0.10.6		X										X						
-memchr@2.8.0												X				X		
-mime@0.3.17		X										X						
-miniz_oxide@0.8.9		X										X					X	
-mio@1.0.4												X						
-native-tls@0.2.18		X										X						
-num@0.4.3		X										X						
-num-bigint@0.4.6		X										X						
-num-complex@0.4.6		X										X						
-num-integer@0.1.46		X										X						
-num-iter@0.1.45		X										X						
-num-rational@0.4.2		X										X						
-num-traits@0.2.19		X										X						
-object@0.37.3		X										X						
-object_store@0.13.2		X										X						
-once_cell@1.21.3		X										X						
-opendal@0.55.0		X																
-openssl@0.10.76		X																
-openssl-macros@0.1.1		X										X						
-openssl-probe@0.2.1		X										X						
-openssl-sys@0.9.112												X						
-orc-rust@0.8.0		X																
-ordered-float@2.10.1												X						
-paimon@0.1.0		X																
-paimon-c@0.1.0		X																
-paimon-datafusion@0.1.0		X																
-paimon-integration-tests@0.1.0		X																
-parking_lot@0.12.5		X										X						
-parking_lot_core@0.9.12		X										X						
-parquet@58.1.0		X																
-paste@1.0.15		X										X						
-percent-encoding@2.3.2		X										X						
-petgraph@0.8.3		X										X						
-phf@0.12.1												X						
-phf_shared@0.12.1												X						
-pin-project-lite@0.2.16		X										X						
-pin-utils@0.1.0		X										X						
-pkg-config@0.3.32		X										X						
-plain@0.2.3		X										X						
-portable-atomic@1.13.1		X										X						
-portable-atomic-util@0.2.6		X										X						
-potential_utf@0.1.2															X			
-ppv-lite86@0.2.21		X										X						
-pretty_assertions@1.4.1		X										X						
-proc-macro2@1.0.95		X										X						
-prost@0.13.5		X																
-prost@0.14.3		X																
-prost-derive@0.13.5		X																
-prost-derive@0.14.3		X																
-prost-types@0.14.3		X																
-psm@0.1.30		X										X						
-pyo3@0.28.3		X										X						
-pyo3-build-config@0.28.3		X										X						
-pyo3-ffi@0.28.3		X										X						
-pyo3-macros@0.28.3		X										X						
-pyo3-macros-backend@0.28.3		X										X						
-pypaimon_rust@0.1.0		X																
-quick-xml@0.37.5												X						
-quick-xml@0.38.4												X						
-quote@1.0.44		X										X						
-r-efi@5.3.0		X								X		X						
-rand@0.10.0		X										X						
-rand@0.8.5		X										X						
-rand@0.9.2		X										X						
-rand_chacha@0.3.1		X										X						
-rand_chacha@0.9.0		X										X						
-rand_core@0.10.0		X										X						
-rand_core@0.6.4		X										X						
-rand_core@0.9.3		X										X						
-recursive@0.1.1												X						
-recursive-proc-macro-impl@0.1.1												X						
-redox_syscall@0.5.18												X						
-regex@1.12.3		X										X						
-regex-automata@0.4.14		X										X						
-regex-syntax@0.8.10		X										X						
-repr_offset@0.2.2																	X	
-reqsign@0.16.5		X																
-reqwest@0.12.28		X										X						
-ring@0.17.14		X							X									
-roaring@0.11.3		X										X						
-roxmltree@0.21.1		X										X						
-rust_decimal@1.41.0												X						
-rustc_version@0.4.1		X										X						
-rustix@1.1.4		X	X									X						
-rustls@0.23.29		X							X			X						
-rustls-pki-types@1.12.0		X										X						
-rustls-webpki@0.103.4									X									
-rustversion@1.0.21		X										X						
-ryu@1.0.20		X				X												
-same-file@1.0.6												X				X		
-schannel@0.1.29												X						
-scopeguard@1.2.0		X										X						
-security-framework@3.6.0		X										X						
-security-framework-sys@2.17.0		X										X						
-semver@1.0.27		X										X						
-seq-macro@0.3.6		X										X						
-serde@1.0.228		X										X						
-serde-transcode@1.1.1		X										X						
-serde_avro_fast@2.0.2											X							
-serde_bytes@0.11.19		X										X						
-serde_core@1.0.228		X										X						
-serde_derive@1.0.228		X										X						
-serde_json@1.0.149		X										X						
-serde_repr@0.1.20		X										X						
-serde_serializer_quick_unsupported@1.0.0											X							
-serde_urlencoded@0.7.1		X										X						
-serde_with@3.14.0		X										X						
-serde_with_macros@3.14.0		X										X						
-sha1@0.10.6		X										X						
-sha2@0.10.9		X										X						
-shlex@1.3.0		X										X						
-simd-adler32@0.3.8												X						
-simdutf8@0.1.5		X										X						
-siphasher@1.0.2		X										X						
-slab@0.4.10												X						
-smallvec@1.15.1		X										X						
-snafu@0.8.9		X										X						
-snafu@0.9.0		X										X						
-snafu-derive@0.8.9		X										X						
-snafu-derive@0.9.0		X										X						
-snap@1.1.1					X													
-socket2@0.5.10		X										X						
-socket2@0.6.2		X										X						
-sqlparser@0.61.0		X																
-sqlparser_derive@0.5.0		X																
-stable_deref_trait@1.2.0		X										X						
-stacker@0.1.23		X										X						
-strsim@0.11.1												X						
-subtle@2.6.1					X													
-syn@1.0.109		X										X						
-syn@2.0.117		X										X						
-sync_wrapper@1.0.2		X																
-synstructure@0.13.2												X						
-system-configuration@0.6.1		X										X						
-system-configuration-sys@0.6.0		X										X						
-target-lexicon@0.13.5			X															
-tempfile@3.26.0		X										X						
-thiserror@1.0.69		X										X						
-thiserror@2.0.18		X										X						
-thiserror-impl@1.0.69		X										X						
-thiserror-impl@2.0.18		X										X						
-thrift@0.17.0		X																
-tiny-keccak@2.0.2							X											
-tinystr@0.8.1															X			
-tokio@1.49.0												X						
-tokio-macros@2.6.0												X						
-tokio-native-tls@0.3.1												X						
-tokio-rustls@0.26.2		X										X						
-tokio-stream@0.1.18												X						
-tokio-util@0.7.18												X						
-tower@0.5.2												X						
-tower-http@0.6.8												X						
-tower-layer@0.3.3												X						
-tower-service@0.3.3												X						
-tracing@0.1.41												X						
-tracing-attributes@0.1.31												X						
-tracing-core@0.1.36												X						
-try-lock@0.2.5												X						
-tstr@0.2.4																	X	
-tstr_proc_macros@0.2.2																	X	
-twox-hash@2.1.2												X						
-typed-arena@2.0.2												X						
-typed-builder@0.19.1		X										X						
-typed-builder-macro@0.19.1		X										X						
-typenum@1.18.0		X										X						
-typewit@1.15.1																	X	
-unicode-ident@1.0.18		X										X			X			
-unicode-segmentation@1.13.2		X										X						
-unicode-width@0.2.2		X										X						
-untrusted@0.9.0									X									
-url@2.5.8		X										X						
-urlencoding@2.1.3												X						
-utf8_iter@1.0.4		X										X						
-uuid@1.21.0		X										X						
-vcpkg@0.2.15		X										X						
-version_check@0.9.5		X										X						
-walkdir@2.5.0												X				X		
-want@0.3.1												X						
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X						
-wasi@0.14.2+wasi-0.2.4		X	X									X						
-wasip2@1.0.2+wasi-0.2.9		X	X									X						
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X						
-wasite@0.1.0		X				X						X						
-wasm-bindgen@0.2.100		X										X						
-wasm-bindgen-backend@0.2.100		X										X						
-wasm-bindgen-futures@0.4.50		X										X						
-wasm-bindgen-macro@0.2.100		X										X						
-wasm-bindgen-macro-support@0.2.100		X										X						
-wasm-bindgen-shared@0.2.100		X										X						
-wasm-streams@0.4.2		X										X						
-web-sys@0.3.77		X										X						
-web-time@1.1.0		X										X						
-webpki-roots@1.0.2								X										
-whoami@1.6.1		X				X						X						
-winapi@0.3.9		X										X						
-winapi-i686-pc-windows-gnu@0.4.0		X										X						
-winapi-util@0.1.11												X				X		
-winapi-x86_64-pc-windows-gnu@0.4.0		X										X						
-windows-core@0.61.2		X										X						
-windows-implement@0.60.0		X										X						
-windows-interface@0.59.1		X										X						
-windows-link@0.1.3		X										X						
-windows-link@0.2.1		X										X						
-windows-registry@0.5.3		X										X						
-windows-result@0.3.4		X										X						
-windows-strings@0.4.2		X										X						
-windows-sys@0.52.0		X										X						
-windows-sys@0.59.0		X										X						
-windows-sys@0.60.2		X										X						
-windows-sys@0.61.2		X										X						
-windows-targets@0.52.6		X										X						
-windows-targets@0.53.5		X										X						
-windows_aarch64_gnullvm@0.52.6		X										X						
-windows_aarch64_gnullvm@0.53.1		X										X						
-windows_aarch64_msvc@0.52.6		X										X						
-windows_aarch64_msvc@0.53.1		X										X						
-windows_i686_gnu@0.52.6		X										X						
-windows_i686_gnu@0.53.1		X										X						
-windows_i686_gnullvm@0.52.6		X										X						
-windows_i686_gnullvm@0.53.1		X										X						
-windows_i686_msvc@0.52.6		X										X						
-windows_i686_msvc@0.53.1		X										X						
-windows_x86_64_gnu@0.52.6		X										X						
-windows_x86_64_gnu@0.53.1		X										X						
-windows_x86_64_gnullvm@0.52.6		X										X						
-windows_x86_64_gnullvm@0.53.1		X										X						
-windows_x86_64_msvc@0.52.6		X										X						
-windows_x86_64_msvc@0.53.1		X										X						
-wit-bindgen@0.51.0		X	X									X						
-wit-bindgen-rt@0.39.0		X	X									X						
-writeable@0.6.1															X			
-yansi@1.0.1		X										X						
-yoke@0.8.0															X			
-yoke-derive@0.8.0															X			
-zerocopy@0.8.26		X		X								X						
-zerocopy-derive@0.8.26		X		X								X						
-zerofrom@0.1.6															X			
-zerofrom-derive@0.1.6															X			
-zeroize@1.8.1		X										X						
-zerotrie@0.2.2															X			
-zerovec@0.11.2															X			
-zerovec-derive@0.11.1															X			
-zlib-rs@0.6.3																	X	
-zmij@1.0.21												X						
-zstd@0.13.3												X						
-zstd-safe@7.2.4		X										X						
-zstd-sys@2.0.16+zstd.1.5.7		X										X						
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
+abi_stable@0.11.3		X									X						
+abi_stable_derive@0.11.3		X									X						
+abi_stable_shared@0.11.0		X									X						
+adler2@2.0.1	X	X									X						
+aes@0.8.4		X									X						
+ahash@0.8.12		X									X						
+aho-corasick@1.1.4											X				X		
+alloc-no-stdlib@2.0.4					X												
+alloc-stdlib@0.2.2					X												
+allocator-api2@0.2.21		X									X						
+android_system_properties@0.1.5		X									X						
+anyhow@1.0.102		X									X						
+apache-avro@0.21.0		X															
+ar_archive_writer@0.5.1			X														
+arrayref@0.3.9				X													
+arrayvec@0.7.6		X									X						
+arrow@58.1.0		X															
+arrow-arith@58.1.0		X															
+arrow-array@58.1.0		X															
+arrow-buffer@58.1.0		X															
+arrow-cast@58.1.0		X															
+arrow-csv@58.1.0		X															
+arrow-data@58.1.0		X															
+arrow-ipc@58.1.0		X															
+arrow-json@58.1.0		X															
+arrow-ord@58.1.0		X															
+arrow-pyarrow@58.1.0		X															
+arrow-row@58.1.0		X															
+arrow-schema@58.1.0		X															
+arrow-select@58.1.0		X															
+arrow-string@58.1.0		X															
+as_derive_utils@0.11.0		X									X						
+async-compression@0.4.41		X									X						
+async-ffi@0.5.0											X						
+async-stream@0.3.6											X						
+async-stream-impl@0.3.6											X						
+async-trait@0.1.89		X									X						
+atoi@2.0.0											X						
+atomic-waker@1.1.2		X									X						
+autocfg@1.5.0		X									X						
+backon@1.6.0		X															
+base64@0.22.1		X									X						
+bigdecimal@0.4.10		X									X						
+bitflags@2.9.1		X									X						
+blake2@0.10.6		X									X						
+blake3@1.8.3		X	X				X										
+block-buffer@0.10.4		X									X						
+block-padding@0.3.3		X									X						
+bon@3.9.1		X									X						
+bon-macros@3.9.1		X									X						
+brotli@8.0.2					X						X						
+brotli-decompressor@5.0.0					X						X						
+bumpalo@3.19.0		X									X						
+bytemuck@1.25.0		X									X					X	
+byteorder@1.5.0											X				X		
+bytes@1.11.1											X						
+bzip2@0.6.1		X									X						
+cbc@0.1.2		X									X						
+cc@1.2.56		X									X						
+cfg-if@1.0.1		X									X						
+chrono@0.4.44		X									X						
+chrono-tz@0.10.4		X									X						
+cipher@0.4.4		X									X						
+comfy-table@7.2.2											X						
+compression-codecs@0.4.37		X									X						
+compression-core@0.4.31		X									X						
+const-oid@0.9.6		X									X						
+const-random@0.1.18		X									X						
+const-random-macro@0.1.16		X									X						
+const_panic@0.2.15																X	
+constant_time_eq@0.4.2		X					X					X					
+core-foundation@0.10.1		X									X						
+core-foundation@0.9.4		X									X						
+core-foundation-sys@0.8.7		X									X						
+core_extensions@1.5.4		X									X						
+core_extensions_proc_macros@1.5.4		X									X						
+cpufeatures@0.2.17		X									X						
+crc@3.4.0		X									X						
+crc-catalog@2.4.0		X									X						
+crc32c@0.6.8		X									X						
+crc32fast@1.5.0		X									X						
+crossbeam-channel@0.5.15		X									X						
+crossbeam-utils@0.8.21		X									X						
+crunchy@0.2.4											X						
+crypto-common@0.1.6		X									X						
+csv@1.4.0											X				X		
+csv-core@0.1.13											X				X		
+ctr@0.9.2		X									X						
+darling@0.20.11											X						
+darling_core@0.20.11											X						
+darling_macro@0.20.11											X						
+dashmap@6.1.0											X						
+datafusion@53.0.0		X															
+datafusion-catalog@53.0.0		X															
+datafusion-catalog-listing@53.0.0		X															
+datafusion-common@53.0.0		X															
+datafusion-common-runtime@53.0.0		X															
+datafusion-datasource@53.0.0		X															
+datafusion-datasource-arrow@53.0.0		X															
+datafusion-datasource-csv@53.0.0		X															
+datafusion-datasource-json@53.0.0		X															
+datafusion-datasource-parquet@53.0.0		X															
+datafusion-doc@53.0.0		X															
+datafusion-execution@53.0.0		X															
+datafusion-expr@53.0.0		X															
+datafusion-expr-common@53.0.0		X															
+datafusion-ffi@53.0.0		X															
+datafusion-functions@53.0.0		X															
+datafusion-functions-aggregate@53.0.0		X															
+datafusion-functions-aggregate-common@53.0.0		X															
+datafusion-functions-nested@53.0.0		X															
+datafusion-functions-table@53.0.0		X															
+datafusion-functions-window@53.0.0		X															
+datafusion-functions-window-common@53.0.0		X															
+datafusion-macros@53.0.0		X															
+datafusion-optimizer@53.0.0		X															
+datafusion-physical-expr@53.0.0		X															
+datafusion-physical-expr-adapter@53.0.0		X															
+datafusion-physical-expr-common@53.0.0		X															
+datafusion-physical-optimizer@53.0.0		X															
+datafusion-physical-plan@53.0.0		X															
+datafusion-proto@53.0.0		X															
+datafusion-proto-common@53.0.0		X															
+datafusion-pruning@53.0.0		X															
+datafusion-session@53.0.0		X															
+datafusion-sql@53.0.0		X															
+des@0.8.1		X									X						
+diff@0.1.13		X									X						
+digest@0.10.7		X									X						
+displaydoc@0.2.5		X									X						
+dns-lookup@3.0.1		X									X						
+either@1.15.0		X									X						
+encoding_rs@0.8.35		X			X						X						
+equivalent@1.0.2		X									X						
+errno@0.3.14		X									X						
+fallible-streaming-iterator@0.1.9		X									X						
+fastrand@2.3.0		X									X						
+find-msvc-tools@0.1.9		X									X						
+fixedbitset@0.5.7		X									X						
+flatbuffers@25.12.19		X															
+flate2@1.1.9		X									X						
+fnv@1.0.7		X									X						
+foldhash@0.1.5																X	
+foldhash@0.2.0																X	
+foreign-types@0.3.2		X									X						
+foreign-types-shared@0.1.1		X									X						
+form_urlencoded@1.2.2		X									X						
+futures@0.3.31		X									X						
+futures-channel@0.3.31		X									X						
+futures-core@0.3.31		X									X						
+futures-executor@0.3.31		X									X						
+futures-io@0.3.31		X									X						
+futures-macro@0.3.31		X									X						
+futures-sink@0.3.31		X									X						
+futures-task@0.3.31		X									X						
+futures-util@0.3.31		X									X						
+g2gen@1.2.2		X									X						
+g2p@1.2.2		X									X						
+g2poly@1.2.2		X									X						
+generational-arena@0.2.9													X				
+generic-array@0.14.7											X						
+getrandom@0.2.16		X									X						
+getrandom@0.3.3		X									X						
+getrandom@0.4.1		X									X						
+glob@0.3.3		X									X						
+gloo-timers@0.3.0		X									X						
+h2@0.4.13											X						
+half@2.7.1		X									X						
+hashbrown@0.14.5		X									X						
+hashbrown@0.15.4		X									X						
+hashbrown@0.16.1		X									X						
+hdfs-native@0.13.5		X															
+heck@0.5.0		X									X						
+hex@0.4.3		X									X						
+hmac@0.12.1		X									X						
+home@0.5.12		X									X						
+http@1.3.1		X									X						
+http-body@1.0.1											X						
+http-body-util@0.1.3											X						
+httparse@1.10.1		X									X						
+httpdate@1.0.3		X									X						
+humantime@2.3.0		X									X						
+hyper@1.6.0											X						
+hyper-rustls@0.27.7		X							X		X						
+hyper-tls@0.6.0		X									X						
+hyper-util@0.1.15											X						
+iana-time-zone@0.1.63		X									X						
+iana-time-zone-haiku@0.1.2		X									X						
+icu_collections@2.0.0														X			
+icu_locale_core@2.0.0														X			
+icu_normalizer@2.0.0														X			
+icu_normalizer_data@2.0.0														X			
+icu_properties@2.0.1														X			
+icu_properties_data@2.0.1														X			
+icu_provider@2.0.0														X			
+ident_case@1.0.1		X									X						
+idna@1.1.0		X									X						
+idna_adapter@1.2.1		X									X						
+indexmap@2.13.0		X									X						
+inout@0.1.4		X									X						
+integer-encoding@3.0.4											X						
+ipnet@2.11.0		X									X						
+iri-string@0.7.8		X									X						
+itertools@0.14.0		X									X						
+itoa@1.0.15		X									X						
+jiff@0.2.23											X				X		
+jiff-tzdb@0.1.6											X				X		
+jiff-tzdb-platform@0.1.3											X				X		
+jobserver@0.1.34		X									X						
+js-sys@0.3.95		X									X						
+lexical-core@1.0.6		X									X						
+lexical-parse-float@1.0.6		X									X						
+lexical-parse-integer@1.0.6		X									X						
+lexical-util@1.0.7		X									X						
+lexical-write-float@1.0.6		X									X						
+lexical-write-integer@1.0.6		X									X						
+libbz2-rs-sys@0.2.2																	X
+libc@0.2.182		X									X						
+libloading@0.7.4									X								
+libloading@0.9.0									X								
+liblzma@0.4.6		X									X						
+liblzma-sys@0.4.5		X									X						
+libm@0.2.15											X						
+libredox@0.1.16											X						
+linux-raw-sys@0.12.1		X	X								X						
+litemap@0.8.0														X			
+lock_api@0.4.14		X									X						
+log@0.4.29		X									X						
+lz4_flex@0.11.6											X						
+lz4_flex@0.13.0											X						
+lzokay-native@0.1.0											X						
+md-5@0.10.6		X									X						
+memchr@2.8.0											X				X		
+mime@0.3.17		X									X						
+miniz_oxide@0.8.9		X									X					X	
+mio@1.0.4											X						
+native-tls@0.2.18		X									X						
+num@0.4.3		X									X						
+num-bigint@0.4.6		X									X						
+num-complex@0.4.6		X									X						
+num-integer@0.1.46		X									X						
+num-iter@0.1.45		X									X						
+num-rational@0.4.2		X									X						
+num-traits@0.2.19		X									X						
+object@0.37.3		X									X						
+object_store@0.13.2		X									X						
+once_cell@1.21.3		X									X						
+opendal@0.55.0		X															
+openssl@0.10.77		X															
+openssl-macros@0.1.1		X									X						
+openssl-probe@0.2.1		X									X						
+openssl-sys@0.9.113											X						
+orc-rust@0.8.0		X															
+ordered-float@2.10.1											X						
+paimon@0.1.0		X															
+paimon-c@0.1.0		X															
+paimon-datafusion@0.1.0		X															
+paimon-integration-tests@0.1.0		X															
+parking_lot@0.12.5		X									X						
+parking_lot_core@0.9.12		X									X						
+parquet@58.1.0		X															
+paste@1.0.15		X									X						
+percent-encoding@2.3.2		X									X						
+petgraph@0.8.3		X									X						
+phf@0.12.1											X						
+phf_shared@0.12.1											X						
+pin-project-lite@0.2.16		X									X						
+pin-utils@0.1.0		X									X						
+pkg-config@0.3.32		X									X						
+plain@0.2.3		X									X						
+portable-atomic@1.13.1		X									X						
+portable-atomic-util@0.2.6		X									X						
+potential_utf@0.1.2														X			
+ppv-lite86@0.2.21		X									X						
+pretty_assertions@1.4.1		X									X						
+prettyplease@0.2.37		X									X						
+proc-macro2@1.0.95		X									X						
+prost@0.13.5		X															
+prost@0.14.3		X															
+prost-derive@0.13.5		X															
+prost-derive@0.14.3		X															
+prost-types@0.14.3		X															
+psm@0.1.30		X									X						
+pyo3@0.28.3		X									X						
+pyo3-build-config@0.28.3		X									X						
+pyo3-ffi@0.28.3		X									X						
+pyo3-macros@0.28.3		X									X						
+pyo3-macros-backend@0.28.3		X									X						
+pypaimon_rust@0.1.0		X															
+quad-rand@0.2.3											X						
+quick-xml@0.37.5											X						
+quick-xml@0.38.4											X						
+quote@1.0.44		X									X						
+r-efi@5.3.0		X								X	X						
+rand@0.8.5		X									X						
+rand@0.9.2		X									X						
+rand_chacha@0.3.1		X									X						
+rand_chacha@0.9.0		X									X						
+rand_core@0.6.4		X									X						
+rand_core@0.9.3		X									X						
+recursive@0.1.1											X						
+recursive-proc-macro-impl@0.1.1											X						
+redox_syscall@0.5.18											X						
+regex@1.12.3		X									X						
+regex-automata@0.4.14		X									X						
+regex-lite@0.1.9		X									X						
+regex-syntax@0.8.10		X									X						
+repr_offset@0.2.2																X	
+reqsign@0.16.5		X															
+reqwest@0.12.28		X									X						
+ring@0.17.14		X							X								
+roaring@0.11.3		X									X						
+roxmltree@0.21.1		X									X						
+rustc_version@0.4.1		X									X						
+rustix@1.1.4		X	X								X						
+rustls@0.23.29		X							X		X						
+rustls-pki-types@1.12.0		X									X						
+rustls-webpki@0.103.4									X								
+rustversion@1.0.21		X									X						
+ryu@1.0.20		X				X											
+same-file@1.0.6											X				X		
+schannel@0.1.29											X						
+scopeguard@1.2.0		X									X						
+security-framework@3.6.0		X									X						
+security-framework-sys@2.17.0		X									X						
+semver@1.0.27		X									X						
+seq-macro@0.3.6		X									X						
+serde@1.0.228		X									X						
+serde_bytes@0.11.19		X									X						
+serde_core@1.0.228		X									X						
+serde_derive@1.0.228		X									X						
+serde_json@1.0.149		X									X						
+serde_repr@0.1.20		X									X						
+serde_urlencoded@0.7.1		X									X						
+serde_with@3.14.0		X									X						
+serde_with_macros@3.14.0		X									X						
+sha1@0.10.6		X									X						
+sha2@0.10.9		X									X						
+shlex@1.3.0		X									X						
+simd-adler32@0.3.8											X						
+simdutf8@0.1.5		X									X						
+siphasher@1.0.2		X									X						
+slab@0.4.10											X						
+smallvec@1.15.1		X									X						
+snafu@0.8.9		X									X						
+snafu@0.9.0		X									X						
+snafu-derive@0.8.9		X									X						
+snafu-derive@0.9.0		X									X						
+snap@1.1.1					X												
+socket2@0.5.10		X									X						
+socket2@0.6.2		X									X						
+sqlparser@0.61.0		X															
+sqlparser_derive@0.5.0		X															
+stable_deref_trait@1.2.0		X									X						
+stacker@0.1.23		X									X						
+strsim@0.11.1											X						
+strum@0.27.2											X						
+strum_macros@0.27.2											X						
+subtle@2.6.1					X												
+syn@1.0.109		X									X						
+syn@2.0.117		X									X						
+sync_wrapper@1.0.2		X															
+synstructure@0.13.2											X						
+system-configuration@0.6.1		X									X						
+system-configuration-sys@0.6.0		X									X						
+target-lexicon@0.13.5			X														
+tempfile@3.26.0		X									X						
+thiserror@1.0.69		X									X						
+thiserror@2.0.18		X									X						
+thiserror-impl@1.0.69		X									X						
+thiserror-impl@2.0.18		X									X						
+thrift@0.17.0		X															
+tiny-keccak@2.0.2							X										
+tinystr@0.8.1														X			
+tokio@1.49.0											X						
+tokio-macros@2.6.0											X						
+tokio-native-tls@0.3.1											X						
+tokio-rustls@0.26.2		X									X						
+tokio-stream@0.1.18											X						
+tokio-util@0.7.18											X						
+tower@0.5.2											X						
+tower-http@0.6.8											X						
+tower-layer@0.3.3											X						
+tower-service@0.3.3											X						
+tracing@0.1.41											X						
+tracing-attributes@0.1.31											X						
+tracing-core@0.1.36											X						
+try-lock@0.2.5											X						
+tstr@0.2.4																X	
+tstr_proc_macros@0.2.2																X	
+twox-hash@2.1.2											X						
+typed-arena@2.0.2											X						
+typed-builder@0.19.1		X									X						
+typed-builder-macro@0.19.1		X									X						
+typenum@1.18.0		X									X						
+typewit@1.15.1																X	
+unicode-ident@1.0.18		X									X			X			
+unicode-segmentation@1.13.2		X									X						
+unicode-width@0.2.2		X									X						
+untrusted@0.9.0									X								
+url@2.5.8		X									X						
+urlencoding@2.1.3											X						
+utf8_iter@1.0.4		X									X						
+uuid@1.21.0		X									X						
+vcpkg@0.2.15		X									X						
+version_check@0.9.5		X									X						
+walkdir@2.5.0											X				X		
+want@0.3.1											X						
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X						
+wasi@0.14.2+wasi-0.2.4		X	X								X						
+wasip2@1.0.2+wasi-0.2.9		X	X								X						
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X						
+wasite@0.1.0		X				X					X						
+wasm-bindgen@0.2.118		X									X						
+wasm-bindgen-futures@0.4.68		X									X						
+wasm-bindgen-macro@0.2.118		X									X						
+wasm-bindgen-macro-support@0.2.118		X									X						
+wasm-bindgen-shared@0.2.118		X									X						
+wasm-streams@0.4.2		X									X						
+web-sys@0.3.95		X									X						
+web-time@1.1.0		X									X						
+webpki-roots@1.0.2								X									
+whoami@1.6.1		X				X					X						
+winapi@0.3.9		X									X						
+winapi-i686-pc-windows-gnu@0.4.0		X									X						
+winapi-util@0.1.11											X				X		
+winapi-x86_64-pc-windows-gnu@0.4.0		X									X						
+windows-core@0.61.2		X									X						
+windows-implement@0.60.0		X									X						
+windows-interface@0.59.1		X									X						
+windows-link@0.1.3		X									X						
+windows-link@0.2.1		X									X						
+windows-registry@0.5.3		X									X						
+windows-result@0.3.4		X									X						
+windows-strings@0.4.2		X									X						
+windows-sys@0.52.0		X									X						
+windows-sys@0.59.0		X									X						
+windows-sys@0.60.2		X									X						
+windows-sys@0.61.2		X									X						
+windows-targets@0.52.6		X									X						
+windows-targets@0.53.5		X									X						
+windows_aarch64_gnullvm@0.52.6		X									X						
+windows_aarch64_gnullvm@0.53.1		X									X						
+windows_aarch64_msvc@0.52.6		X									X						
+windows_aarch64_msvc@0.53.1		X									X						
+windows_i686_gnu@0.52.6		X									X						
+windows_i686_gnu@0.53.1		X									X						
+windows_i686_gnullvm@0.52.6		X									X						
+windows_i686_gnullvm@0.53.1		X									X						
+windows_i686_msvc@0.52.6		X									X						
+windows_i686_msvc@0.53.1		X									X						
+windows_x86_64_gnu@0.52.6		X									X						
+windows_x86_64_gnu@0.53.1		X									X						
+windows_x86_64_gnullvm@0.52.6		X									X						
+windows_x86_64_gnullvm@0.53.1		X									X						
+windows_x86_64_msvc@0.52.6		X									X						
+windows_x86_64_msvc@0.53.1		X									X						
+wit-bindgen@0.51.0		X	X								X						
+wit-bindgen-rt@0.39.0		X	X								X						
+writeable@0.6.1														X			
+yansi@1.0.1		X									X						
+yoke@0.8.0														X			
+yoke-derive@0.8.0														X			
+zerocopy@0.8.26		X		X							X						
+zerocopy-derive@0.8.26		X		X							X						
+zerofrom@0.1.6														X			
+zerofrom-derive@0.1.6														X			
+zeroize@1.8.1		X									X						
+zerotrie@0.2.2														X			
+zerovec@0.11.2														X			
+zerovec-derive@0.11.1														X			
+zlib-rs@0.6.3																X	
+zmij@1.0.21											X						
+zstd@0.13.3											X						
+zstd-safe@7.2.4		X									X						
+zstd-sys@2.0.16+zstd.1.5.7		X									X						

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -1,344 +1,345 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X										X			
-ahash@0.8.12		X										X			
-aho-corasick@1.1.4												X		X	
-alloc-no-stdlib@2.0.4					X										
-alloc-stdlib@0.2.2					X										
-android_system_properties@0.1.5		X										X			
-anyhow@1.0.102		X										X			
-arrayvec@0.7.6		X										X			
-arrow@58.1.0		X													
-arrow-arith@58.1.0		X													
-arrow-array@58.1.0		X													
-arrow-buffer@58.1.0		X													
-arrow-cast@58.1.0		X													
-arrow-csv@58.1.0		X													
-arrow-data@58.1.0		X													
-arrow-ipc@58.1.0		X													
-arrow-json@58.1.0		X													
-arrow-ord@58.1.0		X													
-arrow-row@58.1.0		X													
-arrow-schema@58.1.0		X													
-arrow-select@58.1.0		X													
-arrow-string@58.1.0		X													
-async-stream@0.3.6												X			
-async-stream-impl@0.3.6												X			
-async-trait@0.1.89		X										X			
-atoi@2.0.0												X			
-atomic-waker@1.1.2		X										X			
-autocfg@1.5.0		X										X			
-backon@1.6.0		X													
-base64@0.22.1		X										X			
-bitflags@2.9.1		X										X			
-block-buffer@0.10.4		X										X			
-brotli@8.0.2					X							X			
-brotli-decompressor@5.0.0					X							X			
-bumpalo@3.19.0		X										X			
-bytemuck@1.25.0		X										X			X
-byteorder@1.5.0												X		X	
-bytes@1.11.1												X			
-cc@1.2.56		X										X			
-cfg-if@1.0.1		X										X			
-chacha20@0.10.0		X										X			
-chrono@0.4.44		X										X			
-chrono-tz@0.10.4		X										X			
-comfy-table@7.2.2												X			
-const-oid@0.9.6		X										X			
-const-random@0.1.18		X										X			
-const-random-macro@0.1.16		X										X			
-core-foundation@0.10.1		X										X			
-core-foundation@0.9.4		X										X			
-core-foundation-sys@0.8.7		X										X			
-cpufeatures@0.2.17		X										X			
-cpufeatures@0.3.0		X										X			
-crc32fast@1.5.0		X										X			
-crunchy@0.2.4												X			
-crypto-common@0.1.6		X										X			
-csv@1.4.0												X		X	
-csv-core@0.1.13												X		X	
-darling@0.20.11												X			
-darling_core@0.20.11												X			
-darling_macro@0.20.11												X			
-diff@0.1.13		X										X			
-digest@0.10.7		X										X			
-displaydoc@0.2.5		X										X			
-either@1.15.0		X										X			
-encoding_rs@0.8.35		X			X							X			
-equivalent@1.0.2		X										X			
-errno@0.3.14		X										X			
-fallible-streaming-iterator@0.1.9		X										X			
-fastrand@2.3.0		X										X			
-find-msvc-tools@0.1.9		X										X			
-flatbuffers@25.12.19		X													
-flate2@1.1.9		X										X			
-fnv@1.0.7		X										X			
-foreign-types@0.3.2		X										X			
-foreign-types-shared@0.1.1		X										X			
-form_urlencoded@1.2.2		X										X			
-futures@0.3.31		X										X			
-futures-channel@0.3.31		X										X			
-futures-core@0.3.31		X										X			
-futures-executor@0.3.31		X										X			
-futures-io@0.3.31		X										X			
-futures-macro@0.3.31		X										X			
-futures-sink@0.3.31		X										X			
-futures-task@0.3.31		X										X			
-futures-util@0.3.31		X										X			
-generic-array@0.14.7												X			
-getrandom@0.2.16		X										X			
-getrandom@0.3.3		X										X			
-getrandom@0.4.1		X										X			
-gloo-timers@0.3.0		X										X			
-h2@0.4.13												X			
-half@2.7.1		X										X			
-hashbrown@0.16.1		X										X			
-heck@0.5.0		X										X			
-hex@0.4.3		X										X			
-hmac@0.12.1		X										X			
-home@0.5.12		X										X			
-http@1.3.1		X										X			
-http-body@1.0.1												X			
-http-body-util@0.1.3												X			
-httparse@1.10.1		X										X			
-httpdate@1.0.3		X										X			
-hyper@1.6.0												X			
-hyper-rustls@0.27.7		X							X			X			
-hyper-tls@0.6.0		X										X			
-hyper-util@0.1.15												X			
-iana-time-zone@0.1.63		X										X			
-iana-time-zone-haiku@0.1.2		X										X			
-icu_collections@2.0.0													X		
-icu_locale_core@2.0.0													X		
-icu_normalizer@2.0.0													X		
-icu_normalizer_data@2.0.0													X		
-icu_properties@2.0.1													X		
-icu_properties_data@2.0.1													X		
-icu_provider@2.0.0													X		
-ident_case@1.0.1		X										X			
-idna@1.1.0		X										X			
-idna_adapter@1.2.1		X										X			
-indexmap@2.13.0		X										X			
-integer-encoding@3.0.4												X			
-integer-encoding@4.1.0												X			
-ipnet@2.11.0		X										X			
-iri-string@0.7.8		X										X			
-itertools@0.14.0		X										X			
-itoa@1.0.15		X										X			
-jiff@0.2.23												X		X	
-jiff-tzdb@0.1.6												X		X	
-jiff-tzdb-platform@0.1.3												X		X	
-jobserver@0.1.34		X										X			
-js-sys@0.3.77		X										X			
-lexical-core@1.0.6		X										X			
-lexical-parse-float@1.0.6		X										X			
-lexical-parse-integer@1.0.6		X										X			
-lexical-util@1.0.7		X										X			
-lexical-write-float@1.0.6		X										X			
-lexical-write-integer@1.0.6		X										X			
-libc@0.2.182		X										X			
-libm@0.2.15												X			
-linux-raw-sys@0.12.1		X	X									X			
-litemap@0.8.0													X		
-log@0.4.29		X										X			
-lz4_flex@0.11.6												X			
-lz4_flex@0.13.0												X			
-lzokay-native@0.1.0												X			
-md-5@0.10.6		X										X			
-memchr@2.8.0												X		X	
-mime@0.3.17		X										X			
-miniz_oxide@0.8.9		X										X			X
-mio@1.0.4												X			
-native-tls@0.2.18		X										X			
-num@0.4.3		X										X			
-num-bigint@0.4.6		X										X			
-num-complex@0.4.6		X										X			
-num-integer@0.1.46		X										X			
-num-iter@0.1.45		X										X			
-num-rational@0.4.2		X										X			
-num-traits@0.2.19		X										X			
-once_cell@1.21.3		X										X			
-opendal@0.55.0		X													
-openssl@0.10.76		X													
-openssl-macros@0.1.1		X										X			
-openssl-probe@0.2.1		X										X			
-openssl-sys@0.9.112												X			
-orc-rust@0.8.0		X													
-ordered-float@2.10.1												X			
-paimon@0.1.0		X													
-paimon-c@0.1.0		X													
-parquet@58.1.0		X													
-paste@1.0.15		X										X			
-percent-encoding@2.3.2		X										X			
-phf@0.12.1												X			
-phf_shared@0.12.1												X			
-pin-project-lite@0.2.16		X										X			
-pin-utils@0.1.0		X										X			
-pkg-config@0.3.32		X										X			
-portable-atomic@1.13.1		X										X			
-portable-atomic-util@0.2.6		X										X			
-potential_utf@0.1.2													X		
-ppv-lite86@0.2.21		X										X			
-pretty_assertions@1.4.1		X										X			
-proc-macro2@1.0.95		X										X			
-prost@0.13.5		X													
-prost-derive@0.13.5		X													
-quick-xml@0.38.4												X			
-quote@1.0.44		X										X			
-r-efi@5.3.0		X								X		X			
-rand@0.10.0		X										X			
-rand@0.8.5		X										X			
-rand_chacha@0.3.1		X										X			
-rand_core@0.10.0		X										X			
-rand_core@0.6.4		X										X			
-regex@1.12.3		X										X			
-regex-automata@0.4.14		X										X			
-regex-syntax@0.8.10		X										X			
-reqsign@0.16.5		X													
-reqwest@0.12.28		X										X			
-ring@0.17.14		X							X						
-roaring@0.11.3		X										X			
-rust_decimal@1.41.0												X			
-rustc_version@0.4.1		X										X			
-rustix@1.1.4		X	X									X			
-rustls@0.23.29		X							X			X			
-rustls-pki-types@1.12.0		X										X			
-rustls-webpki@0.103.4									X						
-rustversion@1.0.21		X										X			
-ryu@1.0.20		X				X									
-schannel@0.1.29												X			
-security-framework@3.6.0		X										X			
-security-framework-sys@2.17.0		X										X			
-semver@1.0.27		X										X			
-seq-macro@0.3.6		X										X			
-serde@1.0.228		X										X			
-serde-transcode@1.1.1		X										X			
-serde_avro_fast@2.0.2											X				
-serde_bytes@0.11.19		X										X			
-serde_core@1.0.228		X										X			
-serde_derive@1.0.228		X										X			
-serde_json@1.0.149		X										X			
-serde_repr@0.1.20		X										X			
-serde_serializer_quick_unsupported@1.0.0											X				
-serde_urlencoded@0.7.1		X										X			
-serde_with@3.14.0		X										X			
-serde_with_macros@3.14.0		X										X			
-sha1@0.10.6		X										X			
-sha2@0.10.9		X										X			
-shlex@1.3.0		X										X			
-simd-adler32@0.3.8												X			
-simdutf8@0.1.5		X										X			
-siphasher@1.0.2		X										X			
-slab@0.4.10												X			
-smallvec@1.15.1		X										X			
-snafu@0.8.9		X										X			
-snafu@0.9.0		X										X			
-snafu-derive@0.8.9		X										X			
-snafu-derive@0.9.0		X										X			
-snap@1.1.1					X										
-socket2@0.5.10		X										X			
-socket2@0.6.2		X										X			
-stable_deref_trait@1.2.0		X										X			
-strsim@0.11.1												X			
-subtle@2.6.1					X										
-syn@2.0.117		X										X			
-sync_wrapper@1.0.2		X													
-synstructure@0.13.2												X			
-system-configuration@0.6.1		X										X			
-system-configuration-sys@0.6.0		X										X			
-tempfile@3.26.0		X										X			
-thiserror@1.0.69		X										X			
-thiserror@2.0.18		X										X			
-thiserror-impl@1.0.69		X										X			
-thiserror-impl@2.0.18		X										X			
-thrift@0.17.0		X													
-tiny-keccak@2.0.2							X								
-tinystr@0.8.1													X		
-tokio@1.49.0												X			
-tokio-macros@2.6.0												X			
-tokio-native-tls@0.3.1												X			
-tokio-rustls@0.26.2		X										X			
-tokio-util@0.7.18												X			
-tower@0.5.2												X			
-tower-http@0.6.8												X			
-tower-layer@0.3.3												X			
-tower-service@0.3.3												X			
-tracing@0.1.41												X			
-tracing-core@0.1.36												X			
-try-lock@0.2.5												X			
-twox-hash@2.1.2												X			
-typed-builder@0.19.1		X										X			
-typed-builder-macro@0.19.1		X										X			
-typenum@1.18.0		X										X			
-unicode-ident@1.0.18		X										X	X		
-unicode-segmentation@1.13.2		X										X			
-unicode-width@0.2.2		X										X			
-untrusted@0.9.0									X						
-url@2.5.8		X										X			
-urlencoding@2.1.3												X			
-utf8_iter@1.0.4		X										X			
-uuid@1.21.0		X										X			
-vcpkg@0.2.15		X										X			
-version_check@0.9.5		X										X			
-want@0.3.1												X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X			
-wasi@0.14.2+wasi-0.2.4		X	X									X			
-wasip2@1.0.2+wasi-0.2.9		X	X									X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X			
-wasm-bindgen@0.2.100		X										X			
-wasm-bindgen-backend@0.2.100		X										X			
-wasm-bindgen-futures@0.4.50		X										X			
-wasm-bindgen-macro@0.2.100		X										X			
-wasm-bindgen-macro-support@0.2.100		X										X			
-wasm-bindgen-shared@0.2.100		X										X			
-wasm-streams@0.4.2		X										X			
-web-sys@0.3.77		X										X			
-webpki-roots@1.0.2								X							
-windows-core@0.61.2		X										X			
-windows-implement@0.60.0		X										X			
-windows-interface@0.59.1		X										X			
-windows-link@0.1.3		X										X			
-windows-link@0.2.1		X										X			
-windows-registry@0.5.3		X										X			
-windows-result@0.3.4		X										X			
-windows-strings@0.4.2		X										X			
-windows-sys@0.52.0		X										X			
-windows-sys@0.59.0		X										X			
-windows-sys@0.60.2		X										X			
-windows-sys@0.61.2		X										X			
-windows-targets@0.52.6		X										X			
-windows-targets@0.53.5		X										X			
-windows_aarch64_gnullvm@0.52.6		X										X			
-windows_aarch64_gnullvm@0.53.1		X										X			
-windows_aarch64_msvc@0.52.6		X										X			
-windows_aarch64_msvc@0.53.1		X										X			
-windows_i686_gnu@0.52.6		X										X			
-windows_i686_gnu@0.53.1		X										X			
-windows_i686_gnullvm@0.52.6		X										X			
-windows_i686_gnullvm@0.53.1		X										X			
-windows_i686_msvc@0.52.6		X										X			
-windows_i686_msvc@0.53.1		X										X			
-windows_x86_64_gnu@0.52.6		X										X			
-windows_x86_64_gnu@0.53.1		X										X			
-windows_x86_64_gnullvm@0.52.6		X										X			
-windows_x86_64_gnullvm@0.53.1		X										X			
-windows_x86_64_msvc@0.52.6		X										X			
-windows_x86_64_msvc@0.53.1		X										X			
-wit-bindgen@0.51.0		X	X									X			
-wit-bindgen-rt@0.39.0		X	X									X			
-writeable@0.6.1													X		
-yansi@1.0.1		X										X			
-yoke@0.8.0													X		
-yoke-derive@0.8.0													X		
-zerocopy@0.8.26		X		X								X			
-zerocopy-derive@0.8.26		X		X								X			
-zerofrom@0.1.6													X		
-zerofrom-derive@0.1.6													X		
-zeroize@1.8.1		X										X			
-zerotrie@0.2.2													X		
-zerovec@0.11.2													X		
-zerovec-derive@0.11.1													X		
-zlib-rs@0.6.3															X
-zmij@1.0.21												X			
-zstd@0.13.3												X			
-zstd-safe@7.2.4		X										X			
-zstd-sys@2.0.16+zstd.1.5.7		X										X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X			
+ahash@0.8.12		X									X			
+aho-corasick@1.1.4											X		X	
+alloc-no-stdlib@2.0.4					X									
+alloc-stdlib@0.2.2					X									
+android_system_properties@0.1.5		X									X			
+anyhow@1.0.102		X									X			
+apache-avro@0.21.0		X												
+arrow@58.1.0		X												
+arrow-arith@58.1.0		X												
+arrow-array@58.1.0		X												
+arrow-buffer@58.1.0		X												
+arrow-cast@58.1.0		X												
+arrow-csv@58.1.0		X												
+arrow-data@58.1.0		X												
+arrow-ipc@58.1.0		X												
+arrow-json@58.1.0		X												
+arrow-ord@58.1.0		X												
+arrow-row@58.1.0		X												
+arrow-schema@58.1.0		X												
+arrow-select@58.1.0		X												
+arrow-string@58.1.0		X												
+async-stream@0.3.6											X			
+async-stream-impl@0.3.6											X			
+async-trait@0.1.89		X									X			
+atoi@2.0.0											X			
+atomic-waker@1.1.2		X									X			
+autocfg@1.5.0		X									X			
+backon@1.6.0		X												
+base64@0.22.1		X									X			
+bigdecimal@0.4.10		X									X			
+bitflags@2.9.1		X									X			
+block-buffer@0.10.4		X									X			
+bon@3.9.1		X									X			
+bon-macros@3.9.1		X									X			
+brotli@8.0.2					X						X			
+brotli-decompressor@5.0.0					X						X			
+bumpalo@3.19.0		X									X			
+bytemuck@1.25.0		X									X			X
+byteorder@1.5.0											X		X	
+bytes@1.11.1											X			
+cc@1.2.56		X									X			
+cfg-if@1.0.1		X									X			
+chrono@0.4.44		X									X			
+chrono-tz@0.10.4		X									X			
+comfy-table@7.2.2											X			
+const-oid@0.9.6		X									X			
+const-random@0.1.18		X									X			
+const-random-macro@0.1.16		X									X			
+core-foundation@0.10.1		X									X			
+core-foundation@0.9.4		X									X			
+core-foundation-sys@0.8.7		X									X			
+cpufeatures@0.2.17		X									X			
+crc32fast@1.5.0		X									X			
+crunchy@0.2.4											X			
+crypto-common@0.1.6		X									X			
+csv@1.4.0											X		X	
+csv-core@0.1.13											X		X	
+darling@0.20.11											X			
+darling_core@0.20.11											X			
+darling_macro@0.20.11											X			
+diff@0.1.13		X									X			
+digest@0.10.7		X									X			
+displaydoc@0.2.5		X									X			
+either@1.15.0		X									X			
+encoding_rs@0.8.35		X			X						X			
+equivalent@1.0.2		X									X			
+errno@0.3.14		X									X			
+fallible-streaming-iterator@0.1.9		X									X			
+fastrand@2.3.0		X									X			
+find-msvc-tools@0.1.9		X									X			
+flatbuffers@25.12.19		X												
+flate2@1.1.9		X									X			
+fnv@1.0.7		X									X			
+foreign-types@0.3.2		X									X			
+foreign-types-shared@0.1.1		X									X			
+form_urlencoded@1.2.2		X									X			
+futures@0.3.31		X									X			
+futures-channel@0.3.31		X									X			
+futures-core@0.3.31		X									X			
+futures-executor@0.3.31		X									X			
+futures-io@0.3.31		X									X			
+futures-macro@0.3.31		X									X			
+futures-sink@0.3.31		X									X			
+futures-task@0.3.31		X									X			
+futures-util@0.3.31		X									X			
+generic-array@0.14.7											X			
+getrandom@0.2.16		X									X			
+getrandom@0.3.3		X									X			
+getrandom@0.4.1		X									X			
+gloo-timers@0.3.0		X									X			
+h2@0.4.13											X			
+half@2.7.1		X									X			
+hashbrown@0.16.1		X									X			
+heck@0.5.0		X									X			
+hex@0.4.3		X									X			
+hmac@0.12.1		X									X			
+home@0.5.12		X									X			
+http@1.3.1		X									X			
+http-body@1.0.1											X			
+http-body-util@0.1.3											X			
+httparse@1.10.1		X									X			
+httpdate@1.0.3		X									X			
+hyper@1.6.0											X			
+hyper-rustls@0.27.7		X							X		X			
+hyper-tls@0.6.0		X									X			
+hyper-util@0.1.15											X			
+iana-time-zone@0.1.63		X									X			
+iana-time-zone-haiku@0.1.2		X									X			
+icu_collections@2.0.0												X		
+icu_locale_core@2.0.0												X		
+icu_normalizer@2.0.0												X		
+icu_normalizer_data@2.0.0												X		
+icu_properties@2.0.1												X		
+icu_properties_data@2.0.1												X		
+icu_provider@2.0.0												X		
+ident_case@1.0.1		X									X			
+idna@1.1.0		X									X			
+idna_adapter@1.2.1		X									X			
+indexmap@2.13.0		X									X			
+integer-encoding@3.0.4											X			
+ipnet@2.11.0		X									X			
+iri-string@0.7.8		X									X			
+itertools@0.14.0		X									X			
+itoa@1.0.15		X									X			
+jiff@0.2.23											X		X	
+jiff-tzdb@0.1.6											X		X	
+jiff-tzdb-platform@0.1.3											X		X	
+jobserver@0.1.34		X									X			
+js-sys@0.3.95		X									X			
+lexical-core@1.0.6		X									X			
+lexical-parse-float@1.0.6		X									X			
+lexical-parse-integer@1.0.6		X									X			
+lexical-util@1.0.7		X									X			
+lexical-write-float@1.0.6		X									X			
+lexical-write-integer@1.0.6		X									X			
+libc@0.2.182		X									X			
+libm@0.2.15											X			
+linux-raw-sys@0.12.1		X	X								X			
+litemap@0.8.0												X		
+log@0.4.29		X									X			
+lz4_flex@0.11.6											X			
+lz4_flex@0.13.0											X			
+lzokay-native@0.1.0											X			
+md-5@0.10.6		X									X			
+memchr@2.8.0											X		X	
+mime@0.3.17		X									X			
+miniz_oxide@0.8.9		X									X			X
+mio@1.0.4											X			
+native-tls@0.2.18		X									X			
+num@0.4.3		X									X			
+num-bigint@0.4.6		X									X			
+num-complex@0.4.6		X									X			
+num-integer@0.1.46		X									X			
+num-iter@0.1.45		X									X			
+num-rational@0.4.2		X									X			
+num-traits@0.2.19		X									X			
+once_cell@1.21.3		X									X			
+opendal@0.55.0		X												
+openssl@0.10.77		X												
+openssl-macros@0.1.1		X									X			
+openssl-probe@0.2.1		X									X			
+openssl-sys@0.9.113											X			
+orc-rust@0.8.0		X												
+ordered-float@2.10.1											X			
+paimon@0.1.0		X												
+paimon-c@0.1.0		X												
+parquet@58.1.0		X												
+paste@1.0.15		X									X			
+percent-encoding@2.3.2		X									X			
+phf@0.12.1											X			
+phf_shared@0.12.1											X			
+pin-project-lite@0.2.16		X									X			
+pin-utils@0.1.0		X									X			
+pkg-config@0.3.32		X									X			
+portable-atomic@1.13.1		X									X			
+portable-atomic-util@0.2.6		X									X			
+potential_utf@0.1.2												X		
+ppv-lite86@0.2.21		X									X			
+pretty_assertions@1.4.1		X									X			
+prettyplease@0.2.37		X									X			
+proc-macro2@1.0.95		X									X			
+prost@0.13.5		X												
+prost-derive@0.13.5		X												
+quad-rand@0.2.3											X			
+quick-xml@0.38.4											X			
+quote@1.0.44		X									X			
+r-efi@5.3.0		X								X	X			
+rand@0.8.5		X									X			
+rand@0.9.2		X									X			
+rand_chacha@0.3.1		X									X			
+rand_chacha@0.9.0		X									X			
+rand_core@0.6.4		X									X			
+rand_core@0.9.3		X									X			
+regex@1.12.3		X									X			
+regex-automata@0.4.14		X									X			
+regex-lite@0.1.9		X									X			
+regex-syntax@0.8.10		X									X			
+reqsign@0.16.5		X												
+reqwest@0.12.28		X									X			
+ring@0.17.14		X							X					
+roaring@0.11.3		X									X			
+rustc_version@0.4.1		X									X			
+rustix@1.1.4		X	X								X			
+rustls@0.23.29		X							X		X			
+rustls-pki-types@1.12.0		X									X			
+rustls-webpki@0.103.4									X					
+rustversion@1.0.21		X									X			
+ryu@1.0.20		X				X								
+schannel@0.1.29											X			
+security-framework@3.6.0		X									X			
+security-framework-sys@2.17.0		X									X			
+semver@1.0.27		X									X			
+seq-macro@0.3.6		X									X			
+serde@1.0.228		X									X			
+serde_bytes@0.11.19		X									X			
+serde_core@1.0.228		X									X			
+serde_derive@1.0.228		X									X			
+serde_json@1.0.149		X									X			
+serde_repr@0.1.20		X									X			
+serde_urlencoded@0.7.1		X									X			
+serde_with@3.14.0		X									X			
+serde_with_macros@3.14.0		X									X			
+sha1@0.10.6		X									X			
+sha2@0.10.9		X									X			
+shlex@1.3.0		X									X			
+simd-adler32@0.3.8											X			
+simdutf8@0.1.5		X									X			
+siphasher@1.0.2		X									X			
+slab@0.4.10											X			
+smallvec@1.15.1		X									X			
+snafu@0.8.9		X									X			
+snafu@0.9.0		X									X			
+snafu-derive@0.8.9		X									X			
+snafu-derive@0.9.0		X									X			
+snap@1.1.1					X									
+socket2@0.5.10		X									X			
+socket2@0.6.2		X									X			
+stable_deref_trait@1.2.0		X									X			
+strsim@0.11.1											X			
+strum@0.27.2											X			
+strum_macros@0.27.2											X			
+subtle@2.6.1					X									
+syn@2.0.117		X									X			
+sync_wrapper@1.0.2		X												
+synstructure@0.13.2											X			
+system-configuration@0.6.1		X									X			
+system-configuration-sys@0.6.0		X									X			
+tempfile@3.26.0		X									X			
+thiserror@1.0.69		X									X			
+thiserror@2.0.18		X									X			
+thiserror-impl@1.0.69		X									X			
+thiserror-impl@2.0.18		X									X			
+thrift@0.17.0		X												
+tiny-keccak@2.0.2							X							
+tinystr@0.8.1												X		
+tokio@1.49.0											X			
+tokio-macros@2.6.0											X			
+tokio-native-tls@0.3.1											X			
+tokio-rustls@0.26.2		X									X			
+tokio-util@0.7.18											X			
+tower@0.5.2											X			
+tower-http@0.6.8											X			
+tower-layer@0.3.3											X			
+tower-service@0.3.3											X			
+tracing@0.1.41											X			
+tracing-core@0.1.36											X			
+try-lock@0.2.5											X			
+twox-hash@2.1.2											X			
+typed-builder@0.19.1		X									X			
+typed-builder-macro@0.19.1		X									X			
+typenum@1.18.0		X									X			
+unicode-ident@1.0.18		X									X	X		
+unicode-segmentation@1.13.2		X									X			
+unicode-width@0.2.2		X									X			
+untrusted@0.9.0									X					
+url@2.5.8		X									X			
+urlencoding@2.1.3											X			
+utf8_iter@1.0.4		X									X			
+uuid@1.21.0		X									X			
+vcpkg@0.2.15		X									X			
+version_check@0.9.5		X									X			
+want@0.3.1											X			
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
+wasi@0.14.2+wasi-0.2.4		X	X								X			
+wasip2@1.0.2+wasi-0.2.9		X	X								X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X			
+wasm-bindgen@0.2.118		X									X			
+wasm-bindgen-futures@0.4.68		X									X			
+wasm-bindgen-macro@0.2.118		X									X			
+wasm-bindgen-macro-support@0.2.118		X									X			
+wasm-bindgen-shared@0.2.118		X									X			
+wasm-streams@0.4.2		X									X			
+web-sys@0.3.95		X									X			
+webpki-roots@1.0.2								X						
+windows-core@0.61.2		X									X			
+windows-implement@0.60.0		X									X			
+windows-interface@0.59.1		X									X			
+windows-link@0.1.3		X									X			
+windows-link@0.2.1		X									X			
+windows-registry@0.5.3		X									X			
+windows-result@0.3.4		X									X			
+windows-strings@0.4.2		X									X			
+windows-sys@0.52.0		X									X			
+windows-sys@0.59.0		X									X			
+windows-sys@0.60.2		X									X			
+windows-sys@0.61.2		X									X			
+windows-targets@0.52.6		X									X			
+windows-targets@0.53.5		X									X			
+windows_aarch64_gnullvm@0.52.6		X									X			
+windows_aarch64_gnullvm@0.53.1		X									X			
+windows_aarch64_msvc@0.52.6		X									X			
+windows_aarch64_msvc@0.53.1		X									X			
+windows_i686_gnu@0.52.6		X									X			
+windows_i686_gnu@0.53.1		X									X			
+windows_i686_gnullvm@0.52.6		X									X			
+windows_i686_gnullvm@0.53.1		X									X			
+windows_i686_msvc@0.52.6		X									X			
+windows_i686_msvc@0.53.1		X									X			
+windows_x86_64_gnu@0.52.6		X									X			
+windows_x86_64_gnu@0.53.1		X									X			
+windows_x86_64_gnullvm@0.52.6		X									X			
+windows_x86_64_gnullvm@0.53.1		X									X			
+windows_x86_64_msvc@0.52.6		X									X			
+windows_x86_64_msvc@0.53.1		X									X			
+wit-bindgen@0.51.0		X	X								X			
+wit-bindgen-rt@0.39.0		X	X								X			
+writeable@0.6.1												X		
+yansi@1.0.1		X									X			
+yoke@0.8.0												X		
+yoke-derive@0.8.0												X		
+zerocopy@0.8.26		X		X							X			
+zerocopy-derive@0.8.26		X		X							X			
+zerofrom@0.1.6												X		
+zerofrom-derive@0.1.6												X		
+zeroize@1.8.1		X									X			
+zerotrie@0.2.2												X		
+zerovec@0.11.2												X		
+zerovec-derive@0.11.1												X		
+zlib-rs@0.6.3														X
+zmij@1.0.21											X			
+zstd@0.13.3											X			
+zstd-safe@7.2.4		X									X			
+zstd-sys@2.0.16+zstd.1.5.7		X									X			

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -1,477 +1,475 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
-abi_stable@0.11.3		X										X						
-abi_stable_derive@0.11.3		X										X						
-abi_stable_shared@0.11.0		X										X						
-adler2@2.0.1	X	X										X						
-aes@0.8.4		X										X						
-ahash@0.8.12		X										X						
-aho-corasick@1.1.4												X				X		
-alloc-no-stdlib@2.0.4					X													
-alloc-stdlib@0.2.2					X													
-allocator-api2@0.2.21		X										X						
-android_system_properties@0.1.5		X										X						
-anyhow@1.0.102		X										X						
-ar_archive_writer@0.5.1			X															
-arrayref@0.3.9				X														
-arrayvec@0.7.6		X										X						
-arrow@58.1.0		X																
-arrow-arith@58.1.0		X																
-arrow-array@58.1.0		X																
-arrow-buffer@58.1.0		X																
-arrow-cast@58.1.0		X																
-arrow-csv@58.1.0		X																
-arrow-data@58.1.0		X																
-arrow-ipc@58.1.0		X																
-arrow-json@58.1.0		X																
-arrow-ord@58.1.0		X																
-arrow-pyarrow@58.1.0		X																
-arrow-row@58.1.0		X																
-arrow-schema@58.1.0		X																
-arrow-select@58.1.0		X																
-arrow-string@58.1.0		X																
-as_derive_utils@0.11.0		X										X						
-async-compression@0.4.41		X										X						
-async-ffi@0.5.0												X						
-async-stream@0.3.6												X						
-async-stream-impl@0.3.6												X						
-async-trait@0.1.89		X										X						
-atoi@2.0.0												X						
-atomic-waker@1.1.2		X										X						
-autocfg@1.5.0		X										X						
-backon@1.6.0		X																
-base64@0.22.1		X										X						
-bigdecimal@0.4.10		X										X						
-bitflags@2.9.1		X										X						
-blake2@0.10.6		X										X						
-blake3@1.8.3		X	X				X											
-block-buffer@0.10.4		X										X						
-block-padding@0.3.3		X										X						
-brotli@8.0.2					X							X						
-brotli-decompressor@5.0.0					X							X						
-bumpalo@3.19.0		X										X						
-bytemuck@1.25.0		X										X					X	
-byteorder@1.5.0												X				X		
-bytes@1.11.1												X						
-bzip2@0.6.1		X										X						
-cbc@0.1.2		X										X						
-cc@1.2.56		X										X						
-cfg-if@1.0.1		X										X						
-chacha20@0.10.0		X										X						
-chrono@0.4.44		X										X						
-chrono-tz@0.10.4		X										X						
-cipher@0.4.4		X										X						
-comfy-table@7.2.2												X						
-compression-codecs@0.4.37		X										X						
-compression-core@0.4.31		X										X						
-const-oid@0.9.6		X										X						
-const-random@0.1.18		X										X						
-const-random-macro@0.1.16		X										X						
-const_panic@0.2.15																	X	
-constant_time_eq@0.4.2		X					X						X					
-core-foundation@0.10.1		X										X						
-core-foundation@0.9.4		X										X						
-core-foundation-sys@0.8.7		X										X						
-core_extensions@1.5.4		X										X						
-core_extensions_proc_macros@1.5.4		X										X						
-cpufeatures@0.2.17		X										X						
-cpufeatures@0.3.0		X										X						
-crc@3.4.0		X										X						
-crc-catalog@2.4.0		X										X						
-crc32c@0.6.8		X										X						
-crc32fast@1.5.0		X										X						
-crossbeam-channel@0.5.15		X										X						
-crossbeam-utils@0.8.21		X										X						
-crunchy@0.2.4												X						
-crypto-common@0.1.6		X										X						
-csv@1.4.0												X				X		
-csv-core@0.1.13												X				X		
-ctr@0.9.2		X										X						
-darling@0.20.11												X						
-darling_core@0.20.11												X						
-darling_macro@0.20.11												X						
-dashmap@6.1.0												X						
-datafusion@53.0.0		X																
-datafusion-catalog@53.0.0		X																
-datafusion-catalog-listing@53.0.0		X																
-datafusion-common@53.0.0		X																
-datafusion-common-runtime@53.0.0		X																
-datafusion-datasource@53.0.0		X																
-datafusion-datasource-arrow@53.0.0		X																
-datafusion-datasource-csv@53.0.0		X																
-datafusion-datasource-json@53.0.0		X																
-datafusion-datasource-parquet@53.0.0		X																
-datafusion-doc@53.0.0		X																
-datafusion-execution@53.0.0		X																
-datafusion-expr@53.0.0		X																
-datafusion-expr-common@53.0.0		X																
-datafusion-ffi@53.0.0		X																
-datafusion-functions@53.0.0		X																
-datafusion-functions-aggregate@53.0.0		X																
-datafusion-functions-aggregate-common@53.0.0		X																
-datafusion-functions-nested@53.0.0		X																
-datafusion-functions-table@53.0.0		X																
-datafusion-functions-window@53.0.0		X																
-datafusion-functions-window-common@53.0.0		X																
-datafusion-macros@53.0.0		X																
-datafusion-optimizer@53.0.0		X																
-datafusion-physical-expr@53.0.0		X																
-datafusion-physical-expr-adapter@53.0.0		X																
-datafusion-physical-expr-common@53.0.0		X																
-datafusion-physical-optimizer@53.0.0		X																
-datafusion-physical-plan@53.0.0		X																
-datafusion-proto@53.0.0		X																
-datafusion-proto-common@53.0.0		X																
-datafusion-pruning@53.0.0		X																
-datafusion-session@53.0.0		X																
-datafusion-sql@53.0.0		X																
-des@0.8.1		X										X						
-diff@0.1.13		X										X						
-digest@0.10.7		X										X						
-displaydoc@0.2.5		X										X						
-dns-lookup@3.0.1		X										X						
-either@1.15.0		X										X						
-encoding_rs@0.8.35		X			X							X						
-equivalent@1.0.2		X										X						
-errno@0.3.14		X										X						
-fallible-streaming-iterator@0.1.9		X										X						
-fastrand@2.3.0		X										X						
-find-msvc-tools@0.1.9		X										X						
-fixedbitset@0.5.7		X										X						
-flatbuffers@25.12.19		X																
-flate2@1.1.9		X										X						
-fnv@1.0.7		X										X						
-foldhash@0.1.5																	X	
-foldhash@0.2.0																	X	
-foreign-types@0.3.2		X										X						
-foreign-types-shared@0.1.1		X										X						
-form_urlencoded@1.2.2		X										X						
-futures@0.3.31		X										X						
-futures-channel@0.3.31		X										X						
-futures-core@0.3.31		X										X						
-futures-executor@0.3.31		X										X						
-futures-io@0.3.31		X										X						
-futures-macro@0.3.31		X										X						
-futures-sink@0.3.31		X										X						
-futures-task@0.3.31		X										X						
-futures-util@0.3.31		X										X						
-g2gen@1.2.2		X										X						
-g2p@1.2.2		X										X						
-g2poly@1.2.2		X										X						
-generational-arena@0.2.9														X				
-generic-array@0.14.7												X						
-getrandom@0.2.16		X										X						
-getrandom@0.3.3		X										X						
-getrandom@0.4.1		X										X						
-glob@0.3.3		X										X						
-gloo-timers@0.3.0		X										X						
-h2@0.4.13												X						
-half@2.7.1		X										X						
-hashbrown@0.14.5		X										X						
-hashbrown@0.15.4		X										X						
-hashbrown@0.16.1		X										X						
-hdfs-native@0.13.5		X																
-heck@0.5.0		X										X						
-hex@0.4.3		X										X						
-hmac@0.12.1		X										X						
-home@0.5.12		X										X						
-http@1.3.1		X										X						
-http-body@1.0.1												X						
-http-body-util@0.1.3												X						
-httparse@1.10.1		X										X						
-httpdate@1.0.3		X										X						
-humantime@2.3.0		X										X						
-hyper@1.6.0												X						
-hyper-rustls@0.27.7		X							X			X						
-hyper-tls@0.6.0		X										X						
-hyper-util@0.1.15												X						
-iana-time-zone@0.1.63		X										X						
-iana-time-zone-haiku@0.1.2		X										X						
-icu_collections@2.0.0															X			
-icu_locale_core@2.0.0															X			
-icu_normalizer@2.0.0															X			
-icu_normalizer_data@2.0.0															X			
-icu_properties@2.0.1															X			
-icu_properties_data@2.0.1															X			
-icu_provider@2.0.0															X			
-ident_case@1.0.1		X										X						
-idna@1.1.0		X										X						
-idna_adapter@1.2.1		X										X						
-indexmap@2.13.0		X										X						
-inout@0.1.4		X										X						
-integer-encoding@3.0.4												X						
-integer-encoding@4.1.0												X						
-ipnet@2.11.0		X										X						
-iri-string@0.7.8		X										X						
-itertools@0.14.0		X										X						
-itoa@1.0.15		X										X						
-jiff@0.2.23												X				X		
-jiff-tzdb@0.1.6												X				X		
-jiff-tzdb-platform@0.1.3												X				X		
-jobserver@0.1.34		X										X						
-js-sys@0.3.77		X										X						
-lexical-core@1.0.6		X										X						
-lexical-parse-float@1.0.6		X										X						
-lexical-parse-integer@1.0.6		X										X						
-lexical-util@1.0.7		X										X						
-lexical-write-float@1.0.6		X										X						
-lexical-write-integer@1.0.6		X										X						
-libbz2-rs-sys@0.2.2																		X
-libc@0.2.182		X										X						
-libloading@0.7.4									X									
-libloading@0.9.0									X									
-liblzma@0.4.6		X										X						
-liblzma-sys@0.4.5		X										X						
-libm@0.2.15												X						
-libredox@0.1.16												X						
-linux-raw-sys@0.12.1		X	X									X						
-litemap@0.8.0															X			
-lock_api@0.4.14		X										X						
-log@0.4.29		X										X						
-lz4_flex@0.11.6												X						
-lz4_flex@0.13.0												X						
-lzokay-native@0.1.0												X						
-md-5@0.10.6		X										X						
-memchr@2.8.0												X				X		
-mime@0.3.17		X										X						
-miniz_oxide@0.8.9		X										X					X	
-mio@1.0.4												X						
-native-tls@0.2.18		X										X						
-num@0.4.3		X										X						
-num-bigint@0.4.6		X										X						
-num-complex@0.4.6		X										X						
-num-integer@0.1.46		X										X						
-num-iter@0.1.45		X										X						
-num-rational@0.4.2		X										X						
-num-traits@0.2.19		X										X						
-object@0.37.3		X										X						
-object_store@0.13.2		X										X						
-once_cell@1.21.3		X										X						
-opendal@0.55.0		X																
-openssl@0.10.76		X																
-openssl-macros@0.1.1		X										X						
-openssl-probe@0.2.1		X										X						
-openssl-sys@0.9.112												X						
-orc-rust@0.8.0		X																
-ordered-float@2.10.1												X						
-paimon@0.1.0		X																
-paimon-datafusion@0.1.0		X																
-parking_lot@0.12.5		X										X						
-parking_lot_core@0.9.12		X										X						
-parquet@58.1.0		X																
-paste@1.0.15		X										X						
-percent-encoding@2.3.2		X										X						
-petgraph@0.8.3		X										X						
-phf@0.12.1												X						
-phf_shared@0.12.1												X						
-pin-project-lite@0.2.16		X										X						
-pin-utils@0.1.0		X										X						
-pkg-config@0.3.32		X										X						
-plain@0.2.3		X										X						
-portable-atomic@1.13.1		X										X						
-portable-atomic-util@0.2.6		X										X						
-potential_utf@0.1.2															X			
-ppv-lite86@0.2.21		X										X						
-pretty_assertions@1.4.1		X										X						
-proc-macro2@1.0.95		X										X						
-prost@0.13.5		X																
-prost@0.14.3		X																
-prost-derive@0.13.5		X																
-prost-derive@0.14.3		X																
-prost-types@0.14.3		X																
-psm@0.1.30		X										X						
-pyo3@0.28.3		X										X						
-pyo3-build-config@0.28.3		X										X						
-pyo3-ffi@0.28.3		X										X						
-pyo3-macros@0.28.3		X										X						
-pyo3-macros-backend@0.28.3		X										X						
-pypaimon_rust@0.1.0		X																
-quick-xml@0.37.5												X						
-quick-xml@0.38.4												X						
-quote@1.0.44		X										X						
-r-efi@5.3.0		X								X		X						
-rand@0.10.0		X										X						
-rand@0.8.5		X										X						
-rand@0.9.2		X										X						
-rand_chacha@0.3.1		X										X						
-rand_chacha@0.9.0		X										X						
-rand_core@0.10.0		X										X						
-rand_core@0.6.4		X										X						
-rand_core@0.9.3		X										X						
-recursive@0.1.1												X						
-recursive-proc-macro-impl@0.1.1												X						
-redox_syscall@0.5.18												X						
-regex@1.12.3		X										X						
-regex-automata@0.4.14		X										X						
-regex-syntax@0.8.10		X										X						
-repr_offset@0.2.2																	X	
-reqsign@0.16.5		X																
-reqwest@0.12.28		X										X						
-ring@0.17.14		X							X									
-roaring@0.11.3		X										X						
-roxmltree@0.21.1		X										X						
-rust_decimal@1.41.0												X						
-rustc_version@0.4.1		X										X						
-rustix@1.1.4		X	X									X						
-rustls@0.23.29		X							X			X						
-rustls-pki-types@1.12.0		X										X						
-rustls-webpki@0.103.4									X									
-rustversion@1.0.21		X										X						
-ryu@1.0.20		X				X												
-same-file@1.0.6												X				X		
-schannel@0.1.29												X						
-scopeguard@1.2.0		X										X						
-security-framework@3.6.0		X										X						
-security-framework-sys@2.17.0		X										X						
-semver@1.0.27		X										X						
-seq-macro@0.3.6		X										X						
-serde@1.0.228		X										X						
-serde-transcode@1.1.1		X										X						
-serde_avro_fast@2.0.2											X							
-serde_bytes@0.11.19		X										X						
-serde_core@1.0.228		X										X						
-serde_derive@1.0.228		X										X						
-serde_json@1.0.149		X										X						
-serde_repr@0.1.20		X										X						
-serde_serializer_quick_unsupported@1.0.0											X							
-serde_urlencoded@0.7.1		X										X						
-serde_with@3.14.0		X										X						
-serde_with_macros@3.14.0		X										X						
-sha1@0.10.6		X										X						
-sha2@0.10.9		X										X						
-shlex@1.3.0		X										X						
-simd-adler32@0.3.8												X						
-simdutf8@0.1.5		X										X						
-siphasher@1.0.2		X										X						
-slab@0.4.10												X						
-smallvec@1.15.1		X										X						
-snafu@0.8.9		X										X						
-snafu@0.9.0		X										X						
-snafu-derive@0.8.9		X										X						
-snafu-derive@0.9.0		X										X						
-snap@1.1.1					X													
-socket2@0.5.10		X										X						
-socket2@0.6.2		X										X						
-sqlparser@0.61.0		X																
-sqlparser_derive@0.5.0		X																
-stable_deref_trait@1.2.0		X										X						
-stacker@0.1.23		X										X						
-strsim@0.11.1												X						
-subtle@2.6.1					X													
-syn@1.0.109		X										X						
-syn@2.0.117		X										X						
-sync_wrapper@1.0.2		X																
-synstructure@0.13.2												X						
-system-configuration@0.6.1		X										X						
-system-configuration-sys@0.6.0		X										X						
-target-lexicon@0.13.5			X															
-tempfile@3.26.0		X										X						
-thiserror@1.0.69		X										X						
-thiserror@2.0.18		X										X						
-thiserror-impl@1.0.69		X										X						
-thiserror-impl@2.0.18		X										X						
-thrift@0.17.0		X																
-tiny-keccak@2.0.2							X											
-tinystr@0.8.1															X			
-tokio@1.49.0												X						
-tokio-macros@2.6.0												X						
-tokio-native-tls@0.3.1												X						
-tokio-rustls@0.26.2		X										X						
-tokio-stream@0.1.18												X						
-tokio-util@0.7.18												X						
-tower@0.5.2												X						
-tower-http@0.6.8												X						
-tower-layer@0.3.3												X						
-tower-service@0.3.3												X						
-tracing@0.1.41												X						
-tracing-attributes@0.1.31												X						
-tracing-core@0.1.36												X						
-try-lock@0.2.5												X						
-tstr@0.2.4																	X	
-tstr_proc_macros@0.2.2																	X	
-twox-hash@2.1.2												X						
-typed-arena@2.0.2												X						
-typed-builder@0.19.1		X										X						
-typed-builder-macro@0.19.1		X										X						
-typenum@1.18.0		X										X						
-typewit@1.15.1																	X	
-unicode-ident@1.0.18		X										X			X			
-unicode-segmentation@1.13.2		X										X						
-unicode-width@0.2.2		X										X						
-untrusted@0.9.0									X									
-url@2.5.8		X										X						
-urlencoding@2.1.3												X						
-utf8_iter@1.0.4		X										X						
-uuid@1.21.0		X										X						
-vcpkg@0.2.15		X										X						
-version_check@0.9.5		X										X						
-walkdir@2.5.0												X				X		
-want@0.3.1												X						
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X						
-wasi@0.14.2+wasi-0.2.4		X	X									X						
-wasip2@1.0.2+wasi-0.2.9		X	X									X						
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X						
-wasite@0.1.0		X				X						X						
-wasm-bindgen@0.2.100		X										X						
-wasm-bindgen-backend@0.2.100		X										X						
-wasm-bindgen-futures@0.4.50		X										X						
-wasm-bindgen-macro@0.2.100		X										X						
-wasm-bindgen-macro-support@0.2.100		X										X						
-wasm-bindgen-shared@0.2.100		X										X						
-wasm-streams@0.4.2		X										X						
-web-sys@0.3.77		X										X						
-web-time@1.1.0		X										X						
-webpki-roots@1.0.2								X										
-whoami@1.6.1		X				X						X						
-winapi@0.3.9		X										X						
-winapi-i686-pc-windows-gnu@0.4.0		X										X						
-winapi-util@0.1.11												X				X		
-winapi-x86_64-pc-windows-gnu@0.4.0		X										X						
-windows-core@0.61.2		X										X						
-windows-implement@0.60.0		X										X						
-windows-interface@0.59.1		X										X						
-windows-link@0.1.3		X										X						
-windows-link@0.2.1		X										X						
-windows-registry@0.5.3		X										X						
-windows-result@0.3.4		X										X						
-windows-strings@0.4.2		X										X						
-windows-sys@0.52.0		X										X						
-windows-sys@0.59.0		X										X						
-windows-sys@0.60.2		X										X						
-windows-sys@0.61.2		X										X						
-windows-targets@0.52.6		X										X						
-windows-targets@0.53.5		X										X						
-windows_aarch64_gnullvm@0.52.6		X										X						
-windows_aarch64_gnullvm@0.53.1		X										X						
-windows_aarch64_msvc@0.52.6		X										X						
-windows_aarch64_msvc@0.53.1		X										X						
-windows_i686_gnu@0.52.6		X										X						
-windows_i686_gnu@0.53.1		X										X						
-windows_i686_gnullvm@0.52.6		X										X						
-windows_i686_gnullvm@0.53.1		X										X						
-windows_i686_msvc@0.52.6		X										X						
-windows_i686_msvc@0.53.1		X										X						
-windows_x86_64_gnu@0.52.6		X										X						
-windows_x86_64_gnu@0.53.1		X										X						
-windows_x86_64_gnullvm@0.52.6		X										X						
-windows_x86_64_gnullvm@0.53.1		X										X						
-windows_x86_64_msvc@0.52.6		X										X						
-windows_x86_64_msvc@0.53.1		X										X						
-wit-bindgen@0.51.0		X	X									X						
-wit-bindgen-rt@0.39.0		X	X									X						
-writeable@0.6.1															X			
-yansi@1.0.1		X										X						
-yoke@0.8.0															X			
-yoke-derive@0.8.0															X			
-zerocopy@0.8.26		X		X								X						
-zerocopy-derive@0.8.26		X		X								X						
-zerofrom@0.1.6															X			
-zerofrom-derive@0.1.6															X			
-zeroize@1.8.1		X										X						
-zerotrie@0.2.2															X			
-zerovec@0.11.2															X			
-zerovec-derive@0.11.1															X			
-zlib-rs@0.6.3																	X	
-zmij@1.0.21												X						
-zstd@0.13.3												X						
-zstd-safe@7.2.4		X										X						
-zstd-sys@2.0.16+zstd.1.5.7		X										X						
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
+abi_stable@0.11.3		X									X						
+abi_stable_derive@0.11.3		X									X						
+abi_stable_shared@0.11.0		X									X						
+adler2@2.0.1	X	X									X						
+aes@0.8.4		X									X						
+ahash@0.8.12		X									X						
+aho-corasick@1.1.4											X				X		
+alloc-no-stdlib@2.0.4					X												
+alloc-stdlib@0.2.2					X												
+allocator-api2@0.2.21		X									X						
+android_system_properties@0.1.5		X									X						
+anyhow@1.0.102		X									X						
+apache-avro@0.21.0		X															
+ar_archive_writer@0.5.1			X														
+arrayref@0.3.9				X													
+arrayvec@0.7.6		X									X						
+arrow@58.1.0		X															
+arrow-arith@58.1.0		X															
+arrow-array@58.1.0		X															
+arrow-buffer@58.1.0		X															
+arrow-cast@58.1.0		X															
+arrow-csv@58.1.0		X															
+arrow-data@58.1.0		X															
+arrow-ipc@58.1.0		X															
+arrow-json@58.1.0		X															
+arrow-ord@58.1.0		X															
+arrow-pyarrow@58.1.0		X															
+arrow-row@58.1.0		X															
+arrow-schema@58.1.0		X															
+arrow-select@58.1.0		X															
+arrow-string@58.1.0		X															
+as_derive_utils@0.11.0		X									X						
+async-compression@0.4.41		X									X						
+async-ffi@0.5.0											X						
+async-stream@0.3.6											X						
+async-stream-impl@0.3.6											X						
+async-trait@0.1.89		X									X						
+atoi@2.0.0											X						
+atomic-waker@1.1.2		X									X						
+autocfg@1.5.0		X									X						
+backon@1.6.0		X															
+base64@0.22.1		X									X						
+bigdecimal@0.4.10		X									X						
+bitflags@2.9.1		X									X						
+blake2@0.10.6		X									X						
+blake3@1.8.3		X	X				X										
+block-buffer@0.10.4		X									X						
+block-padding@0.3.3		X									X						
+bon@3.9.1		X									X						
+bon-macros@3.9.1		X									X						
+brotli@8.0.2					X						X						
+brotli-decompressor@5.0.0					X						X						
+bumpalo@3.19.0		X									X						
+bytemuck@1.25.0		X									X					X	
+byteorder@1.5.0											X				X		
+bytes@1.11.1											X						
+bzip2@0.6.1		X									X						
+cbc@0.1.2		X									X						
+cc@1.2.56		X									X						
+cfg-if@1.0.1		X									X						
+chrono@0.4.44		X									X						
+chrono-tz@0.10.4		X									X						
+cipher@0.4.4		X									X						
+comfy-table@7.2.2											X						
+compression-codecs@0.4.37		X									X						
+compression-core@0.4.31		X									X						
+const-oid@0.9.6		X									X						
+const-random@0.1.18		X									X						
+const-random-macro@0.1.16		X									X						
+const_panic@0.2.15																X	
+constant_time_eq@0.4.2		X					X					X					
+core-foundation@0.10.1		X									X						
+core-foundation@0.9.4		X									X						
+core-foundation-sys@0.8.7		X									X						
+core_extensions@1.5.4		X									X						
+core_extensions_proc_macros@1.5.4		X									X						
+cpufeatures@0.2.17		X									X						
+crc@3.4.0		X									X						
+crc-catalog@2.4.0		X									X						
+crc32c@0.6.8		X									X						
+crc32fast@1.5.0		X									X						
+crossbeam-channel@0.5.15		X									X						
+crossbeam-utils@0.8.21		X									X						
+crunchy@0.2.4											X						
+crypto-common@0.1.6		X									X						
+csv@1.4.0											X				X		
+csv-core@0.1.13											X				X		
+ctr@0.9.2		X									X						
+darling@0.20.11											X						
+darling_core@0.20.11											X						
+darling_macro@0.20.11											X						
+dashmap@6.1.0											X						
+datafusion@53.0.0		X															
+datafusion-catalog@53.0.0		X															
+datafusion-catalog-listing@53.0.0		X															
+datafusion-common@53.0.0		X															
+datafusion-common-runtime@53.0.0		X															
+datafusion-datasource@53.0.0		X															
+datafusion-datasource-arrow@53.0.0		X															
+datafusion-datasource-csv@53.0.0		X															
+datafusion-datasource-json@53.0.0		X															
+datafusion-datasource-parquet@53.0.0		X															
+datafusion-doc@53.0.0		X															
+datafusion-execution@53.0.0		X															
+datafusion-expr@53.0.0		X															
+datafusion-expr-common@53.0.0		X															
+datafusion-ffi@53.0.0		X															
+datafusion-functions@53.0.0		X															
+datafusion-functions-aggregate@53.0.0		X															
+datafusion-functions-aggregate-common@53.0.0		X															
+datafusion-functions-nested@53.0.0		X															
+datafusion-functions-table@53.0.0		X															
+datafusion-functions-window@53.0.0		X															
+datafusion-functions-window-common@53.0.0		X															
+datafusion-macros@53.0.0		X															
+datafusion-optimizer@53.0.0		X															
+datafusion-physical-expr@53.0.0		X															
+datafusion-physical-expr-adapter@53.0.0		X															
+datafusion-physical-expr-common@53.0.0		X															
+datafusion-physical-optimizer@53.0.0		X															
+datafusion-physical-plan@53.0.0		X															
+datafusion-proto@53.0.0		X															
+datafusion-proto-common@53.0.0		X															
+datafusion-pruning@53.0.0		X															
+datafusion-session@53.0.0		X															
+datafusion-sql@53.0.0		X															
+des@0.8.1		X									X						
+diff@0.1.13		X									X						
+digest@0.10.7		X									X						
+displaydoc@0.2.5		X									X						
+dns-lookup@3.0.1		X									X						
+either@1.15.0		X									X						
+encoding_rs@0.8.35		X			X						X						
+equivalent@1.0.2		X									X						
+errno@0.3.14		X									X						
+fallible-streaming-iterator@0.1.9		X									X						
+fastrand@2.3.0		X									X						
+find-msvc-tools@0.1.9		X									X						
+fixedbitset@0.5.7		X									X						
+flatbuffers@25.12.19		X															
+flate2@1.1.9		X									X						
+fnv@1.0.7		X									X						
+foldhash@0.1.5																X	
+foldhash@0.2.0																X	
+foreign-types@0.3.2		X									X						
+foreign-types-shared@0.1.1		X									X						
+form_urlencoded@1.2.2		X									X						
+futures@0.3.31		X									X						
+futures-channel@0.3.31		X									X						
+futures-core@0.3.31		X									X						
+futures-executor@0.3.31		X									X						
+futures-io@0.3.31		X									X						
+futures-macro@0.3.31		X									X						
+futures-sink@0.3.31		X									X						
+futures-task@0.3.31		X									X						
+futures-util@0.3.31		X									X						
+g2gen@1.2.2		X									X						
+g2p@1.2.2		X									X						
+g2poly@1.2.2		X									X						
+generational-arena@0.2.9													X				
+generic-array@0.14.7											X						
+getrandom@0.2.16		X									X						
+getrandom@0.3.3		X									X						
+getrandom@0.4.1		X									X						
+glob@0.3.3		X									X						
+gloo-timers@0.3.0		X									X						
+h2@0.4.13											X						
+half@2.7.1		X									X						
+hashbrown@0.14.5		X									X						
+hashbrown@0.15.4		X									X						
+hashbrown@0.16.1		X									X						
+hdfs-native@0.13.5		X															
+heck@0.5.0		X									X						
+hex@0.4.3		X									X						
+hmac@0.12.1		X									X						
+home@0.5.12		X									X						
+http@1.3.1		X									X						
+http-body@1.0.1											X						
+http-body-util@0.1.3											X						
+httparse@1.10.1		X									X						
+httpdate@1.0.3		X									X						
+humantime@2.3.0		X									X						
+hyper@1.6.0											X						
+hyper-rustls@0.27.7		X							X		X						
+hyper-tls@0.6.0		X									X						
+hyper-util@0.1.15											X						
+iana-time-zone@0.1.63		X									X						
+iana-time-zone-haiku@0.1.2		X									X						
+icu_collections@2.0.0														X			
+icu_locale_core@2.0.0														X			
+icu_normalizer@2.0.0														X			
+icu_normalizer_data@2.0.0														X			
+icu_properties@2.0.1														X			
+icu_properties_data@2.0.1														X			
+icu_provider@2.0.0														X			
+ident_case@1.0.1		X									X						
+idna@1.1.0		X									X						
+idna_adapter@1.2.1		X									X						
+indexmap@2.13.0		X									X						
+inout@0.1.4		X									X						
+integer-encoding@3.0.4											X						
+ipnet@2.11.0		X									X						
+iri-string@0.7.8		X									X						
+itertools@0.14.0		X									X						
+itoa@1.0.15		X									X						
+jiff@0.2.23											X				X		
+jiff-tzdb@0.1.6											X				X		
+jiff-tzdb-platform@0.1.3											X				X		
+jobserver@0.1.34		X									X						
+js-sys@0.3.95		X									X						
+lexical-core@1.0.6		X									X						
+lexical-parse-float@1.0.6		X									X						
+lexical-parse-integer@1.0.6		X									X						
+lexical-util@1.0.7		X									X						
+lexical-write-float@1.0.6		X									X						
+lexical-write-integer@1.0.6		X									X						
+libbz2-rs-sys@0.2.2																	X
+libc@0.2.182		X									X						
+libloading@0.7.4									X								
+libloading@0.9.0									X								
+liblzma@0.4.6		X									X						
+liblzma-sys@0.4.5		X									X						
+libm@0.2.15											X						
+libredox@0.1.16											X						
+linux-raw-sys@0.12.1		X	X								X						
+litemap@0.8.0														X			
+lock_api@0.4.14		X									X						
+log@0.4.29		X									X						
+lz4_flex@0.11.6											X						
+lz4_flex@0.13.0											X						
+lzokay-native@0.1.0											X						
+md-5@0.10.6		X									X						
+memchr@2.8.0											X				X		
+mime@0.3.17		X									X						
+miniz_oxide@0.8.9		X									X					X	
+mio@1.0.4											X						
+native-tls@0.2.18		X									X						
+num@0.4.3		X									X						
+num-bigint@0.4.6		X									X						
+num-complex@0.4.6		X									X						
+num-integer@0.1.46		X									X						
+num-iter@0.1.45		X									X						
+num-rational@0.4.2		X									X						
+num-traits@0.2.19		X									X						
+object@0.37.3		X									X						
+object_store@0.13.2		X									X						
+once_cell@1.21.3		X									X						
+opendal@0.55.0		X															
+openssl@0.10.77		X															
+openssl-macros@0.1.1		X									X						
+openssl-probe@0.2.1		X									X						
+openssl-sys@0.9.113											X						
+orc-rust@0.8.0		X															
+ordered-float@2.10.1											X						
+paimon@0.1.0		X															
+paimon-datafusion@0.1.0		X															
+parking_lot@0.12.5		X									X						
+parking_lot_core@0.9.12		X									X						
+parquet@58.1.0		X															
+paste@1.0.15		X									X						
+percent-encoding@2.3.2		X									X						
+petgraph@0.8.3		X									X						
+phf@0.12.1											X						
+phf_shared@0.12.1											X						
+pin-project-lite@0.2.16		X									X						
+pin-utils@0.1.0		X									X						
+pkg-config@0.3.32		X									X						
+plain@0.2.3		X									X						
+portable-atomic@1.13.1		X									X						
+portable-atomic-util@0.2.6		X									X						
+potential_utf@0.1.2														X			
+ppv-lite86@0.2.21		X									X						
+pretty_assertions@1.4.1		X									X						
+prettyplease@0.2.37		X									X						
+proc-macro2@1.0.95		X									X						
+prost@0.13.5		X															
+prost@0.14.3		X															
+prost-derive@0.13.5		X															
+prost-derive@0.14.3		X															
+prost-types@0.14.3		X															
+psm@0.1.30		X									X						
+pyo3@0.28.3		X									X						
+pyo3-build-config@0.28.3		X									X						
+pyo3-ffi@0.28.3		X									X						
+pyo3-macros@0.28.3		X									X						
+pyo3-macros-backend@0.28.3		X									X						
+pypaimon_rust@0.1.0		X															
+quad-rand@0.2.3											X						
+quick-xml@0.37.5											X						
+quick-xml@0.38.4											X						
+quote@1.0.44		X									X						
+r-efi@5.3.0		X								X	X						
+rand@0.8.5		X									X						
+rand@0.9.2		X									X						
+rand_chacha@0.3.1		X									X						
+rand_chacha@0.9.0		X									X						
+rand_core@0.6.4		X									X						
+rand_core@0.9.3		X									X						
+recursive@0.1.1											X						
+recursive-proc-macro-impl@0.1.1											X						
+redox_syscall@0.5.18											X						
+regex@1.12.3		X									X						
+regex-automata@0.4.14		X									X						
+regex-lite@0.1.9		X									X						
+regex-syntax@0.8.10		X									X						
+repr_offset@0.2.2																X	
+reqsign@0.16.5		X															
+reqwest@0.12.28		X									X						
+ring@0.17.14		X							X								
+roaring@0.11.3		X									X						
+roxmltree@0.21.1		X									X						
+rustc_version@0.4.1		X									X						
+rustix@1.1.4		X	X								X						
+rustls@0.23.29		X							X		X						
+rustls-pki-types@1.12.0		X									X						
+rustls-webpki@0.103.4									X								
+rustversion@1.0.21		X									X						
+ryu@1.0.20		X				X											
+same-file@1.0.6											X				X		
+schannel@0.1.29											X						
+scopeguard@1.2.0		X									X						
+security-framework@3.6.0		X									X						
+security-framework-sys@2.17.0		X									X						
+semver@1.0.27		X									X						
+seq-macro@0.3.6		X									X						
+serde@1.0.228		X									X						
+serde_bytes@0.11.19		X									X						
+serde_core@1.0.228		X									X						
+serde_derive@1.0.228		X									X						
+serde_json@1.0.149		X									X						
+serde_repr@0.1.20		X									X						
+serde_urlencoded@0.7.1		X									X						
+serde_with@3.14.0		X									X						
+serde_with_macros@3.14.0		X									X						
+sha1@0.10.6		X									X						
+sha2@0.10.9		X									X						
+shlex@1.3.0		X									X						
+simd-adler32@0.3.8											X						
+simdutf8@0.1.5		X									X						
+siphasher@1.0.2		X									X						
+slab@0.4.10											X						
+smallvec@1.15.1		X									X						
+snafu@0.8.9		X									X						
+snafu@0.9.0		X									X						
+snafu-derive@0.8.9		X									X						
+snafu-derive@0.9.0		X									X						
+snap@1.1.1					X												
+socket2@0.5.10		X									X						
+socket2@0.6.2		X									X						
+sqlparser@0.61.0		X															
+sqlparser_derive@0.5.0		X															
+stable_deref_trait@1.2.0		X									X						
+stacker@0.1.23		X									X						
+strsim@0.11.1											X						
+strum@0.27.2											X						
+strum_macros@0.27.2											X						
+subtle@2.6.1					X												
+syn@1.0.109		X									X						
+syn@2.0.117		X									X						
+sync_wrapper@1.0.2		X															
+synstructure@0.13.2											X						
+system-configuration@0.6.1		X									X						
+system-configuration-sys@0.6.0		X									X						
+target-lexicon@0.13.5			X														
+tempfile@3.26.0		X									X						
+thiserror@1.0.69		X									X						
+thiserror@2.0.18		X									X						
+thiserror-impl@1.0.69		X									X						
+thiserror-impl@2.0.18		X									X						
+thrift@0.17.0		X															
+tiny-keccak@2.0.2							X										
+tinystr@0.8.1														X			
+tokio@1.49.0											X						
+tokio-macros@2.6.0											X						
+tokio-native-tls@0.3.1											X						
+tokio-rustls@0.26.2		X									X						
+tokio-stream@0.1.18											X						
+tokio-util@0.7.18											X						
+tower@0.5.2											X						
+tower-http@0.6.8											X						
+tower-layer@0.3.3											X						
+tower-service@0.3.3											X						
+tracing@0.1.41											X						
+tracing-attributes@0.1.31											X						
+tracing-core@0.1.36											X						
+try-lock@0.2.5											X						
+tstr@0.2.4																X	
+tstr_proc_macros@0.2.2																X	
+twox-hash@2.1.2											X						
+typed-arena@2.0.2											X						
+typed-builder@0.19.1		X									X						
+typed-builder-macro@0.19.1		X									X						
+typenum@1.18.0		X									X						
+typewit@1.15.1																X	
+unicode-ident@1.0.18		X									X			X			
+unicode-segmentation@1.13.2		X									X						
+unicode-width@0.2.2		X									X						
+untrusted@0.9.0									X								
+url@2.5.8		X									X						
+urlencoding@2.1.3											X						
+utf8_iter@1.0.4		X									X						
+uuid@1.21.0		X									X						
+vcpkg@0.2.15		X									X						
+version_check@0.9.5		X									X						
+walkdir@2.5.0											X				X		
+want@0.3.1											X						
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X						
+wasi@0.14.2+wasi-0.2.4		X	X								X						
+wasip2@1.0.2+wasi-0.2.9		X	X								X						
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X						
+wasite@0.1.0		X				X					X						
+wasm-bindgen@0.2.118		X									X						
+wasm-bindgen-futures@0.4.68		X									X						
+wasm-bindgen-macro@0.2.118		X									X						
+wasm-bindgen-macro-support@0.2.118		X									X						
+wasm-bindgen-shared@0.2.118		X									X						
+wasm-streams@0.4.2		X									X						
+web-sys@0.3.95		X									X						
+web-time@1.1.0		X									X						
+webpki-roots@1.0.2								X									
+whoami@1.6.1		X				X					X						
+winapi@0.3.9		X									X						
+winapi-i686-pc-windows-gnu@0.4.0		X									X						
+winapi-util@0.1.11											X				X		
+winapi-x86_64-pc-windows-gnu@0.4.0		X									X						
+windows-core@0.61.2		X									X						
+windows-implement@0.60.0		X									X						
+windows-interface@0.59.1		X									X						
+windows-link@0.1.3		X									X						
+windows-link@0.2.1		X									X						
+windows-registry@0.5.3		X									X						
+windows-result@0.3.4		X									X						
+windows-strings@0.4.2		X									X						
+windows-sys@0.52.0		X									X						
+windows-sys@0.59.0		X									X						
+windows-sys@0.60.2		X									X						
+windows-sys@0.61.2		X									X						
+windows-targets@0.52.6		X									X						
+windows-targets@0.53.5		X									X						
+windows_aarch64_gnullvm@0.52.6		X									X						
+windows_aarch64_gnullvm@0.53.1		X									X						
+windows_aarch64_msvc@0.52.6		X									X						
+windows_aarch64_msvc@0.53.1		X									X						
+windows_i686_gnu@0.52.6		X									X						
+windows_i686_gnu@0.53.1		X									X						
+windows_i686_gnullvm@0.52.6		X									X						
+windows_i686_gnullvm@0.53.1		X									X						
+windows_i686_msvc@0.52.6		X									X						
+windows_i686_msvc@0.53.1		X									X						
+windows_x86_64_gnu@0.52.6		X									X						
+windows_x86_64_gnu@0.53.1		X									X						
+windows_x86_64_gnullvm@0.52.6		X									X						
+windows_x86_64_gnullvm@0.53.1		X									X						
+windows_x86_64_msvc@0.52.6		X									X						
+windows_x86_64_msvc@0.53.1		X									X						
+wit-bindgen@0.51.0		X	X								X						
+wit-bindgen-rt@0.39.0		X	X								X						
+writeable@0.6.1														X			
+yansi@1.0.1		X									X						
+yoke@0.8.0														X			
+yoke-derive@0.8.0														X			
+zerocopy@0.8.26		X		X							X						
+zerocopy-derive@0.8.26		X		X							X						
+zerofrom@0.1.6														X			
+zerofrom-derive@0.1.6														X			
+zeroize@1.8.1		X									X						
+zerotrie@0.2.2														X			
+zerovec@0.11.2														X			
+zerovec-derive@0.11.1														X			
+zlib-rs@0.6.3																X	
+zmij@1.0.21											X						
+zstd@0.13.3											X						
+zstd-safe@7.2.4		X									X						
+zstd-sys@2.0.16+zstd.1.5.7		X									X						

--- a/crates/integration_tests/DEPENDENCIES.rust.tsv
+++ b/crates/integration_tests/DEPENDENCIES.rust.tsv
@@ -1,344 +1,345 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X										X			
-ahash@0.8.12		X										X			
-aho-corasick@1.1.4												X		X	
-alloc-no-stdlib@2.0.4					X										
-alloc-stdlib@0.2.2					X										
-android_system_properties@0.1.5		X										X			
-anyhow@1.0.102		X										X			
-arrayvec@0.7.6		X										X			
-arrow@58.1.0		X													
-arrow-arith@58.1.0		X													
-arrow-array@58.1.0		X													
-arrow-buffer@58.1.0		X													
-arrow-cast@58.1.0		X													
-arrow-csv@58.1.0		X													
-arrow-data@58.1.0		X													
-arrow-ipc@58.1.0		X													
-arrow-json@58.1.0		X													
-arrow-ord@58.1.0		X													
-arrow-row@58.1.0		X													
-arrow-schema@58.1.0		X													
-arrow-select@58.1.0		X													
-arrow-string@58.1.0		X													
-async-stream@0.3.6												X			
-async-stream-impl@0.3.6												X			
-async-trait@0.1.89		X										X			
-atoi@2.0.0												X			
-atomic-waker@1.1.2		X										X			
-autocfg@1.5.0		X										X			
-backon@1.6.0		X													
-base64@0.22.1		X										X			
-bitflags@2.9.1		X										X			
-block-buffer@0.10.4		X										X			
-brotli@8.0.2					X							X			
-brotli-decompressor@5.0.0					X							X			
-bumpalo@3.19.0		X										X			
-bytemuck@1.25.0		X										X			X
-byteorder@1.5.0												X		X	
-bytes@1.11.1												X			
-cc@1.2.56		X										X			
-cfg-if@1.0.1		X										X			
-chacha20@0.10.0		X										X			
-chrono@0.4.44		X										X			
-chrono-tz@0.10.4		X										X			
-comfy-table@7.2.2												X			
-const-oid@0.9.6		X										X			
-const-random@0.1.18		X										X			
-const-random-macro@0.1.16		X										X			
-core-foundation@0.10.1		X										X			
-core-foundation@0.9.4		X										X			
-core-foundation-sys@0.8.7		X										X			
-cpufeatures@0.2.17		X										X			
-cpufeatures@0.3.0		X										X			
-crc32fast@1.5.0		X										X			
-crunchy@0.2.4												X			
-crypto-common@0.1.6		X										X			
-csv@1.4.0												X		X	
-csv-core@0.1.13												X		X	
-darling@0.20.11												X			
-darling_core@0.20.11												X			
-darling_macro@0.20.11												X			
-diff@0.1.13		X										X			
-digest@0.10.7		X										X			
-displaydoc@0.2.5		X										X			
-either@1.15.0		X										X			
-encoding_rs@0.8.35		X			X							X			
-equivalent@1.0.2		X										X			
-errno@0.3.14		X										X			
-fallible-streaming-iterator@0.1.9		X										X			
-fastrand@2.3.0		X										X			
-find-msvc-tools@0.1.9		X										X			
-flatbuffers@25.12.19		X													
-flate2@1.1.9		X										X			
-fnv@1.0.7		X										X			
-foreign-types@0.3.2		X										X			
-foreign-types-shared@0.1.1		X										X			
-form_urlencoded@1.2.2		X										X			
-futures@0.3.31		X										X			
-futures-channel@0.3.31		X										X			
-futures-core@0.3.31		X										X			
-futures-executor@0.3.31		X										X			
-futures-io@0.3.31		X										X			
-futures-macro@0.3.31		X										X			
-futures-sink@0.3.31		X										X			
-futures-task@0.3.31		X										X			
-futures-util@0.3.31		X										X			
-generic-array@0.14.7												X			
-getrandom@0.2.16		X										X			
-getrandom@0.3.3		X										X			
-getrandom@0.4.1		X										X			
-gloo-timers@0.3.0		X										X			
-h2@0.4.13												X			
-half@2.7.1		X										X			
-hashbrown@0.16.1		X										X			
-heck@0.5.0		X										X			
-hex@0.4.3		X										X			
-hmac@0.12.1		X										X			
-home@0.5.12		X										X			
-http@1.3.1		X										X			
-http-body@1.0.1												X			
-http-body-util@0.1.3												X			
-httparse@1.10.1		X										X			
-httpdate@1.0.3		X										X			
-hyper@1.6.0												X			
-hyper-rustls@0.27.7		X							X			X			
-hyper-tls@0.6.0		X										X			
-hyper-util@0.1.15												X			
-iana-time-zone@0.1.63		X										X			
-iana-time-zone-haiku@0.1.2		X										X			
-icu_collections@2.0.0													X		
-icu_locale_core@2.0.0													X		
-icu_normalizer@2.0.0													X		
-icu_normalizer_data@2.0.0													X		
-icu_properties@2.0.1													X		
-icu_properties_data@2.0.1													X		
-icu_provider@2.0.0													X		
-ident_case@1.0.1		X										X			
-idna@1.1.0		X										X			
-idna_adapter@1.2.1		X										X			
-indexmap@2.13.0		X										X			
-integer-encoding@3.0.4												X			
-integer-encoding@4.1.0												X			
-ipnet@2.11.0		X										X			
-iri-string@0.7.8		X										X			
-itertools@0.14.0		X										X			
-itoa@1.0.15		X										X			
-jiff@0.2.23												X		X	
-jiff-tzdb@0.1.6												X		X	
-jiff-tzdb-platform@0.1.3												X		X	
-jobserver@0.1.34		X										X			
-js-sys@0.3.77		X										X			
-lexical-core@1.0.6		X										X			
-lexical-parse-float@1.0.6		X										X			
-lexical-parse-integer@1.0.6		X										X			
-lexical-util@1.0.7		X										X			
-lexical-write-float@1.0.6		X										X			
-lexical-write-integer@1.0.6		X										X			
-libc@0.2.182		X										X			
-libm@0.2.15												X			
-linux-raw-sys@0.12.1		X	X									X			
-litemap@0.8.0													X		
-log@0.4.29		X										X			
-lz4_flex@0.11.6												X			
-lz4_flex@0.13.0												X			
-lzokay-native@0.1.0												X			
-md-5@0.10.6		X										X			
-memchr@2.8.0												X		X	
-mime@0.3.17		X										X			
-miniz_oxide@0.8.9		X										X			X
-mio@1.0.4												X			
-native-tls@0.2.18		X										X			
-num@0.4.3		X										X			
-num-bigint@0.4.6		X										X			
-num-complex@0.4.6		X										X			
-num-integer@0.1.46		X										X			
-num-iter@0.1.45		X										X			
-num-rational@0.4.2		X										X			
-num-traits@0.2.19		X										X			
-once_cell@1.21.3		X										X			
-opendal@0.55.0		X													
-openssl@0.10.76		X													
-openssl-macros@0.1.1		X										X			
-openssl-probe@0.2.1		X										X			
-openssl-sys@0.9.112												X			
-orc-rust@0.8.0		X													
-ordered-float@2.10.1												X			
-paimon@0.1.0		X													
-paimon-integration-tests@0.1.0		X													
-parquet@58.1.0		X													
-paste@1.0.15		X										X			
-percent-encoding@2.3.2		X										X			
-phf@0.12.1												X			
-phf_shared@0.12.1												X			
-pin-project-lite@0.2.16		X										X			
-pin-utils@0.1.0		X										X			
-pkg-config@0.3.32		X										X			
-portable-atomic@1.13.1		X										X			
-portable-atomic-util@0.2.6		X										X			
-potential_utf@0.1.2													X		
-ppv-lite86@0.2.21		X										X			
-pretty_assertions@1.4.1		X										X			
-proc-macro2@1.0.95		X										X			
-prost@0.13.5		X													
-prost-derive@0.13.5		X													
-quick-xml@0.38.4												X			
-quote@1.0.44		X										X			
-r-efi@5.3.0		X								X		X			
-rand@0.10.0		X										X			
-rand@0.8.5		X										X			
-rand_chacha@0.3.1		X										X			
-rand_core@0.10.0		X										X			
-rand_core@0.6.4		X										X			
-regex@1.12.3		X										X			
-regex-automata@0.4.14		X										X			
-regex-syntax@0.8.10		X										X			
-reqsign@0.16.5		X													
-reqwest@0.12.28		X										X			
-ring@0.17.14		X							X						
-roaring@0.11.3		X										X			
-rust_decimal@1.41.0												X			
-rustc_version@0.4.1		X										X			
-rustix@1.1.4		X	X									X			
-rustls@0.23.29		X							X			X			
-rustls-pki-types@1.12.0		X										X			
-rustls-webpki@0.103.4									X						
-rustversion@1.0.21		X										X			
-ryu@1.0.20		X				X									
-schannel@0.1.29												X			
-security-framework@3.6.0		X										X			
-security-framework-sys@2.17.0		X										X			
-semver@1.0.27		X										X			
-seq-macro@0.3.6		X										X			
-serde@1.0.228		X										X			
-serde-transcode@1.1.1		X										X			
-serde_avro_fast@2.0.2											X				
-serde_bytes@0.11.19		X										X			
-serde_core@1.0.228		X										X			
-serde_derive@1.0.228		X										X			
-serde_json@1.0.149		X										X			
-serde_repr@0.1.20		X										X			
-serde_serializer_quick_unsupported@1.0.0											X				
-serde_urlencoded@0.7.1		X										X			
-serde_with@3.14.0		X										X			
-serde_with_macros@3.14.0		X										X			
-sha1@0.10.6		X										X			
-sha2@0.10.9		X										X			
-shlex@1.3.0		X										X			
-simd-adler32@0.3.8												X			
-simdutf8@0.1.5		X										X			
-siphasher@1.0.2		X										X			
-slab@0.4.10												X			
-smallvec@1.15.1		X										X			
-snafu@0.8.9		X										X			
-snafu@0.9.0		X										X			
-snafu-derive@0.8.9		X										X			
-snafu-derive@0.9.0		X										X			
-snap@1.1.1					X										
-socket2@0.5.10		X										X			
-socket2@0.6.2		X										X			
-stable_deref_trait@1.2.0		X										X			
-strsim@0.11.1												X			
-subtle@2.6.1					X										
-syn@2.0.117		X										X			
-sync_wrapper@1.0.2		X													
-synstructure@0.13.2												X			
-system-configuration@0.6.1		X										X			
-system-configuration-sys@0.6.0		X										X			
-tempfile@3.26.0		X										X			
-thiserror@1.0.69		X										X			
-thiserror@2.0.18		X										X			
-thiserror-impl@1.0.69		X										X			
-thiserror-impl@2.0.18		X										X			
-thrift@0.17.0		X													
-tiny-keccak@2.0.2							X								
-tinystr@0.8.1													X		
-tokio@1.49.0												X			
-tokio-macros@2.6.0												X			
-tokio-native-tls@0.3.1												X			
-tokio-rustls@0.26.2		X										X			
-tokio-util@0.7.18												X			
-tower@0.5.2												X			
-tower-http@0.6.8												X			
-tower-layer@0.3.3												X			
-tower-service@0.3.3												X			
-tracing@0.1.41												X			
-tracing-core@0.1.36												X			
-try-lock@0.2.5												X			
-twox-hash@2.1.2												X			
-typed-builder@0.19.1		X										X			
-typed-builder-macro@0.19.1		X										X			
-typenum@1.18.0		X										X			
-unicode-ident@1.0.18		X										X	X		
-unicode-segmentation@1.13.2		X										X			
-unicode-width@0.2.2		X										X			
-untrusted@0.9.0									X						
-url@2.5.8		X										X			
-urlencoding@2.1.3												X			
-utf8_iter@1.0.4		X										X			
-uuid@1.21.0		X										X			
-vcpkg@0.2.15		X										X			
-version_check@0.9.5		X										X			
-want@0.3.1												X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X			
-wasi@0.14.2+wasi-0.2.4		X	X									X			
-wasip2@1.0.2+wasi-0.2.9		X	X									X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X			
-wasm-bindgen@0.2.100		X										X			
-wasm-bindgen-backend@0.2.100		X										X			
-wasm-bindgen-futures@0.4.50		X										X			
-wasm-bindgen-macro@0.2.100		X										X			
-wasm-bindgen-macro-support@0.2.100		X										X			
-wasm-bindgen-shared@0.2.100		X										X			
-wasm-streams@0.4.2		X										X			
-web-sys@0.3.77		X										X			
-webpki-roots@1.0.2								X							
-windows-core@0.61.2		X										X			
-windows-implement@0.60.0		X										X			
-windows-interface@0.59.1		X										X			
-windows-link@0.1.3		X										X			
-windows-link@0.2.1		X										X			
-windows-registry@0.5.3		X										X			
-windows-result@0.3.4		X										X			
-windows-strings@0.4.2		X										X			
-windows-sys@0.52.0		X										X			
-windows-sys@0.59.0		X										X			
-windows-sys@0.60.2		X										X			
-windows-sys@0.61.2		X										X			
-windows-targets@0.52.6		X										X			
-windows-targets@0.53.5		X										X			
-windows_aarch64_gnullvm@0.52.6		X										X			
-windows_aarch64_gnullvm@0.53.1		X										X			
-windows_aarch64_msvc@0.52.6		X										X			
-windows_aarch64_msvc@0.53.1		X										X			
-windows_i686_gnu@0.52.6		X										X			
-windows_i686_gnu@0.53.1		X										X			
-windows_i686_gnullvm@0.52.6		X										X			
-windows_i686_gnullvm@0.53.1		X										X			
-windows_i686_msvc@0.52.6		X										X			
-windows_i686_msvc@0.53.1		X										X			
-windows_x86_64_gnu@0.52.6		X										X			
-windows_x86_64_gnu@0.53.1		X										X			
-windows_x86_64_gnullvm@0.52.6		X										X			
-windows_x86_64_gnullvm@0.53.1		X										X			
-windows_x86_64_msvc@0.52.6		X										X			
-windows_x86_64_msvc@0.53.1		X										X			
-wit-bindgen@0.51.0		X	X									X			
-wit-bindgen-rt@0.39.0		X	X									X			
-writeable@0.6.1													X		
-yansi@1.0.1		X										X			
-yoke@0.8.0													X		
-yoke-derive@0.8.0													X		
-zerocopy@0.8.26		X		X								X			
-zerocopy-derive@0.8.26		X		X								X			
-zerofrom@0.1.6													X		
-zerofrom-derive@0.1.6													X		
-zeroize@1.8.1		X										X			
-zerotrie@0.2.2													X		
-zerovec@0.11.2													X		
-zerovec-derive@0.11.1													X		
-zlib-rs@0.6.3															X
-zmij@1.0.21												X			
-zstd@0.13.3												X			
-zstd-safe@7.2.4		X										X			
-zstd-sys@2.0.16+zstd.1.5.7		X										X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X			
+ahash@0.8.12		X									X			
+aho-corasick@1.1.4											X		X	
+alloc-no-stdlib@2.0.4					X									
+alloc-stdlib@0.2.2					X									
+android_system_properties@0.1.5		X									X			
+anyhow@1.0.102		X									X			
+apache-avro@0.21.0		X												
+arrow@58.1.0		X												
+arrow-arith@58.1.0		X												
+arrow-array@58.1.0		X												
+arrow-buffer@58.1.0		X												
+arrow-cast@58.1.0		X												
+arrow-csv@58.1.0		X												
+arrow-data@58.1.0		X												
+arrow-ipc@58.1.0		X												
+arrow-json@58.1.0		X												
+arrow-ord@58.1.0		X												
+arrow-row@58.1.0		X												
+arrow-schema@58.1.0		X												
+arrow-select@58.1.0		X												
+arrow-string@58.1.0		X												
+async-stream@0.3.6											X			
+async-stream-impl@0.3.6											X			
+async-trait@0.1.89		X									X			
+atoi@2.0.0											X			
+atomic-waker@1.1.2		X									X			
+autocfg@1.5.0		X									X			
+backon@1.6.0		X												
+base64@0.22.1		X									X			
+bigdecimal@0.4.10		X									X			
+bitflags@2.9.1		X									X			
+block-buffer@0.10.4		X									X			
+bon@3.9.1		X									X			
+bon-macros@3.9.1		X									X			
+brotli@8.0.2					X						X			
+brotli-decompressor@5.0.0					X						X			
+bumpalo@3.19.0		X									X			
+bytemuck@1.25.0		X									X			X
+byteorder@1.5.0											X		X	
+bytes@1.11.1											X			
+cc@1.2.56		X									X			
+cfg-if@1.0.1		X									X			
+chrono@0.4.44		X									X			
+chrono-tz@0.10.4		X									X			
+comfy-table@7.2.2											X			
+const-oid@0.9.6		X									X			
+const-random@0.1.18		X									X			
+const-random-macro@0.1.16		X									X			
+core-foundation@0.10.1		X									X			
+core-foundation@0.9.4		X									X			
+core-foundation-sys@0.8.7		X									X			
+cpufeatures@0.2.17		X									X			
+crc32fast@1.5.0		X									X			
+crunchy@0.2.4											X			
+crypto-common@0.1.6		X									X			
+csv@1.4.0											X		X	
+csv-core@0.1.13											X		X	
+darling@0.20.11											X			
+darling_core@0.20.11											X			
+darling_macro@0.20.11											X			
+diff@0.1.13		X									X			
+digest@0.10.7		X									X			
+displaydoc@0.2.5		X									X			
+either@1.15.0		X									X			
+encoding_rs@0.8.35		X			X						X			
+equivalent@1.0.2		X									X			
+errno@0.3.14		X									X			
+fallible-streaming-iterator@0.1.9		X									X			
+fastrand@2.3.0		X									X			
+find-msvc-tools@0.1.9		X									X			
+flatbuffers@25.12.19		X												
+flate2@1.1.9		X									X			
+fnv@1.0.7		X									X			
+foreign-types@0.3.2		X									X			
+foreign-types-shared@0.1.1		X									X			
+form_urlencoded@1.2.2		X									X			
+futures@0.3.31		X									X			
+futures-channel@0.3.31		X									X			
+futures-core@0.3.31		X									X			
+futures-executor@0.3.31		X									X			
+futures-io@0.3.31		X									X			
+futures-macro@0.3.31		X									X			
+futures-sink@0.3.31		X									X			
+futures-task@0.3.31		X									X			
+futures-util@0.3.31		X									X			
+generic-array@0.14.7											X			
+getrandom@0.2.16		X									X			
+getrandom@0.3.3		X									X			
+getrandom@0.4.1		X									X			
+gloo-timers@0.3.0		X									X			
+h2@0.4.13											X			
+half@2.7.1		X									X			
+hashbrown@0.16.1		X									X			
+heck@0.5.0		X									X			
+hex@0.4.3		X									X			
+hmac@0.12.1		X									X			
+home@0.5.12		X									X			
+http@1.3.1		X									X			
+http-body@1.0.1											X			
+http-body-util@0.1.3											X			
+httparse@1.10.1		X									X			
+httpdate@1.0.3		X									X			
+hyper@1.6.0											X			
+hyper-rustls@0.27.7		X							X		X			
+hyper-tls@0.6.0		X									X			
+hyper-util@0.1.15											X			
+iana-time-zone@0.1.63		X									X			
+iana-time-zone-haiku@0.1.2		X									X			
+icu_collections@2.0.0												X		
+icu_locale_core@2.0.0												X		
+icu_normalizer@2.0.0												X		
+icu_normalizer_data@2.0.0												X		
+icu_properties@2.0.1												X		
+icu_properties_data@2.0.1												X		
+icu_provider@2.0.0												X		
+ident_case@1.0.1		X									X			
+idna@1.1.0		X									X			
+idna_adapter@1.2.1		X									X			
+indexmap@2.13.0		X									X			
+integer-encoding@3.0.4											X			
+ipnet@2.11.0		X									X			
+iri-string@0.7.8		X									X			
+itertools@0.14.0		X									X			
+itoa@1.0.15		X									X			
+jiff@0.2.23											X		X	
+jiff-tzdb@0.1.6											X		X	
+jiff-tzdb-platform@0.1.3											X		X	
+jobserver@0.1.34		X									X			
+js-sys@0.3.95		X									X			
+lexical-core@1.0.6		X									X			
+lexical-parse-float@1.0.6		X									X			
+lexical-parse-integer@1.0.6		X									X			
+lexical-util@1.0.7		X									X			
+lexical-write-float@1.0.6		X									X			
+lexical-write-integer@1.0.6		X									X			
+libc@0.2.182		X									X			
+libm@0.2.15											X			
+linux-raw-sys@0.12.1		X	X								X			
+litemap@0.8.0												X		
+log@0.4.29		X									X			
+lz4_flex@0.11.6											X			
+lz4_flex@0.13.0											X			
+lzokay-native@0.1.0											X			
+md-5@0.10.6		X									X			
+memchr@2.8.0											X		X	
+mime@0.3.17		X									X			
+miniz_oxide@0.8.9		X									X			X
+mio@1.0.4											X			
+native-tls@0.2.18		X									X			
+num@0.4.3		X									X			
+num-bigint@0.4.6		X									X			
+num-complex@0.4.6		X									X			
+num-integer@0.1.46		X									X			
+num-iter@0.1.45		X									X			
+num-rational@0.4.2		X									X			
+num-traits@0.2.19		X									X			
+once_cell@1.21.3		X									X			
+opendal@0.55.0		X												
+openssl@0.10.77		X												
+openssl-macros@0.1.1		X									X			
+openssl-probe@0.2.1		X									X			
+openssl-sys@0.9.113											X			
+orc-rust@0.8.0		X												
+ordered-float@2.10.1											X			
+paimon@0.1.0		X												
+paimon-integration-tests@0.1.0		X												
+parquet@58.1.0		X												
+paste@1.0.15		X									X			
+percent-encoding@2.3.2		X									X			
+phf@0.12.1											X			
+phf_shared@0.12.1											X			
+pin-project-lite@0.2.16		X									X			
+pin-utils@0.1.0		X									X			
+pkg-config@0.3.32		X									X			
+portable-atomic@1.13.1		X									X			
+portable-atomic-util@0.2.6		X									X			
+potential_utf@0.1.2												X		
+ppv-lite86@0.2.21		X									X			
+pretty_assertions@1.4.1		X									X			
+prettyplease@0.2.37		X									X			
+proc-macro2@1.0.95		X									X			
+prost@0.13.5		X												
+prost-derive@0.13.5		X												
+quad-rand@0.2.3											X			
+quick-xml@0.38.4											X			
+quote@1.0.44		X									X			
+r-efi@5.3.0		X								X	X			
+rand@0.8.5		X									X			
+rand@0.9.2		X									X			
+rand_chacha@0.3.1		X									X			
+rand_chacha@0.9.0		X									X			
+rand_core@0.6.4		X									X			
+rand_core@0.9.3		X									X			
+regex@1.12.3		X									X			
+regex-automata@0.4.14		X									X			
+regex-lite@0.1.9		X									X			
+regex-syntax@0.8.10		X									X			
+reqsign@0.16.5		X												
+reqwest@0.12.28		X									X			
+ring@0.17.14		X							X					
+roaring@0.11.3		X									X			
+rustc_version@0.4.1		X									X			
+rustix@1.1.4		X	X								X			
+rustls@0.23.29		X							X		X			
+rustls-pki-types@1.12.0		X									X			
+rustls-webpki@0.103.4									X					
+rustversion@1.0.21		X									X			
+ryu@1.0.20		X				X								
+schannel@0.1.29											X			
+security-framework@3.6.0		X									X			
+security-framework-sys@2.17.0		X									X			
+semver@1.0.27		X									X			
+seq-macro@0.3.6		X									X			
+serde@1.0.228		X									X			
+serde_bytes@0.11.19		X									X			
+serde_core@1.0.228		X									X			
+serde_derive@1.0.228		X									X			
+serde_json@1.0.149		X									X			
+serde_repr@0.1.20		X									X			
+serde_urlencoded@0.7.1		X									X			
+serde_with@3.14.0		X									X			
+serde_with_macros@3.14.0		X									X			
+sha1@0.10.6		X									X			
+sha2@0.10.9		X									X			
+shlex@1.3.0		X									X			
+simd-adler32@0.3.8											X			
+simdutf8@0.1.5		X									X			
+siphasher@1.0.2		X									X			
+slab@0.4.10											X			
+smallvec@1.15.1		X									X			
+snafu@0.8.9		X									X			
+snafu@0.9.0		X									X			
+snafu-derive@0.8.9		X									X			
+snafu-derive@0.9.0		X									X			
+snap@1.1.1					X									
+socket2@0.5.10		X									X			
+socket2@0.6.2		X									X			
+stable_deref_trait@1.2.0		X									X			
+strsim@0.11.1											X			
+strum@0.27.2											X			
+strum_macros@0.27.2											X			
+subtle@2.6.1					X									
+syn@2.0.117		X									X			
+sync_wrapper@1.0.2		X												
+synstructure@0.13.2											X			
+system-configuration@0.6.1		X									X			
+system-configuration-sys@0.6.0		X									X			
+tempfile@3.26.0		X									X			
+thiserror@1.0.69		X									X			
+thiserror@2.0.18		X									X			
+thiserror-impl@1.0.69		X									X			
+thiserror-impl@2.0.18		X									X			
+thrift@0.17.0		X												
+tiny-keccak@2.0.2							X							
+tinystr@0.8.1												X		
+tokio@1.49.0											X			
+tokio-macros@2.6.0											X			
+tokio-native-tls@0.3.1											X			
+tokio-rustls@0.26.2		X									X			
+tokio-util@0.7.18											X			
+tower@0.5.2											X			
+tower-http@0.6.8											X			
+tower-layer@0.3.3											X			
+tower-service@0.3.3											X			
+tracing@0.1.41											X			
+tracing-core@0.1.36											X			
+try-lock@0.2.5											X			
+twox-hash@2.1.2											X			
+typed-builder@0.19.1		X									X			
+typed-builder-macro@0.19.1		X									X			
+typenum@1.18.0		X									X			
+unicode-ident@1.0.18		X									X	X		
+unicode-segmentation@1.13.2		X									X			
+unicode-width@0.2.2		X									X			
+untrusted@0.9.0									X					
+url@2.5.8		X									X			
+urlencoding@2.1.3											X			
+utf8_iter@1.0.4		X									X			
+uuid@1.21.0		X									X			
+vcpkg@0.2.15		X									X			
+version_check@0.9.5		X									X			
+want@0.3.1											X			
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
+wasi@0.14.2+wasi-0.2.4		X	X								X			
+wasip2@1.0.2+wasi-0.2.9		X	X								X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X			
+wasm-bindgen@0.2.118		X									X			
+wasm-bindgen-futures@0.4.68		X									X			
+wasm-bindgen-macro@0.2.118		X									X			
+wasm-bindgen-macro-support@0.2.118		X									X			
+wasm-bindgen-shared@0.2.118		X									X			
+wasm-streams@0.4.2		X									X			
+web-sys@0.3.95		X									X			
+webpki-roots@1.0.2								X						
+windows-core@0.61.2		X									X			
+windows-implement@0.60.0		X									X			
+windows-interface@0.59.1		X									X			
+windows-link@0.1.3		X									X			
+windows-link@0.2.1		X									X			
+windows-registry@0.5.3		X									X			
+windows-result@0.3.4		X									X			
+windows-strings@0.4.2		X									X			
+windows-sys@0.52.0		X									X			
+windows-sys@0.59.0		X									X			
+windows-sys@0.60.2		X									X			
+windows-sys@0.61.2		X									X			
+windows-targets@0.52.6		X									X			
+windows-targets@0.53.5		X									X			
+windows_aarch64_gnullvm@0.52.6		X									X			
+windows_aarch64_gnullvm@0.53.1		X									X			
+windows_aarch64_msvc@0.52.6		X									X			
+windows_aarch64_msvc@0.53.1		X									X			
+windows_i686_gnu@0.52.6		X									X			
+windows_i686_gnu@0.53.1		X									X			
+windows_i686_gnullvm@0.52.6		X									X			
+windows_i686_gnullvm@0.53.1		X									X			
+windows_i686_msvc@0.52.6		X									X			
+windows_i686_msvc@0.53.1		X									X			
+windows_x86_64_gnu@0.52.6		X									X			
+windows_x86_64_gnu@0.53.1		X									X			
+windows_x86_64_gnullvm@0.52.6		X									X			
+windows_x86_64_gnullvm@0.53.1		X									X			
+windows_x86_64_msvc@0.52.6		X									X			
+windows_x86_64_msvc@0.53.1		X									X			
+wit-bindgen@0.51.0		X	X								X			
+wit-bindgen-rt@0.39.0		X	X								X			
+writeable@0.6.1												X		
+yansi@1.0.1		X									X			
+yoke@0.8.0												X		
+yoke-derive@0.8.0												X		
+zerocopy@0.8.26		X		X							X			
+zerocopy-derive@0.8.26		X		X							X			
+zerofrom@0.1.6												X		
+zerofrom-derive@0.1.6												X		
+zeroize@1.8.1		X									X			
+zerotrie@0.2.2												X		
+zerovec@0.11.2												X		
+zerovec-derive@0.11.1												X		
+zlib-rs@0.6.3														X
+zmij@1.0.21											X			
+zstd@0.13.3											X			
+zstd-safe@7.2.4		X									X			
+zstd-sys@2.0.16+zstd.1.5.7		X									X			

--- a/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
@@ -1,421 +1,419 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
-adler2@2.0.1	X	X										X					
-ahash@0.8.12		X										X					
-aho-corasick@1.1.4												X			X		
-alloc-no-stdlib@2.0.4					X												
-alloc-stdlib@0.2.2					X												
-allocator-api2@0.2.21		X										X					
-android_system_properties@0.1.5		X										X					
-anyhow@1.0.102		X										X					
-ar_archive_writer@0.5.1			X														
-arrayref@0.3.9				X													
-arrayvec@0.7.6		X										X					
-arrow@58.1.0		X															
-arrow-arith@58.1.0		X															
-arrow-array@58.1.0		X															
-arrow-buffer@58.1.0		X															
-arrow-cast@58.1.0		X															
-arrow-csv@58.1.0		X															
-arrow-data@58.1.0		X															
-arrow-ipc@58.1.0		X															
-arrow-json@58.1.0		X															
-arrow-ord@58.1.0		X															
-arrow-row@58.1.0		X															
-arrow-schema@58.1.0		X															
-arrow-select@58.1.0		X															
-arrow-string@58.1.0		X															
-async-compression@0.4.41		X										X					
-async-stream@0.3.6												X					
-async-stream-impl@0.3.6												X					
-async-trait@0.1.89		X										X					
-atoi@2.0.0												X					
-atomic-waker@1.1.2		X										X					
-autocfg@1.5.0		X										X					
-backon@1.6.0		X															
-base64@0.22.1		X										X					
-bigdecimal@0.4.10		X										X					
-bitflags@2.9.1		X										X					
-blake2@0.10.6		X										X					
-blake3@1.8.3		X	X				X										
-block-buffer@0.10.4		X										X					
-brotli@8.0.2					X							X					
-brotli-decompressor@5.0.0					X							X					
-bumpalo@3.19.0		X										X					
-bytemuck@1.25.0		X										X				X	
-byteorder@1.5.0												X			X		
-bytes@1.11.1												X					
-bzip2@0.6.1		X										X					
-cc@1.2.56		X										X					
-cfg-if@1.0.1		X										X					
-chacha20@0.10.0		X										X					
-chrono@0.4.44		X										X					
-chrono-tz@0.10.4		X										X					
-comfy-table@7.2.2												X					
-compression-codecs@0.4.37		X										X					
-compression-core@0.4.31		X										X					
-const-oid@0.9.6		X										X					
-const-random@0.1.18		X										X					
-const-random-macro@0.1.16		X										X					
-constant_time_eq@0.4.2		X					X						X				
-core-foundation@0.10.1		X										X					
-core-foundation@0.9.4		X										X					
-core-foundation-sys@0.8.7		X										X					
-cpufeatures@0.2.17		X										X					
-cpufeatures@0.3.0		X										X					
-crc32fast@1.5.0		X										X					
-crossbeam-utils@0.8.21		X										X					
-crunchy@0.2.4												X					
-crypto-common@0.1.6		X										X					
-csv@1.4.0												X			X		
-csv-core@0.1.13												X			X		
-darling@0.20.11												X					
-darling_core@0.20.11												X					
-darling_macro@0.20.11												X					
-dashmap@6.1.0												X					
-datafusion@53.0.0		X															
-datafusion-catalog@53.0.0		X															
-datafusion-catalog-listing@53.0.0		X															
-datafusion-common@53.0.0		X															
-datafusion-common-runtime@53.0.0		X															
-datafusion-datasource@53.0.0		X															
-datafusion-datasource-arrow@53.0.0		X															
-datafusion-datasource-csv@53.0.0		X															
-datafusion-datasource-json@53.0.0		X															
-datafusion-datasource-parquet@53.0.0		X															
-datafusion-doc@53.0.0		X															
-datafusion-execution@53.0.0		X															
-datafusion-expr@53.0.0		X															
-datafusion-expr-common@53.0.0		X															
-datafusion-functions@53.0.0		X															
-datafusion-functions-aggregate@53.0.0		X															
-datafusion-functions-aggregate-common@53.0.0		X															
-datafusion-functions-nested@53.0.0		X															
-datafusion-functions-table@53.0.0		X															
-datafusion-functions-window@53.0.0		X															
-datafusion-functions-window-common@53.0.0		X															
-datafusion-macros@53.0.0		X															
-datafusion-optimizer@53.0.0		X															
-datafusion-physical-expr@53.0.0		X															
-datafusion-physical-expr-adapter@53.0.0		X															
-datafusion-physical-expr-common@53.0.0		X															
-datafusion-physical-optimizer@53.0.0		X															
-datafusion-physical-plan@53.0.0		X															
-datafusion-pruning@53.0.0		X															
-datafusion-session@53.0.0		X															
-datafusion-sql@53.0.0		X															
-diff@0.1.13		X										X					
-digest@0.10.7		X										X					
-displaydoc@0.2.5		X										X					
-either@1.15.0		X										X					
-encoding_rs@0.8.35		X			X							X					
-equivalent@1.0.2		X										X					
-errno@0.3.14		X										X					
-fallible-streaming-iterator@0.1.9		X										X					
-fastrand@2.3.0		X										X					
-find-msvc-tools@0.1.9		X										X					
-fixedbitset@0.5.7		X										X					
-flatbuffers@25.12.19		X															
-flate2@1.1.9		X										X					
-fnv@1.0.7		X										X					
-foldhash@0.1.5																X	
-foldhash@0.2.0																X	
-foreign-types@0.3.2		X										X					
-foreign-types-shared@0.1.1		X										X					
-form_urlencoded@1.2.2		X										X					
-futures@0.3.31		X										X					
-futures-channel@0.3.31		X										X					
-futures-core@0.3.31		X										X					
-futures-executor@0.3.31		X										X					
-futures-io@0.3.31		X										X					
-futures-macro@0.3.31		X										X					
-futures-sink@0.3.31		X										X					
-futures-task@0.3.31		X										X					
-futures-util@0.3.31		X										X					
-generic-array@0.14.7												X					
-getrandom@0.2.16		X										X					
-getrandom@0.3.3		X										X					
-getrandom@0.4.1		X										X					
-glob@0.3.3		X										X					
-gloo-timers@0.3.0		X										X					
-h2@0.4.13												X					
-half@2.7.1		X										X					
-hashbrown@0.14.5		X										X					
-hashbrown@0.15.4		X										X					
-hashbrown@0.16.1		X										X					
-heck@0.5.0		X										X					
-hex@0.4.3		X										X					
-hmac@0.12.1		X										X					
-home@0.5.12		X										X					
-http@1.3.1		X										X					
-http-body@1.0.1												X					
-http-body-util@0.1.3												X					
-httparse@1.10.1		X										X					
-httpdate@1.0.3		X										X					
-humantime@2.3.0		X										X					
-hyper@1.6.0												X					
-hyper-rustls@0.27.7		X							X			X					
-hyper-tls@0.6.0		X										X					
-hyper-util@0.1.15												X					
-iana-time-zone@0.1.63		X										X					
-iana-time-zone-haiku@0.1.2		X										X					
-icu_collections@2.0.0														X			
-icu_locale_core@2.0.0														X			
-icu_normalizer@2.0.0														X			
-icu_normalizer_data@2.0.0														X			
-icu_properties@2.0.1														X			
-icu_properties_data@2.0.1														X			
-icu_provider@2.0.0														X			
-ident_case@1.0.1		X										X					
-idna@1.1.0		X										X					
-idna_adapter@1.2.1		X										X					
-indexmap@2.13.0		X										X					
-integer-encoding@3.0.4												X					
-integer-encoding@4.1.0												X					
-ipnet@2.11.0		X										X					
-iri-string@0.7.8		X										X					
-itertools@0.14.0		X										X					
-itoa@1.0.15		X										X					
-jiff@0.2.23												X			X		
-jiff-tzdb@0.1.6												X			X		
-jiff-tzdb-platform@0.1.3												X			X		
-jobserver@0.1.34		X										X					
-js-sys@0.3.77		X										X					
-lexical-core@1.0.6		X										X					
-lexical-parse-float@1.0.6		X										X					
-lexical-parse-integer@1.0.6		X										X					
-lexical-util@1.0.7		X										X					
-lexical-write-float@1.0.6		X										X					
-lexical-write-integer@1.0.6		X										X					
-libbz2-rs-sys@0.2.2																	X
-libc@0.2.182		X										X					
-liblzma@0.4.6		X										X					
-liblzma-sys@0.4.5		X										X					
-libm@0.2.15												X					
-linux-raw-sys@0.12.1		X	X									X					
-litemap@0.8.0														X			
-lock_api@0.4.14		X										X					
-log@0.4.29		X										X					
-lz4_flex@0.11.6												X					
-lz4_flex@0.13.0												X					
-lzokay-native@0.1.0												X					
-md-5@0.10.6		X										X					
-memchr@2.8.0												X			X		
-mime@0.3.17		X										X					
-miniz_oxide@0.8.9		X										X				X	
-mio@1.0.4												X					
-native-tls@0.2.18		X										X					
-num@0.4.3		X										X					
-num-bigint@0.4.6		X										X					
-num-complex@0.4.6		X										X					
-num-integer@0.1.46		X										X					
-num-iter@0.1.45		X										X					
-num-rational@0.4.2		X										X					
-num-traits@0.2.19		X										X					
-object@0.37.3		X										X					
-object_store@0.13.2		X										X					
-once_cell@1.21.3		X										X					
-opendal@0.55.0		X															
-openssl@0.10.76		X															
-openssl-macros@0.1.1		X										X					
-openssl-probe@0.2.1		X										X					
-openssl-sys@0.9.112												X					
-orc-rust@0.8.0		X															
-ordered-float@2.10.1												X					
-paimon@0.1.0		X															
-paimon-datafusion@0.1.0		X															
-parking_lot@0.12.5		X										X					
-parking_lot_core@0.9.12		X										X					
-parquet@58.1.0		X															
-paste@1.0.15		X										X					
-percent-encoding@2.3.2		X										X					
-petgraph@0.8.3		X										X					
-phf@0.12.1												X					
-phf_shared@0.12.1												X					
-pin-project-lite@0.2.16		X										X					
-pin-utils@0.1.0		X										X					
-pkg-config@0.3.32		X										X					
-portable-atomic@1.13.1		X										X					
-portable-atomic-util@0.2.6		X										X					
-potential_utf@0.1.2														X			
-ppv-lite86@0.2.21		X										X					
-pretty_assertions@1.4.1		X										X					
-proc-macro2@1.0.95		X										X					
-prost@0.13.5		X															
-prost-derive@0.13.5		X															
-psm@0.1.30		X										X					
-quick-xml@0.38.4												X					
-quote@1.0.44		X										X					
-r-efi@5.3.0		X								X		X					
-rand@0.10.0		X										X					
-rand@0.8.5		X										X					
-rand@0.9.2		X										X					
-rand_chacha@0.3.1		X										X					
-rand_chacha@0.9.0		X										X					
-rand_core@0.10.0		X										X					
-rand_core@0.6.4		X										X					
-rand_core@0.9.3		X										X					
-recursive@0.1.1												X					
-recursive-proc-macro-impl@0.1.1												X					
-redox_syscall@0.5.18												X					
-regex@1.12.3		X										X					
-regex-automata@0.4.14		X										X					
-regex-syntax@0.8.10		X										X					
-reqsign@0.16.5		X															
-reqwest@0.12.28		X										X					
-ring@0.17.14		X							X								
-roaring@0.11.3		X										X					
-rust_decimal@1.41.0												X					
-rustc_version@0.4.1		X										X					
-rustix@1.1.4		X	X									X					
-rustls@0.23.29		X							X			X					
-rustls-pki-types@1.12.0		X										X					
-rustls-webpki@0.103.4									X								
-rustversion@1.0.21		X										X					
-ryu@1.0.20		X				X											
-same-file@1.0.6												X			X		
-schannel@0.1.29												X					
-scopeguard@1.2.0		X										X					
-security-framework@3.6.0		X										X					
-security-framework-sys@2.17.0		X										X					
-semver@1.0.27		X										X					
-seq-macro@0.3.6		X										X					
-serde@1.0.228		X										X					
-serde-transcode@1.1.1		X										X					
-serde_avro_fast@2.0.2											X						
-serde_bytes@0.11.19		X										X					
-serde_core@1.0.228		X										X					
-serde_derive@1.0.228		X										X					
-serde_json@1.0.149		X										X					
-serde_repr@0.1.20		X										X					
-serde_serializer_quick_unsupported@1.0.0											X						
-serde_urlencoded@0.7.1		X										X					
-serde_with@3.14.0		X										X					
-serde_with_macros@3.14.0		X										X					
-sha1@0.10.6		X										X					
-sha2@0.10.9		X										X					
-shlex@1.3.0		X										X					
-simd-adler32@0.3.8												X					
-simdutf8@0.1.5		X										X					
-siphasher@1.0.2		X										X					
-slab@0.4.10												X					
-smallvec@1.15.1		X										X					
-snafu@0.8.9		X										X					
-snafu@0.9.0		X										X					
-snafu-derive@0.8.9		X										X					
-snafu-derive@0.9.0		X										X					
-snap@1.1.1					X												
-socket2@0.5.10		X										X					
-socket2@0.6.2		X										X					
-sqlparser@0.61.0		X															
-sqlparser_derive@0.5.0		X															
-stable_deref_trait@1.2.0		X										X					
-stacker@0.1.23		X										X					
-strsim@0.11.1												X					
-subtle@2.6.1					X												
-syn@2.0.117		X										X					
-sync_wrapper@1.0.2		X															
-synstructure@0.13.2												X					
-system-configuration@0.6.1		X										X					
-system-configuration-sys@0.6.0		X										X					
-tempfile@3.26.0		X										X					
-thiserror@1.0.69		X										X					
-thiserror@2.0.18		X										X					
-thiserror-impl@1.0.69		X										X					
-thiserror-impl@2.0.18		X										X					
-thrift@0.17.0		X															
-tiny-keccak@2.0.2							X										
-tinystr@0.8.1														X			
-tokio@1.49.0												X					
-tokio-macros@2.6.0												X					
-tokio-native-tls@0.3.1												X					
-tokio-rustls@0.26.2		X										X					
-tokio-stream@0.1.18												X					
-tokio-util@0.7.18												X					
-tower@0.5.2												X					
-tower-http@0.6.8												X					
-tower-layer@0.3.3												X					
-tower-service@0.3.3												X					
-tracing@0.1.41												X					
-tracing-attributes@0.1.31												X					
-tracing-core@0.1.36												X					
-try-lock@0.2.5												X					
-twox-hash@2.1.2												X					
-typed-builder@0.19.1		X										X					
-typed-builder-macro@0.19.1		X										X					
-typenum@1.18.0		X										X					
-unicode-ident@1.0.18		X										X		X			
-unicode-segmentation@1.13.2		X										X					
-unicode-width@0.2.2		X										X					
-untrusted@0.9.0									X								
-url@2.5.8		X										X					
-urlencoding@2.1.3												X					
-utf8_iter@1.0.4		X										X					
-uuid@1.21.0		X										X					
-vcpkg@0.2.15		X										X					
-version_check@0.9.5		X										X					
-walkdir@2.5.0												X			X		
-want@0.3.1												X					
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X					
-wasi@0.14.2+wasi-0.2.4		X	X									X					
-wasip2@1.0.2+wasi-0.2.9		X	X									X					
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X					
-wasm-bindgen@0.2.100		X										X					
-wasm-bindgen-backend@0.2.100		X										X					
-wasm-bindgen-futures@0.4.50		X										X					
-wasm-bindgen-macro@0.2.100		X										X					
-wasm-bindgen-macro-support@0.2.100		X										X					
-wasm-bindgen-shared@0.2.100		X										X					
-wasm-streams@0.4.2		X										X					
-web-sys@0.3.77		X										X					
-web-time@1.1.0		X										X					
-webpki-roots@1.0.2								X									
-winapi-util@0.1.11												X			X		
-windows-core@0.61.2		X										X					
-windows-implement@0.60.0		X										X					
-windows-interface@0.59.1		X										X					
-windows-link@0.1.3		X										X					
-windows-link@0.2.1		X										X					
-windows-registry@0.5.3		X										X					
-windows-result@0.3.4		X										X					
-windows-strings@0.4.2		X										X					
-windows-sys@0.52.0		X										X					
-windows-sys@0.59.0		X										X					
-windows-sys@0.60.2		X										X					
-windows-sys@0.61.2		X										X					
-windows-targets@0.52.6		X										X					
-windows-targets@0.53.5		X										X					
-windows_aarch64_gnullvm@0.52.6		X										X					
-windows_aarch64_gnullvm@0.53.1		X										X					
-windows_aarch64_msvc@0.52.6		X										X					
-windows_aarch64_msvc@0.53.1		X										X					
-windows_i686_gnu@0.52.6		X										X					
-windows_i686_gnu@0.53.1		X										X					
-windows_i686_gnullvm@0.52.6		X										X					
-windows_i686_gnullvm@0.53.1		X										X					
-windows_i686_msvc@0.52.6		X										X					
-windows_i686_msvc@0.53.1		X										X					
-windows_x86_64_gnu@0.52.6		X										X					
-windows_x86_64_gnu@0.53.1		X										X					
-windows_x86_64_gnullvm@0.52.6		X										X					
-windows_x86_64_gnullvm@0.53.1		X										X					
-windows_x86_64_msvc@0.52.6		X										X					
-windows_x86_64_msvc@0.53.1		X										X					
-wit-bindgen@0.51.0		X	X									X					
-wit-bindgen-rt@0.39.0		X	X									X					
-writeable@0.6.1														X			
-yansi@1.0.1		X										X					
-yoke@0.8.0														X			
-yoke-derive@0.8.0														X			
-zerocopy@0.8.26		X		X								X					
-zerocopy-derive@0.8.26		X		X								X					
-zerofrom@0.1.6														X			
-zerofrom-derive@0.1.6														X			
-zeroize@1.8.1		X										X					
-zerotrie@0.2.2														X			
-zerovec@0.11.2														X			
-zerovec-derive@0.11.1														X			
-zlib-rs@0.6.3																X	
-zmij@1.0.21												X					
-zstd@0.13.3												X					
-zstd-safe@7.2.4		X										X					
-zstd-sys@2.0.16+zstd.1.5.7		X										X					
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
+adler2@2.0.1	X	X									X					
+ahash@0.8.12		X									X					
+aho-corasick@1.1.4											X			X		
+alloc-no-stdlib@2.0.4					X											
+alloc-stdlib@0.2.2					X											
+allocator-api2@0.2.21		X									X					
+android_system_properties@0.1.5		X									X					
+anyhow@1.0.102		X									X					
+apache-avro@0.21.0		X														
+ar_archive_writer@0.5.1			X													
+arrayref@0.3.9				X												
+arrayvec@0.7.6		X									X					
+arrow@58.1.0		X														
+arrow-arith@58.1.0		X														
+arrow-array@58.1.0		X														
+arrow-buffer@58.1.0		X														
+arrow-cast@58.1.0		X														
+arrow-csv@58.1.0		X														
+arrow-data@58.1.0		X														
+arrow-ipc@58.1.0		X														
+arrow-json@58.1.0		X														
+arrow-ord@58.1.0		X														
+arrow-row@58.1.0		X														
+arrow-schema@58.1.0		X														
+arrow-select@58.1.0		X														
+arrow-string@58.1.0		X														
+async-compression@0.4.41		X									X					
+async-stream@0.3.6											X					
+async-stream-impl@0.3.6											X					
+async-trait@0.1.89		X									X					
+atoi@2.0.0											X					
+atomic-waker@1.1.2		X									X					
+autocfg@1.5.0		X									X					
+backon@1.6.0		X														
+base64@0.22.1		X									X					
+bigdecimal@0.4.10		X									X					
+bitflags@2.9.1		X									X					
+blake2@0.10.6		X									X					
+blake3@1.8.3		X	X				X									
+block-buffer@0.10.4		X									X					
+bon@3.9.1		X									X					
+bon-macros@3.9.1		X									X					
+brotli@8.0.2					X						X					
+brotli-decompressor@5.0.0					X						X					
+bumpalo@3.19.0		X									X					
+bytemuck@1.25.0		X									X				X	
+byteorder@1.5.0											X			X		
+bytes@1.11.1											X					
+bzip2@0.6.1		X									X					
+cc@1.2.56		X									X					
+cfg-if@1.0.1		X									X					
+chrono@0.4.44		X									X					
+chrono-tz@0.10.4		X									X					
+comfy-table@7.2.2											X					
+compression-codecs@0.4.37		X									X					
+compression-core@0.4.31		X									X					
+const-oid@0.9.6		X									X					
+const-random@0.1.18		X									X					
+const-random-macro@0.1.16		X									X					
+constant_time_eq@0.4.2		X					X					X				
+core-foundation@0.10.1		X									X					
+core-foundation@0.9.4		X									X					
+core-foundation-sys@0.8.7		X									X					
+cpufeatures@0.2.17		X									X					
+crc32fast@1.5.0		X									X					
+crossbeam-utils@0.8.21		X									X					
+crunchy@0.2.4											X					
+crypto-common@0.1.6		X									X					
+csv@1.4.0											X			X		
+csv-core@0.1.13											X			X		
+darling@0.20.11											X					
+darling_core@0.20.11											X					
+darling_macro@0.20.11											X					
+dashmap@6.1.0											X					
+datafusion@53.0.0		X														
+datafusion-catalog@53.0.0		X														
+datafusion-catalog-listing@53.0.0		X														
+datafusion-common@53.0.0		X														
+datafusion-common-runtime@53.0.0		X														
+datafusion-datasource@53.0.0		X														
+datafusion-datasource-arrow@53.0.0		X														
+datafusion-datasource-csv@53.0.0		X														
+datafusion-datasource-json@53.0.0		X														
+datafusion-datasource-parquet@53.0.0		X														
+datafusion-doc@53.0.0		X														
+datafusion-execution@53.0.0		X														
+datafusion-expr@53.0.0		X														
+datafusion-expr-common@53.0.0		X														
+datafusion-functions@53.0.0		X														
+datafusion-functions-aggregate@53.0.0		X														
+datafusion-functions-aggregate-common@53.0.0		X														
+datafusion-functions-nested@53.0.0		X														
+datafusion-functions-table@53.0.0		X														
+datafusion-functions-window@53.0.0		X														
+datafusion-functions-window-common@53.0.0		X														
+datafusion-macros@53.0.0		X														
+datafusion-optimizer@53.0.0		X														
+datafusion-physical-expr@53.0.0		X														
+datafusion-physical-expr-adapter@53.0.0		X														
+datafusion-physical-expr-common@53.0.0		X														
+datafusion-physical-optimizer@53.0.0		X														
+datafusion-physical-plan@53.0.0		X														
+datafusion-pruning@53.0.0		X														
+datafusion-session@53.0.0		X														
+datafusion-sql@53.0.0		X														
+diff@0.1.13		X									X					
+digest@0.10.7		X									X					
+displaydoc@0.2.5		X									X					
+either@1.15.0		X									X					
+encoding_rs@0.8.35		X			X						X					
+equivalent@1.0.2		X									X					
+errno@0.3.14		X									X					
+fallible-streaming-iterator@0.1.9		X									X					
+fastrand@2.3.0		X									X					
+find-msvc-tools@0.1.9		X									X					
+fixedbitset@0.5.7		X									X					
+flatbuffers@25.12.19		X														
+flate2@1.1.9		X									X					
+fnv@1.0.7		X									X					
+foldhash@0.1.5															X	
+foldhash@0.2.0															X	
+foreign-types@0.3.2		X									X					
+foreign-types-shared@0.1.1		X									X					
+form_urlencoded@1.2.2		X									X					
+futures@0.3.31		X									X					
+futures-channel@0.3.31		X									X					
+futures-core@0.3.31		X									X					
+futures-executor@0.3.31		X									X					
+futures-io@0.3.31		X									X					
+futures-macro@0.3.31		X									X					
+futures-sink@0.3.31		X									X					
+futures-task@0.3.31		X									X					
+futures-util@0.3.31		X									X					
+generic-array@0.14.7											X					
+getrandom@0.2.16		X									X					
+getrandom@0.3.3		X									X					
+getrandom@0.4.1		X									X					
+glob@0.3.3		X									X					
+gloo-timers@0.3.0		X									X					
+h2@0.4.13											X					
+half@2.7.1		X									X					
+hashbrown@0.14.5		X									X					
+hashbrown@0.15.4		X									X					
+hashbrown@0.16.1		X									X					
+heck@0.5.0		X									X					
+hex@0.4.3		X									X					
+hmac@0.12.1		X									X					
+home@0.5.12		X									X					
+http@1.3.1		X									X					
+http-body@1.0.1											X					
+http-body-util@0.1.3											X					
+httparse@1.10.1		X									X					
+httpdate@1.0.3		X									X					
+humantime@2.3.0		X									X					
+hyper@1.6.0											X					
+hyper-rustls@0.27.7		X							X		X					
+hyper-tls@0.6.0		X									X					
+hyper-util@0.1.15											X					
+iana-time-zone@0.1.63		X									X					
+iana-time-zone-haiku@0.1.2		X									X					
+icu_collections@2.0.0													X			
+icu_locale_core@2.0.0													X			
+icu_normalizer@2.0.0													X			
+icu_normalizer_data@2.0.0													X			
+icu_properties@2.0.1													X			
+icu_properties_data@2.0.1													X			
+icu_provider@2.0.0													X			
+ident_case@1.0.1		X									X					
+idna@1.1.0		X									X					
+idna_adapter@1.2.1		X									X					
+indexmap@2.13.0		X									X					
+integer-encoding@3.0.4											X					
+ipnet@2.11.0		X									X					
+iri-string@0.7.8		X									X					
+itertools@0.14.0		X									X					
+itoa@1.0.15		X									X					
+jiff@0.2.23											X			X		
+jiff-tzdb@0.1.6											X			X		
+jiff-tzdb-platform@0.1.3											X			X		
+jobserver@0.1.34		X									X					
+js-sys@0.3.95		X									X					
+lexical-core@1.0.6		X									X					
+lexical-parse-float@1.0.6		X									X					
+lexical-parse-integer@1.0.6		X									X					
+lexical-util@1.0.7		X									X					
+lexical-write-float@1.0.6		X									X					
+lexical-write-integer@1.0.6		X									X					
+libbz2-rs-sys@0.2.2																X
+libc@0.2.182		X									X					
+liblzma@0.4.6		X									X					
+liblzma-sys@0.4.5		X									X					
+libm@0.2.15											X					
+linux-raw-sys@0.12.1		X	X								X					
+litemap@0.8.0													X			
+lock_api@0.4.14		X									X					
+log@0.4.29		X									X					
+lz4_flex@0.11.6											X					
+lz4_flex@0.13.0											X					
+lzokay-native@0.1.0											X					
+md-5@0.10.6		X									X					
+memchr@2.8.0											X			X		
+mime@0.3.17		X									X					
+miniz_oxide@0.8.9		X									X				X	
+mio@1.0.4											X					
+native-tls@0.2.18		X									X					
+num@0.4.3		X									X					
+num-bigint@0.4.6		X									X					
+num-complex@0.4.6		X									X					
+num-integer@0.1.46		X									X					
+num-iter@0.1.45		X									X					
+num-rational@0.4.2		X									X					
+num-traits@0.2.19		X									X					
+object@0.37.3		X									X					
+object_store@0.13.2		X									X					
+once_cell@1.21.3		X									X					
+opendal@0.55.0		X														
+openssl@0.10.77		X														
+openssl-macros@0.1.1		X									X					
+openssl-probe@0.2.1		X									X					
+openssl-sys@0.9.113											X					
+orc-rust@0.8.0		X														
+ordered-float@2.10.1											X					
+paimon@0.1.0		X														
+paimon-datafusion@0.1.0		X														
+parking_lot@0.12.5		X									X					
+parking_lot_core@0.9.12		X									X					
+parquet@58.1.0		X														
+paste@1.0.15		X									X					
+percent-encoding@2.3.2		X									X					
+petgraph@0.8.3		X									X					
+phf@0.12.1											X					
+phf_shared@0.12.1											X					
+pin-project-lite@0.2.16		X									X					
+pin-utils@0.1.0		X									X					
+pkg-config@0.3.32		X									X					
+portable-atomic@1.13.1		X									X					
+portable-atomic-util@0.2.6		X									X					
+potential_utf@0.1.2													X			
+ppv-lite86@0.2.21		X									X					
+pretty_assertions@1.4.1		X									X					
+prettyplease@0.2.37		X									X					
+proc-macro2@1.0.95		X									X					
+prost@0.13.5		X														
+prost-derive@0.13.5		X														
+psm@0.1.30		X									X					
+quad-rand@0.2.3											X					
+quick-xml@0.38.4											X					
+quote@1.0.44		X									X					
+r-efi@5.3.0		X								X	X					
+rand@0.8.5		X									X					
+rand@0.9.2		X									X					
+rand_chacha@0.3.1		X									X					
+rand_chacha@0.9.0		X									X					
+rand_core@0.6.4		X									X					
+rand_core@0.9.3		X									X					
+recursive@0.1.1											X					
+recursive-proc-macro-impl@0.1.1											X					
+redox_syscall@0.5.18											X					
+regex@1.12.3		X									X					
+regex-automata@0.4.14		X									X					
+regex-lite@0.1.9		X									X					
+regex-syntax@0.8.10		X									X					
+reqsign@0.16.5		X														
+reqwest@0.12.28		X									X					
+ring@0.17.14		X							X							
+roaring@0.11.3		X									X					
+rustc_version@0.4.1		X									X					
+rustix@1.1.4		X	X								X					
+rustls@0.23.29		X							X		X					
+rustls-pki-types@1.12.0		X									X					
+rustls-webpki@0.103.4									X							
+rustversion@1.0.21		X									X					
+ryu@1.0.20		X				X										
+same-file@1.0.6											X			X		
+schannel@0.1.29											X					
+scopeguard@1.2.0		X									X					
+security-framework@3.6.0		X									X					
+security-framework-sys@2.17.0		X									X					
+semver@1.0.27		X									X					
+seq-macro@0.3.6		X									X					
+serde@1.0.228		X									X					
+serde_bytes@0.11.19		X									X					
+serde_core@1.0.228		X									X					
+serde_derive@1.0.228		X									X					
+serde_json@1.0.149		X									X					
+serde_repr@0.1.20		X									X					
+serde_urlencoded@0.7.1		X									X					
+serde_with@3.14.0		X									X					
+serde_with_macros@3.14.0		X									X					
+sha1@0.10.6		X									X					
+sha2@0.10.9		X									X					
+shlex@1.3.0		X									X					
+simd-adler32@0.3.8											X					
+simdutf8@0.1.5		X									X					
+siphasher@1.0.2		X									X					
+slab@0.4.10											X					
+smallvec@1.15.1		X									X					
+snafu@0.8.9		X									X					
+snafu@0.9.0		X									X					
+snafu-derive@0.8.9		X									X					
+snafu-derive@0.9.0		X									X					
+snap@1.1.1					X											
+socket2@0.5.10		X									X					
+socket2@0.6.2		X									X					
+sqlparser@0.61.0		X														
+sqlparser_derive@0.5.0		X														
+stable_deref_trait@1.2.0		X									X					
+stacker@0.1.23		X									X					
+strsim@0.11.1											X					
+strum@0.27.2											X					
+strum_macros@0.27.2											X					
+subtle@2.6.1					X											
+syn@2.0.117		X									X					
+sync_wrapper@1.0.2		X														
+synstructure@0.13.2											X					
+system-configuration@0.6.1		X									X					
+system-configuration-sys@0.6.0		X									X					
+tempfile@3.26.0		X									X					
+thiserror@1.0.69		X									X					
+thiserror@2.0.18		X									X					
+thiserror-impl@1.0.69		X									X					
+thiserror-impl@2.0.18		X									X					
+thrift@0.17.0		X														
+tiny-keccak@2.0.2							X									
+tinystr@0.8.1													X			
+tokio@1.49.0											X					
+tokio-macros@2.6.0											X					
+tokio-native-tls@0.3.1											X					
+tokio-rustls@0.26.2		X									X					
+tokio-stream@0.1.18											X					
+tokio-util@0.7.18											X					
+tower@0.5.2											X					
+tower-http@0.6.8											X					
+tower-layer@0.3.3											X					
+tower-service@0.3.3											X					
+tracing@0.1.41											X					
+tracing-attributes@0.1.31											X					
+tracing-core@0.1.36											X					
+try-lock@0.2.5											X					
+twox-hash@2.1.2											X					
+typed-builder@0.19.1		X									X					
+typed-builder-macro@0.19.1		X									X					
+typenum@1.18.0		X									X					
+unicode-ident@1.0.18		X									X		X			
+unicode-segmentation@1.13.2		X									X					
+unicode-width@0.2.2		X									X					
+untrusted@0.9.0									X							
+url@2.5.8		X									X					
+urlencoding@2.1.3											X					
+utf8_iter@1.0.4		X									X					
+uuid@1.21.0		X									X					
+vcpkg@0.2.15		X									X					
+version_check@0.9.5		X									X					
+walkdir@2.5.0											X			X		
+want@0.3.1											X					
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X					
+wasi@0.14.2+wasi-0.2.4		X	X								X					
+wasip2@1.0.2+wasi-0.2.9		X	X								X					
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X					
+wasm-bindgen@0.2.118		X									X					
+wasm-bindgen-futures@0.4.68		X									X					
+wasm-bindgen-macro@0.2.118		X									X					
+wasm-bindgen-macro-support@0.2.118		X									X					
+wasm-bindgen-shared@0.2.118		X									X					
+wasm-streams@0.4.2		X									X					
+web-sys@0.3.95		X									X					
+web-time@1.1.0		X									X					
+webpki-roots@1.0.2								X								
+winapi-util@0.1.11											X			X		
+windows-core@0.61.2		X									X					
+windows-implement@0.60.0		X									X					
+windows-interface@0.59.1		X									X					
+windows-link@0.1.3		X									X					
+windows-link@0.2.1		X									X					
+windows-registry@0.5.3		X									X					
+windows-result@0.3.4		X									X					
+windows-strings@0.4.2		X									X					
+windows-sys@0.52.0		X									X					
+windows-sys@0.59.0		X									X					
+windows-sys@0.60.2		X									X					
+windows-sys@0.61.2		X									X					
+windows-targets@0.52.6		X									X					
+windows-targets@0.53.5		X									X					
+windows_aarch64_gnullvm@0.52.6		X									X					
+windows_aarch64_gnullvm@0.53.1		X									X					
+windows_aarch64_msvc@0.52.6		X									X					
+windows_aarch64_msvc@0.53.1		X									X					
+windows_i686_gnu@0.52.6		X									X					
+windows_i686_gnu@0.53.1		X									X					
+windows_i686_gnullvm@0.52.6		X									X					
+windows_i686_gnullvm@0.53.1		X									X					
+windows_i686_msvc@0.52.6		X									X					
+windows_i686_msvc@0.53.1		X									X					
+windows_x86_64_gnu@0.52.6		X									X					
+windows_x86_64_gnu@0.53.1		X									X					
+windows_x86_64_gnullvm@0.52.6		X									X					
+windows_x86_64_gnullvm@0.53.1		X									X					
+windows_x86_64_msvc@0.52.6		X									X					
+windows_x86_64_msvc@0.53.1		X									X					
+wit-bindgen@0.51.0		X	X								X					
+wit-bindgen-rt@0.39.0		X	X								X					
+writeable@0.6.1													X			
+yansi@1.0.1		X									X					
+yoke@0.8.0													X			
+yoke-derive@0.8.0													X			
+zerocopy@0.8.26		X		X							X					
+zerocopy-derive@0.8.26		X		X							X					
+zerofrom@0.1.6													X			
+zerofrom-derive@0.1.6													X			
+zeroize@1.8.1		X									X					
+zerotrie@0.2.2													X			
+zerovec@0.11.2													X			
+zerovec-derive@0.11.1													X			
+zlib-rs@0.6.3															X	
+zmij@1.0.21											X					
+zstd@0.13.3											X					
+zstd-safe@7.2.4		X									X					
+zstd-sys@2.0.16+zstd.1.5.7		X									X					

--- a/crates/paimon/Cargo.toml
+++ b/crates/paimon/Cargo.toml
@@ -55,7 +55,7 @@ snafu = "0.9.0"
 typed-builder = "^0.19"
 opendal = { version = "0.55", features = ["services-fs"] }
 pretty_assertions = "1"
-serde_avro_fast = { version = "2.0.2", features = ["snappy", "zstandard"] }
+apache-avro = { version = "0.21", features = ["snappy", "zstandard"] }
 indexmap = "2.5.0"
 roaring = "0.11"
 crc32fast = "1"

--- a/crates/paimon/DEPENDENCIES.rust.tsv
+++ b/crates/paimon/DEPENDENCIES.rust.tsv
@@ -1,371 +1,369 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X										X			
-aes@0.8.4		X										X			
-ahash@0.8.12		X										X			
-aho-corasick@1.1.4												X		X	
-alloc-no-stdlib@2.0.4					X										
-alloc-stdlib@0.2.2					X										
-android_system_properties@0.1.5		X										X			
-anyhow@1.0.102		X										X			
-arrayvec@0.7.6		X										X			
-arrow@58.1.0		X													
-arrow-arith@58.1.0		X													
-arrow-array@58.1.0		X													
-arrow-buffer@58.1.0		X													
-arrow-cast@58.1.0		X													
-arrow-csv@58.1.0		X													
-arrow-data@58.1.0		X													
-arrow-ipc@58.1.0		X													
-arrow-json@58.1.0		X													
-arrow-ord@58.1.0		X													
-arrow-row@58.1.0		X													
-arrow-schema@58.1.0		X													
-arrow-select@58.1.0		X													
-arrow-string@58.1.0		X													
-async-stream@0.3.6												X			
-async-stream-impl@0.3.6												X			
-async-trait@0.1.89		X										X			
-atoi@2.0.0												X			
-atomic-waker@1.1.2		X										X			
-autocfg@1.5.0		X										X			
-backon@1.6.0		X													
-base64@0.22.1		X										X			
-bitflags@2.9.1		X										X			
-block-buffer@0.10.4		X										X			
-block-padding@0.3.3		X										X			
-brotli@8.0.2					X							X			
-brotli-decompressor@5.0.0					X							X			
-bumpalo@3.19.0		X										X			
-bytemuck@1.25.0		X										X			X
-byteorder@1.5.0												X		X	
-bytes@1.11.1												X			
-cbc@0.1.2		X										X			
-cc@1.2.56		X										X			
-cfg-if@1.0.1		X										X			
-chacha20@0.10.0		X										X			
-chrono@0.4.44		X										X			
-chrono-tz@0.10.4		X										X			
-cipher@0.4.4		X										X			
-comfy-table@7.2.2												X			
-const-oid@0.9.6		X										X			
-const-random@0.1.18		X										X			
-const-random-macro@0.1.16		X										X			
-core-foundation@0.10.1		X										X			
-core-foundation@0.9.4		X										X			
-core-foundation-sys@0.8.7		X										X			
-cpufeatures@0.2.17		X										X			
-cpufeatures@0.3.0		X										X			
-crc@3.4.0		X										X			
-crc-catalog@2.4.0		X										X			
-crc32c@0.6.8		X										X			
-crc32fast@1.5.0		X										X			
-crunchy@0.2.4												X			
-crypto-common@0.1.6		X										X			
-csv@1.4.0												X		X	
-csv-core@0.1.13												X		X	
-ctr@0.9.2		X										X			
-darling@0.20.11												X			
-darling_core@0.20.11												X			
-darling_macro@0.20.11												X			
-des@0.8.1		X										X			
-diff@0.1.13		X										X			
-digest@0.10.7		X										X			
-displaydoc@0.2.5		X										X			
-dns-lookup@3.0.1		X										X			
-either@1.15.0		X										X			
-encoding_rs@0.8.35		X			X							X			
-equivalent@1.0.2		X										X			
-errno@0.3.14		X										X			
-fallible-streaming-iterator@0.1.9		X										X			
-fastrand@2.3.0		X										X			
-find-msvc-tools@0.1.9		X										X			
-flatbuffers@25.12.19		X													
-flate2@1.1.9		X										X			
-fnv@1.0.7		X										X			
-foreign-types@0.3.2		X										X			
-foreign-types-shared@0.1.1		X										X			
-form_urlencoded@1.2.2		X										X			
-futures@0.3.31		X										X			
-futures-channel@0.3.31		X										X			
-futures-core@0.3.31		X										X			
-futures-executor@0.3.31		X										X			
-futures-io@0.3.31		X										X			
-futures-macro@0.3.31		X										X			
-futures-sink@0.3.31		X										X			
-futures-task@0.3.31		X										X			
-futures-util@0.3.31		X										X			
-g2gen@1.2.2		X										X			
-g2p@1.2.2		X										X			
-g2poly@1.2.2		X										X			
-generic-array@0.14.7												X			
-getrandom@0.2.16		X										X			
-getrandom@0.3.3		X										X			
-getrandom@0.4.1		X										X			
-gloo-timers@0.3.0		X										X			
-h2@0.4.13												X			
-half@2.7.1		X										X			
-hashbrown@0.16.1		X										X			
-hdfs-native@0.13.5		X													
-heck@0.5.0		X										X			
-hex@0.4.3		X										X			
-hmac@0.12.1		X										X			
-home@0.5.12		X										X			
-http@1.3.1		X										X			
-http-body@1.0.1												X			
-http-body-util@0.1.3												X			
-httparse@1.10.1		X										X			
-httpdate@1.0.3		X										X			
-hyper@1.6.0												X			
-hyper-rustls@0.27.7		X							X			X			
-hyper-tls@0.6.0		X										X			
-hyper-util@0.1.15												X			
-iana-time-zone@0.1.63		X										X			
-iana-time-zone-haiku@0.1.2		X										X			
-icu_collections@2.0.0													X		
-icu_locale_core@2.0.0													X		
-icu_normalizer@2.0.0													X		
-icu_normalizer_data@2.0.0													X		
-icu_properties@2.0.1													X		
-icu_properties_data@2.0.1													X		
-icu_provider@2.0.0													X		
-ident_case@1.0.1		X										X			
-idna@1.1.0		X										X			
-idna_adapter@1.2.1		X										X			
-indexmap@2.13.0		X										X			
-inout@0.1.4		X										X			
-integer-encoding@3.0.4												X			
-integer-encoding@4.1.0												X			
-ipnet@2.11.0		X										X			
-iri-string@0.7.8		X										X			
-itertools@0.14.0		X										X			
-itoa@1.0.15		X										X			
-jiff@0.2.23												X		X	
-jiff-tzdb@0.1.6												X		X	
-jiff-tzdb-platform@0.1.3												X		X	
-jobserver@0.1.34		X										X			
-js-sys@0.3.77		X										X			
-lexical-core@1.0.6		X										X			
-lexical-parse-float@1.0.6		X										X			
-lexical-parse-integer@1.0.6		X										X			
-lexical-util@1.0.7		X										X			
-lexical-write-float@1.0.6		X										X			
-lexical-write-integer@1.0.6		X										X			
-libc@0.2.182		X										X			
-libloading@0.9.0									X						
-libm@0.2.15												X			
-libredox@0.1.16												X			
-linux-raw-sys@0.12.1		X	X									X			
-litemap@0.8.0													X		
-log@0.4.29		X										X			
-lz4_flex@0.11.6												X			
-lz4_flex@0.13.0												X			
-lzokay-native@0.1.0												X			
-md-5@0.10.6		X										X			
-memchr@2.8.0												X		X	
-mime@0.3.17		X										X			
-miniz_oxide@0.8.9		X										X			X
-mio@1.0.4												X			
-native-tls@0.2.18		X										X			
-num@0.4.3		X										X			
-num-bigint@0.4.6		X										X			
-num-complex@0.4.6		X										X			
-num-integer@0.1.46		X										X			
-num-iter@0.1.45		X										X			
-num-rational@0.4.2		X										X			
-num-traits@0.2.19		X										X			
-once_cell@1.21.3		X										X			
-opendal@0.55.0		X													
-openssl@0.10.76		X													
-openssl-macros@0.1.1		X										X			
-openssl-probe@0.2.1		X										X			
-openssl-sys@0.9.112												X			
-orc-rust@0.8.0		X													
-ordered-float@2.10.1												X			
-paimon@0.1.0		X													
-parquet@58.1.0		X													
-paste@1.0.15		X										X			
-percent-encoding@2.3.2		X										X			
-phf@0.12.1												X			
-phf_shared@0.12.1												X			
-pin-project-lite@0.2.16		X										X			
-pin-utils@0.1.0		X										X			
-pkg-config@0.3.32		X										X			
-plain@0.2.3		X										X			
-portable-atomic@1.13.1		X										X			
-portable-atomic-util@0.2.6		X										X			
-potential_utf@0.1.2													X		
-ppv-lite86@0.2.21		X										X			
-pretty_assertions@1.4.1		X										X			
-proc-macro2@1.0.95		X										X			
-prost@0.13.5		X													
-prost@0.14.3		X													
-prost-derive@0.13.5		X													
-prost-derive@0.14.3		X													
-prost-types@0.14.3		X													
-quick-xml@0.37.5												X			
-quick-xml@0.38.4												X			
-quote@1.0.44		X										X			
-r-efi@5.3.0		X								X		X			
-rand@0.10.0		X										X			
-rand@0.8.5		X										X			
-rand@0.9.2		X										X			
-rand_chacha@0.3.1		X										X			
-rand_chacha@0.9.0		X										X			
-rand_core@0.10.0		X										X			
-rand_core@0.6.4		X										X			
-rand_core@0.9.3		X										X			
-regex@1.12.3		X										X			
-regex-automata@0.4.14		X										X			
-regex-syntax@0.8.10		X										X			
-reqsign@0.16.5		X													
-reqwest@0.12.28		X										X			
-ring@0.17.14		X							X						
-roaring@0.11.3		X										X			
-roxmltree@0.21.1		X										X			
-rust_decimal@1.41.0												X			
-rustc_version@0.4.1		X										X			
-rustix@1.1.4		X	X									X			
-rustls@0.23.29		X							X			X			
-rustls-pki-types@1.12.0		X										X			
-rustls-webpki@0.103.4									X						
-rustversion@1.0.21		X										X			
-ryu@1.0.20		X				X									
-schannel@0.1.29												X			
-security-framework@3.6.0		X										X			
-security-framework-sys@2.17.0		X										X			
-semver@1.0.27		X										X			
-seq-macro@0.3.6		X										X			
-serde@1.0.228		X										X			
-serde-transcode@1.1.1		X										X			
-serde_avro_fast@2.0.2											X				
-serde_bytes@0.11.19		X										X			
-serde_core@1.0.228		X										X			
-serde_derive@1.0.228		X										X			
-serde_json@1.0.149		X										X			
-serde_repr@0.1.20		X										X			
-serde_serializer_quick_unsupported@1.0.0											X				
-serde_urlencoded@0.7.1		X										X			
-serde_with@3.14.0		X										X			
-serde_with_macros@3.14.0		X										X			
-sha1@0.10.6		X										X			
-sha2@0.10.9		X										X			
-shlex@1.3.0		X										X			
-simd-adler32@0.3.8												X			
-simdutf8@0.1.5		X										X			
-siphasher@1.0.2		X										X			
-slab@0.4.10												X			
-smallvec@1.15.1		X										X			
-snafu@0.8.9		X										X			
-snafu@0.9.0		X										X			
-snafu-derive@0.8.9		X										X			
-snafu-derive@0.9.0		X										X			
-snap@1.1.1					X										
-socket2@0.5.10		X										X			
-socket2@0.6.2		X										X			
-stable_deref_trait@1.2.0		X										X			
-strsim@0.11.1												X			
-subtle@2.6.1					X										
-syn@2.0.117		X										X			
-sync_wrapper@1.0.2		X													
-synstructure@0.13.2												X			
-system-configuration@0.6.1		X										X			
-system-configuration-sys@0.6.0		X										X			
-tempfile@3.26.0		X										X			
-thiserror@1.0.69		X										X			
-thiserror@2.0.18		X										X			
-thiserror-impl@1.0.69		X										X			
-thiserror-impl@2.0.18		X										X			
-thrift@0.17.0		X													
-tiny-keccak@2.0.2							X								
-tinystr@0.8.1													X		
-tokio@1.49.0												X			
-tokio-macros@2.6.0												X			
-tokio-native-tls@0.3.1												X			
-tokio-rustls@0.26.2		X										X			
-tokio-util@0.7.18												X			
-tower@0.5.2												X			
-tower-http@0.6.8												X			
-tower-layer@0.3.3												X			
-tower-service@0.3.3												X			
-tracing@0.1.41												X			
-tracing-core@0.1.36												X			
-try-lock@0.2.5												X			
-twox-hash@2.1.2												X			
-typed-builder@0.19.1		X										X			
-typed-builder-macro@0.19.1		X										X			
-typenum@1.18.0		X										X			
-unicode-ident@1.0.18		X										X	X		
-unicode-segmentation@1.13.2		X										X			
-unicode-width@0.2.2		X										X			
-untrusted@0.9.0									X						
-url@2.5.8		X										X			
-urlencoding@2.1.3												X			
-utf8_iter@1.0.4		X										X			
-uuid@1.21.0		X										X			
-vcpkg@0.2.15		X										X			
-version_check@0.9.5		X										X			
-want@0.3.1												X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X			
-wasi@0.14.2+wasi-0.2.4		X	X									X			
-wasip2@1.0.2+wasi-0.2.9		X	X									X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X			
-wasite@0.1.0		X				X						X			
-wasm-bindgen@0.2.100		X										X			
-wasm-bindgen-backend@0.2.100		X										X			
-wasm-bindgen-futures@0.4.50		X										X			
-wasm-bindgen-macro@0.2.100		X										X			
-wasm-bindgen-macro-support@0.2.100		X										X			
-wasm-bindgen-shared@0.2.100		X										X			
-wasm-streams@0.4.2		X										X			
-web-sys@0.3.77		X										X			
-webpki-roots@1.0.2								X							
-whoami@1.6.1		X				X						X			
-windows-core@0.61.2		X										X			
-windows-implement@0.60.0		X										X			
-windows-interface@0.59.1		X										X			
-windows-link@0.1.3		X										X			
-windows-link@0.2.1		X										X			
-windows-registry@0.5.3		X										X			
-windows-result@0.3.4		X										X			
-windows-strings@0.4.2		X										X			
-windows-sys@0.52.0		X										X			
-windows-sys@0.59.0		X										X			
-windows-sys@0.60.2		X										X			
-windows-sys@0.61.2		X										X			
-windows-targets@0.52.6		X										X			
-windows-targets@0.53.5		X										X			
-windows_aarch64_gnullvm@0.52.6		X										X			
-windows_aarch64_gnullvm@0.53.1		X										X			
-windows_aarch64_msvc@0.52.6		X										X			
-windows_aarch64_msvc@0.53.1		X										X			
-windows_i686_gnu@0.52.6		X										X			
-windows_i686_gnu@0.53.1		X										X			
-windows_i686_gnullvm@0.52.6		X										X			
-windows_i686_gnullvm@0.53.1		X										X			
-windows_i686_msvc@0.52.6		X										X			
-windows_i686_msvc@0.53.1		X										X			
-windows_x86_64_gnu@0.52.6		X										X			
-windows_x86_64_gnu@0.53.1		X										X			
-windows_x86_64_gnullvm@0.52.6		X										X			
-windows_x86_64_gnullvm@0.53.1		X										X			
-windows_x86_64_msvc@0.52.6		X										X			
-windows_x86_64_msvc@0.53.1		X										X			
-wit-bindgen@0.51.0		X	X									X			
-wit-bindgen-rt@0.39.0		X	X									X			
-writeable@0.6.1													X		
-yansi@1.0.1		X										X			
-yoke@0.8.0													X		
-yoke-derive@0.8.0													X		
-zerocopy@0.8.26		X		X								X			
-zerocopy-derive@0.8.26		X		X								X			
-zerofrom@0.1.6													X		
-zerofrom-derive@0.1.6													X		
-zeroize@1.8.1		X										X			
-zerotrie@0.2.2													X		
-zerovec@0.11.2													X		
-zerovec-derive@0.11.1													X		
-zlib-rs@0.6.3															X
-zmij@1.0.21												X			
-zstd@0.13.3												X			
-zstd-safe@7.2.4		X										X			
-zstd-sys@2.0.16+zstd.1.5.7		X										X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X			
+aes@0.8.4		X									X			
+ahash@0.8.12		X									X			
+aho-corasick@1.1.4											X		X	
+alloc-no-stdlib@2.0.4					X									
+alloc-stdlib@0.2.2					X									
+android_system_properties@0.1.5		X									X			
+anyhow@1.0.102		X									X			
+apache-avro@0.21.0		X												
+arrow@58.1.0		X												
+arrow-arith@58.1.0		X												
+arrow-array@58.1.0		X												
+arrow-buffer@58.1.0		X												
+arrow-cast@58.1.0		X												
+arrow-csv@58.1.0		X												
+arrow-data@58.1.0		X												
+arrow-ipc@58.1.0		X												
+arrow-json@58.1.0		X												
+arrow-ord@58.1.0		X												
+arrow-row@58.1.0		X												
+arrow-schema@58.1.0		X												
+arrow-select@58.1.0		X												
+arrow-string@58.1.0		X												
+async-stream@0.3.6											X			
+async-stream-impl@0.3.6											X			
+async-trait@0.1.89		X									X			
+atoi@2.0.0											X			
+atomic-waker@1.1.2		X									X			
+autocfg@1.5.0		X									X			
+backon@1.6.0		X												
+base64@0.22.1		X									X			
+bigdecimal@0.4.10		X									X			
+bitflags@2.9.1		X									X			
+block-buffer@0.10.4		X									X			
+block-padding@0.3.3		X									X			
+bon@3.9.1		X									X			
+bon-macros@3.9.1		X									X			
+brotli@8.0.2					X						X			
+brotli-decompressor@5.0.0					X						X			
+bumpalo@3.19.0		X									X			
+bytemuck@1.25.0		X									X			X
+byteorder@1.5.0											X		X	
+bytes@1.11.1											X			
+cbc@0.1.2		X									X			
+cc@1.2.56		X									X			
+cfg-if@1.0.1		X									X			
+chrono@0.4.44		X									X			
+chrono-tz@0.10.4		X									X			
+cipher@0.4.4		X									X			
+comfy-table@7.2.2											X			
+const-oid@0.9.6		X									X			
+const-random@0.1.18		X									X			
+const-random-macro@0.1.16		X									X			
+core-foundation@0.10.1		X									X			
+core-foundation@0.9.4		X									X			
+core-foundation-sys@0.8.7		X									X			
+cpufeatures@0.2.17		X									X			
+crc@3.4.0		X									X			
+crc-catalog@2.4.0		X									X			
+crc32c@0.6.8		X									X			
+crc32fast@1.5.0		X									X			
+crunchy@0.2.4											X			
+crypto-common@0.1.6		X									X			
+csv@1.4.0											X		X	
+csv-core@0.1.13											X		X	
+ctr@0.9.2		X									X			
+darling@0.20.11											X			
+darling_core@0.20.11											X			
+darling_macro@0.20.11											X			
+des@0.8.1		X									X			
+diff@0.1.13		X									X			
+digest@0.10.7		X									X			
+displaydoc@0.2.5		X									X			
+dns-lookup@3.0.1		X									X			
+either@1.15.0		X									X			
+encoding_rs@0.8.35		X			X						X			
+equivalent@1.0.2		X									X			
+errno@0.3.14		X									X			
+fallible-streaming-iterator@0.1.9		X									X			
+fastrand@2.3.0		X									X			
+find-msvc-tools@0.1.9		X									X			
+flatbuffers@25.12.19		X												
+flate2@1.1.9		X									X			
+fnv@1.0.7		X									X			
+foreign-types@0.3.2		X									X			
+foreign-types-shared@0.1.1		X									X			
+form_urlencoded@1.2.2		X									X			
+futures@0.3.31		X									X			
+futures-channel@0.3.31		X									X			
+futures-core@0.3.31		X									X			
+futures-executor@0.3.31		X									X			
+futures-io@0.3.31		X									X			
+futures-macro@0.3.31		X									X			
+futures-sink@0.3.31		X									X			
+futures-task@0.3.31		X									X			
+futures-util@0.3.31		X									X			
+g2gen@1.2.2		X									X			
+g2p@1.2.2		X									X			
+g2poly@1.2.2		X									X			
+generic-array@0.14.7											X			
+getrandom@0.2.16		X									X			
+getrandom@0.3.3		X									X			
+getrandom@0.4.1		X									X			
+gloo-timers@0.3.0		X									X			
+h2@0.4.13											X			
+half@2.7.1		X									X			
+hashbrown@0.16.1		X									X			
+hdfs-native@0.13.5		X												
+heck@0.5.0		X									X			
+hex@0.4.3		X									X			
+hmac@0.12.1		X									X			
+home@0.5.12		X									X			
+http@1.3.1		X									X			
+http-body@1.0.1											X			
+http-body-util@0.1.3											X			
+httparse@1.10.1		X									X			
+httpdate@1.0.3		X									X			
+hyper@1.6.0											X			
+hyper-rustls@0.27.7		X							X		X			
+hyper-tls@0.6.0		X									X			
+hyper-util@0.1.15											X			
+iana-time-zone@0.1.63		X									X			
+iana-time-zone-haiku@0.1.2		X									X			
+icu_collections@2.0.0												X		
+icu_locale_core@2.0.0												X		
+icu_normalizer@2.0.0												X		
+icu_normalizer_data@2.0.0												X		
+icu_properties@2.0.1												X		
+icu_properties_data@2.0.1												X		
+icu_provider@2.0.0												X		
+ident_case@1.0.1		X									X			
+idna@1.1.0		X									X			
+idna_adapter@1.2.1		X									X			
+indexmap@2.13.0		X									X			
+inout@0.1.4		X									X			
+integer-encoding@3.0.4											X			
+ipnet@2.11.0		X									X			
+iri-string@0.7.8		X									X			
+itertools@0.14.0		X									X			
+itoa@1.0.15		X									X			
+jiff@0.2.23											X		X	
+jiff-tzdb@0.1.6											X		X	
+jiff-tzdb-platform@0.1.3											X		X	
+jobserver@0.1.34		X									X			
+js-sys@0.3.95		X									X			
+lexical-core@1.0.6		X									X			
+lexical-parse-float@1.0.6		X									X			
+lexical-parse-integer@1.0.6		X									X			
+lexical-util@1.0.7		X									X			
+lexical-write-float@1.0.6		X									X			
+lexical-write-integer@1.0.6		X									X			
+libc@0.2.182		X									X			
+libloading@0.9.0									X					
+libm@0.2.15											X			
+libredox@0.1.16											X			
+linux-raw-sys@0.12.1		X	X								X			
+litemap@0.8.0												X		
+log@0.4.29		X									X			
+lz4_flex@0.11.6											X			
+lz4_flex@0.13.0											X			
+lzokay-native@0.1.0											X			
+md-5@0.10.6		X									X			
+memchr@2.8.0											X		X	
+mime@0.3.17		X									X			
+miniz_oxide@0.8.9		X									X			X
+mio@1.0.4											X			
+native-tls@0.2.18		X									X			
+num@0.4.3		X									X			
+num-bigint@0.4.6		X									X			
+num-complex@0.4.6		X									X			
+num-integer@0.1.46		X									X			
+num-iter@0.1.45		X									X			
+num-rational@0.4.2		X									X			
+num-traits@0.2.19		X									X			
+once_cell@1.21.3		X									X			
+opendal@0.55.0		X												
+openssl@0.10.77		X												
+openssl-macros@0.1.1		X									X			
+openssl-probe@0.2.1		X									X			
+openssl-sys@0.9.113											X			
+orc-rust@0.8.0		X												
+ordered-float@2.10.1											X			
+paimon@0.1.0		X												
+parquet@58.1.0		X												
+paste@1.0.15		X									X			
+percent-encoding@2.3.2		X									X			
+phf@0.12.1											X			
+phf_shared@0.12.1											X			
+pin-project-lite@0.2.16		X									X			
+pin-utils@0.1.0		X									X			
+pkg-config@0.3.32		X									X			
+plain@0.2.3		X									X			
+portable-atomic@1.13.1		X									X			
+portable-atomic-util@0.2.6		X									X			
+potential_utf@0.1.2												X		
+ppv-lite86@0.2.21		X									X			
+pretty_assertions@1.4.1		X									X			
+prettyplease@0.2.37		X									X			
+proc-macro2@1.0.95		X									X			
+prost@0.13.5		X												
+prost@0.14.3		X												
+prost-derive@0.13.5		X												
+prost-derive@0.14.3		X												
+prost-types@0.14.3		X												
+quad-rand@0.2.3											X			
+quick-xml@0.37.5											X			
+quick-xml@0.38.4											X			
+quote@1.0.44		X									X			
+r-efi@5.3.0		X								X	X			
+rand@0.8.5		X									X			
+rand@0.9.2		X									X			
+rand_chacha@0.3.1		X									X			
+rand_chacha@0.9.0		X									X			
+rand_core@0.6.4		X									X			
+rand_core@0.9.3		X									X			
+regex@1.12.3		X									X			
+regex-automata@0.4.14		X									X			
+regex-lite@0.1.9		X									X			
+regex-syntax@0.8.10		X									X			
+reqsign@0.16.5		X												
+reqwest@0.12.28		X									X			
+ring@0.17.14		X							X					
+roaring@0.11.3		X									X			
+roxmltree@0.21.1		X									X			
+rustc_version@0.4.1		X									X			
+rustix@1.1.4		X	X								X			
+rustls@0.23.29		X							X		X			
+rustls-pki-types@1.12.0		X									X			
+rustls-webpki@0.103.4									X					
+rustversion@1.0.21		X									X			
+ryu@1.0.20		X				X								
+schannel@0.1.29											X			
+security-framework@3.6.0		X									X			
+security-framework-sys@2.17.0		X									X			
+semver@1.0.27		X									X			
+seq-macro@0.3.6		X									X			
+serde@1.0.228		X									X			
+serde_bytes@0.11.19		X									X			
+serde_core@1.0.228		X									X			
+serde_derive@1.0.228		X									X			
+serde_json@1.0.149		X									X			
+serde_repr@0.1.20		X									X			
+serde_urlencoded@0.7.1		X									X			
+serde_with@3.14.0		X									X			
+serde_with_macros@3.14.0		X									X			
+sha1@0.10.6		X									X			
+sha2@0.10.9		X									X			
+shlex@1.3.0		X									X			
+simd-adler32@0.3.8											X			
+simdutf8@0.1.5		X									X			
+siphasher@1.0.2		X									X			
+slab@0.4.10											X			
+smallvec@1.15.1		X									X			
+snafu@0.8.9		X									X			
+snafu@0.9.0		X									X			
+snafu-derive@0.8.9		X									X			
+snafu-derive@0.9.0		X									X			
+snap@1.1.1					X									
+socket2@0.5.10		X									X			
+socket2@0.6.2		X									X			
+stable_deref_trait@1.2.0		X									X			
+strsim@0.11.1											X			
+strum@0.27.2											X			
+strum_macros@0.27.2											X			
+subtle@2.6.1					X									
+syn@2.0.117		X									X			
+sync_wrapper@1.0.2		X												
+synstructure@0.13.2											X			
+system-configuration@0.6.1		X									X			
+system-configuration-sys@0.6.0		X									X			
+tempfile@3.26.0		X									X			
+thiserror@1.0.69		X									X			
+thiserror@2.0.18		X									X			
+thiserror-impl@1.0.69		X									X			
+thiserror-impl@2.0.18		X									X			
+thrift@0.17.0		X												
+tiny-keccak@2.0.2							X							
+tinystr@0.8.1												X		
+tokio@1.49.0											X			
+tokio-macros@2.6.0											X			
+tokio-native-tls@0.3.1											X			
+tokio-rustls@0.26.2		X									X			
+tokio-util@0.7.18											X			
+tower@0.5.2											X			
+tower-http@0.6.8											X			
+tower-layer@0.3.3											X			
+tower-service@0.3.3											X			
+tracing@0.1.41											X			
+tracing-core@0.1.36											X			
+try-lock@0.2.5											X			
+twox-hash@2.1.2											X			
+typed-builder@0.19.1		X									X			
+typed-builder-macro@0.19.1		X									X			
+typenum@1.18.0		X									X			
+unicode-ident@1.0.18		X									X	X		
+unicode-segmentation@1.13.2		X									X			
+unicode-width@0.2.2		X									X			
+untrusted@0.9.0									X					
+url@2.5.8		X									X			
+urlencoding@2.1.3											X			
+utf8_iter@1.0.4		X									X			
+uuid@1.21.0		X									X			
+vcpkg@0.2.15		X									X			
+version_check@0.9.5		X									X			
+want@0.3.1											X			
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
+wasi@0.14.2+wasi-0.2.4		X	X								X			
+wasip2@1.0.2+wasi-0.2.9		X	X								X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X			
+wasite@0.1.0		X				X					X			
+wasm-bindgen@0.2.118		X									X			
+wasm-bindgen-futures@0.4.68		X									X			
+wasm-bindgen-macro@0.2.118		X									X			
+wasm-bindgen-macro-support@0.2.118		X									X			
+wasm-bindgen-shared@0.2.118		X									X			
+wasm-streams@0.4.2		X									X			
+web-sys@0.3.95		X									X			
+webpki-roots@1.0.2								X						
+whoami@1.6.1		X				X					X			
+windows-core@0.61.2		X									X			
+windows-implement@0.60.0		X									X			
+windows-interface@0.59.1		X									X			
+windows-link@0.1.3		X									X			
+windows-link@0.2.1		X									X			
+windows-registry@0.5.3		X									X			
+windows-result@0.3.4		X									X			
+windows-strings@0.4.2		X									X			
+windows-sys@0.52.0		X									X			
+windows-sys@0.59.0		X									X			
+windows-sys@0.60.2		X									X			
+windows-sys@0.61.2		X									X			
+windows-targets@0.52.6		X									X			
+windows-targets@0.53.5		X									X			
+windows_aarch64_gnullvm@0.52.6		X									X			
+windows_aarch64_gnullvm@0.53.1		X									X			
+windows_aarch64_msvc@0.52.6		X									X			
+windows_aarch64_msvc@0.53.1		X									X			
+windows_i686_gnu@0.52.6		X									X			
+windows_i686_gnu@0.53.1		X									X			
+windows_i686_gnullvm@0.52.6		X									X			
+windows_i686_gnullvm@0.53.1		X									X			
+windows_i686_msvc@0.52.6		X									X			
+windows_i686_msvc@0.53.1		X									X			
+windows_x86_64_gnu@0.52.6		X									X			
+windows_x86_64_gnu@0.53.1		X									X			
+windows_x86_64_gnullvm@0.52.6		X									X			
+windows_x86_64_gnullvm@0.53.1		X									X			
+windows_x86_64_msvc@0.52.6		X									X			
+windows_x86_64_msvc@0.53.1		X									X			
+wit-bindgen@0.51.0		X	X								X			
+wit-bindgen-rt@0.39.0		X	X								X			
+writeable@0.6.1												X		
+yansi@1.0.1		X									X			
+yoke@0.8.0												X		
+yoke-derive@0.8.0												X		
+zerocopy@0.8.26		X		X							X			
+zerocopy-derive@0.8.26		X		X							X			
+zerofrom@0.1.6												X		
+zerofrom-derive@0.1.6												X		
+zeroize@1.8.1		X									X			
+zerotrie@0.2.2												X		
+zerovec@0.11.2												X		
+zerovec-derive@0.11.1												X		
+zlib-rs@0.6.3														X
+zmij@1.0.21											X			
+zstd@0.13.3											X			
+zstd-safe@7.2.4		X									X			
+zstd-sys@2.0.16+zstd.1.5.7		X									X			

--- a/crates/paimon/src/arrow/format/avro.rs
+++ b/crates/paimon/src/arrow/format/avro.rs
@@ -21,6 +21,8 @@ use crate::io::FileRead;
 use crate::spec::{DataField, DataType, MapType, RowType};
 use crate::table::{ArrowRecordBatchStream, RowRange};
 use crate::Error;
+use apache_avro::types::Value;
+use apache_avro::Reader;
 use arrow_array::{
     BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
     Int16Array, Int32Array, Int64Array, Int8Array, ListArray, MapArray, RecordBatch, StringArray,
@@ -31,164 +33,7 @@ use arrow_schema::SchemaRef;
 use async_stream::try_stream;
 use async_trait::async_trait;
 use futures::StreamExt;
-use std::collections::HashMap;
 use std::sync::Arc;
-
-// ---------------------------------------------------------------------------
-// AvroValue: a serde_json::Value replacement that handles Avro bytes
-// ---------------------------------------------------------------------------
-
-/// Lightweight value type that can represent all Avro primitives including bytes.
-/// `serde_json::Value` rejects byte arrays, so we need our own.
-#[derive(Debug, Clone, PartialEq)]
-enum AvroValue {
-    Null,
-    Bool(bool),
-    Int(i64),
-    Float(f64),
-    String(String),
-    Bytes(Vec<u8>),
-    /// Avro array / sequence.
-    Array(Vec<AvroValue>),
-    /// Union wrapper or record: `{"type": value}` produced by serde_avro_fast.
-    Object(HashMap<String, AvroValue>),
-}
-
-impl AvroValue {
-    fn as_bool(&self) -> Option<bool> {
-        match self {
-            AvroValue::Bool(b) => Some(*b),
-            _ => None,
-        }
-    }
-
-    fn as_i64(&self) -> Option<i64> {
-        match self {
-            AvroValue::Int(n) => Some(*n),
-            _ => None,
-        }
-    }
-
-    fn as_f64(&self) -> Option<f64> {
-        match self {
-            AvroValue::Float(f) => Some(*f),
-            AvroValue::Int(n) => Some(*n as f64),
-            _ => None,
-        }
-    }
-
-    fn as_str(&self) -> Option<&str> {
-        match self {
-            AvroValue::String(s) => Some(s),
-            _ => None,
-        }
-    }
-
-    fn as_bytes(&self) -> Option<&[u8]> {
-        match self {
-            AvroValue::Bytes(b) => Some(b),
-            AvroValue::String(s) => Some(s.as_bytes()),
-            _ => None,
-        }
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for AvroValue {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct AvroValueVisitor;
-
-        impl<'de> serde::de::Visitor<'de> for AvroValueVisitor {
-            type Value = AvroValue;
-
-            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                f.write_str("any Avro value")
-            }
-
-            fn visit_bool<E>(self, v: bool) -> Result<AvroValue, E> {
-                Ok(AvroValue::Bool(v))
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<AvroValue, E> {
-                Ok(AvroValue::Int(v as i64))
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<AvroValue, E> {
-                Ok(AvroValue::Int(v as i64))
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<AvroValue, E> {
-                Ok(AvroValue::Int(v as i64))
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<AvroValue, E> {
-                Ok(AvroValue::Int(v))
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<AvroValue, E> {
-                Ok(AvroValue::Int(v as i64))
-            }
-
-            fn visit_f32<E>(self, v: f32) -> Result<AvroValue, E> {
-                Ok(AvroValue::Float(v as f64))
-            }
-
-            fn visit_f64<E>(self, v: f64) -> Result<AvroValue, E> {
-                Ok(AvroValue::Float(v))
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<AvroValue, E> {
-                Ok(AvroValue::String(v.to_owned()))
-            }
-
-            fn visit_string<E>(self, v: String) -> Result<AvroValue, E> {
-                Ok(AvroValue::String(v))
-            }
-
-            fn visit_bytes<E>(self, v: &[u8]) -> Result<AvroValue, E> {
-                Ok(AvroValue::Bytes(v.to_vec()))
-            }
-
-            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<AvroValue, E> {
-                Ok(AvroValue::Bytes(v))
-            }
-
-            fn visit_none<E>(self) -> Result<AvroValue, E> {
-                Ok(AvroValue::Null)
-            }
-
-            fn visit_unit<E>(self) -> Result<AvroValue, E> {
-                Ok(AvroValue::Null)
-            }
-
-            fn visit_map<A>(self, mut map: A) -> Result<AvroValue, A::Error>
-            where
-                A: serde::de::MapAccess<'de>,
-            {
-                let mut m = HashMap::new();
-                while let Some((k, v)) = map.next_entry::<String, AvroValue>()? {
-                    m.insert(k, v);
-                }
-                Ok(AvroValue::Object(m))
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<AvroValue, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
-            {
-                let mut v = Vec::new();
-                while let Some(elem) = seq.next_element::<AvroValue>()? {
-                    v.push(elem);
-                }
-                Ok(AvroValue::Array(v))
-            }
-        }
-
-        deserializer.deserialize_any(AvroValueVisitor)
-    }
-}
 
 pub(crate) struct AvroFormatReader;
 
@@ -213,25 +58,20 @@ impl FormatFileReader for AvroFormatReader {
         let target_schema = build_target_arrow_schema(&read_fields)?;
         let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
 
-        // Deserialize all Avro records from the OCF file.
-        let mut reader =
-            serde_avro_fast::object_container_file_encoding::Reader::from_slice(&file_bytes)
-                .map_err(|e| Error::UnexpectedError {
-                    message: format!("Failed to open Avro file: {e}"),
-                    source: Some(Box::new(e)),
-                })?;
-
-        let mut all_records: Vec<HashMap<String, AvroValue>> = Vec::new();
-        for result in reader.deserialize_borrowed::<HashMap<String, AvroValue>>() {
-            let record = result.map_err(|e| Error::UnexpectedError {
+        // Collect Avro records directly as apache_avro::Value, avoiding intermediate conversion.
+        let all_records: Vec<Value> = Reader::new(&file_bytes[..])
+            .map_err(|e| Error::UnexpectedError {
+                message: format!("Failed to open Avro file: {e}"),
+                source: Some(Box::new(e)),
+            })?
+            .collect::<std::result::Result<Vec<Value>, _>>()
+            .map_err(|e| Error::UnexpectedError {
                 message: format!("Failed to deserialize Avro record: {e}"),
                 source: Some(Box::new(e)),
             })?;
-            all_records.push(record);
-        }
 
         // Apply row selection filtering.
-        let records: Vec<HashMap<String, AvroValue>> = match row_selection {
+        let records: Vec<Value> = match row_selection {
             Some(ref ranges) => {
                 let total_rows = all_records.len();
                 let mask = ranges_to_mask(total_rows, ranges);
@@ -252,6 +92,88 @@ impl FormatFileReader for AvroFormatReader {
             }
         }
         .boxed())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Value access helpers — work directly with apache_avro::types::Value
+// ---------------------------------------------------------------------------
+
+/// Find the position of a named field from the first record.
+/// All records in an Avro file share the same schema, so the index is valid
+/// for every record.
+fn field_index(records: &[Value], name: &str) -> Option<usize> {
+    match records.first() {
+        Some(Value::Record(fields)) => fields.iter().position(|(n, _)| n == name),
+        _ => None,
+    }
+}
+
+/// Look up a field by cached index, unwrapping unions.
+/// If `idx` is `None` (field not in schema or empty records), returns `None` directly
+/// without linear search, since all records share the same schema.
+fn get_field_at(record: &Value, idx: Option<usize>) -> Option<&Value> {
+    match (record, idx) {
+        (Value::Record(fields), Some(i)) => fields.get(i).map(|(_, v)| v).and_then(unwrap_value),
+        _ => None,
+    }
+}
+
+/// Unwrap Avro union/null values, returning `None` for null.
+fn unwrap_value(v: &Value) -> Option<&Value> {
+    match v {
+        Value::Null => None,
+        Value::Union(_, inner) => unwrap_value(inner),
+        other => Some(other),
+    }
+}
+
+fn value_as_bool(v: &Value) -> Option<bool> {
+    match v {
+        Value::Boolean(b) => Some(*b),
+        _ => None,
+    }
+}
+
+fn value_as_i64(v: &Value) -> Option<i64> {
+    match v {
+        Value::Int(n) => Some(i64::from(*n)),
+        Value::Long(n) => Some(*n),
+        Value::Date(n) | Value::TimeMillis(n) => Some(i64::from(*n)),
+        Value::TimeMicros(n)
+        | Value::TimestampMillis(n)
+        | Value::TimestampMicros(n)
+        | Value::TimestampNanos(n)
+        | Value::LocalTimestampMillis(n)
+        | Value::LocalTimestampMicros(n)
+        | Value::LocalTimestampNanos(n) => Some(*n),
+        _ => None,
+    }
+}
+
+fn value_as_f64(v: &Value) -> Option<f64> {
+    match v {
+        Value::Float(f) => Some(f64::from(*f)),
+        Value::Double(f) => Some(*f),
+        Value::Int(n) => Some(f64::from(*n)),
+        Value::Long(n) => Some(*n as f64),
+        _ => None,
+    }
+}
+
+fn value_as_str(v: &Value) -> Option<&str> {
+    match v {
+        Value::String(s) => Some(s),
+        Value::Enum(_, s) => Some(s),
+        _ => None,
+    }
+}
+
+fn value_as_bytes(v: &Value) -> Option<&[u8]> {
+    match v {
+        Value::Bytes(b) | Value::Fixed(_, b) => Some(b),
+        Value::String(s) => Some(s.as_bytes()),
+        _ => None,
     }
 }
 
@@ -280,7 +202,7 @@ fn ranges_to_mask(total_rows: usize, ranges: &[RowRange]) -> Vec<bool> {
 // ---------------------------------------------------------------------------
 
 fn records_to_batch(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     fields: &[DataField],
     schema: &SchemaRef,
 ) -> crate::Result<RecordBatch> {
@@ -308,23 +230,26 @@ fn records_to_batch(
 }
 
 fn build_column(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     name: &str,
     data_type: &DataType,
     num_rows: usize,
 ) -> crate::Result<Arc<dyn arrow_array::Array>> {
+    // Pre-compute field position once; O(1) per-row access thereafter.
+    let idx = field_index(records, name);
+
     Ok(match data_type {
         DataType::Boolean(_) => {
             let arr: BooleanArray = (0..num_rows)
-                .map(|i| get_field(&records[i], name).and_then(|v| v.as_bool()))
+                .map(|i| get_field_at(&records[i], idx).and_then(value_as_bool))
                 .collect();
             Arc::new(arr)
         }
         DataType::TinyInt(_) => {
             let arr: Int8Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name)
-                        .and_then(|v| v.as_i64())
+                    get_field_at(&records[i], idx)
+                        .and_then(value_as_i64)
                         .map(|v| v as i8)
                 })
                 .collect();
@@ -333,8 +258,8 @@ fn build_column(
         DataType::SmallInt(_) => {
             let arr: Int16Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name)
-                        .and_then(|v| v.as_i64())
+                    get_field_at(&records[i], idx)
+                        .and_then(value_as_i64)
                         .map(|v| v as i16)
                 })
                 .collect();
@@ -343,8 +268,8 @@ fn build_column(
         DataType::Int(_) => {
             let arr: Int32Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name)
-                        .and_then(|v| v.as_i64())
+                    get_field_at(&records[i], idx)
+                        .and_then(value_as_i64)
                         .map(|v| v as i32)
                 })
                 .collect();
@@ -352,15 +277,15 @@ fn build_column(
         }
         DataType::BigInt(_) => {
             let arr: Int64Array = (0..num_rows)
-                .map(|i| get_field(&records[i], name).and_then(|v| v.as_i64()))
+                .map(|i| get_field_at(&records[i], idx).and_then(value_as_i64))
                 .collect();
             Arc::new(arr)
         }
         DataType::Float(_) => {
             let arr: Float32Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name)
-                        .and_then(|v| v.as_f64())
+                    get_field_at(&records[i], idx)
+                        .and_then(value_as_f64)
                         .map(|v| v as f32)
                 })
                 .collect();
@@ -368,19 +293,19 @@ fn build_column(
         }
         DataType::Double(_) => {
             let arr: Float64Array = (0..num_rows)
-                .map(|i| get_field(&records[i], name).and_then(|v| v.as_f64()))
+                .map(|i| get_field_at(&records[i], idx).and_then(value_as_f64))
                 .collect();
             Arc::new(arr)
         }
         DataType::Char(_) | DataType::VarChar(_) => {
             let arr: StringArray = (0..num_rows)
-                .map(|i| get_field(&records[i], name).and_then(|v| v.as_str()))
+                .map(|i| get_field_at(&records[i], idx).and_then(value_as_str))
                 .collect();
             Arc::new(arr)
         }
         DataType::Binary(_) | DataType::VarBinary(_) => {
             let values: Vec<Option<&[u8]>> = (0..num_rows)
-                .map(|i| get_field(&records[i], name).and_then(|v| v.as_bytes()))
+                .map(|i| get_field_at(&records[i], idx).and_then(value_as_bytes))
                 .collect();
             let arr: BinaryArray = values.into_iter().collect();
             Arc::new(arr)
@@ -388,8 +313,8 @@ fn build_column(
         DataType::Date(_) => {
             let arr: Date32Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name)
-                        .and_then(|v| v.as_i64())
+                    get_field_at(&records[i], idx)
+                        .and_then(value_as_i64)
                         .map(|v| v as i32)
                 })
                 .collect();
@@ -404,12 +329,12 @@ fn build_column(
             })?;
             let arr: Decimal128Array = (0..num_rows)
                 .map(|i| {
-                    get_field(&records[i], name).and_then(|v| match v {
-                        // Avro decimal is encoded as big-endian two's complement bytes.
-                        AvroValue::Bytes(b) => Some(bytes_to_i128_be(b)),
-                        AvroValue::Int(n) => Some(*n as i128),
-                        // serde_avro_fast may deserialize decimal as string representation.
-                        AvroValue::String(s) => parse_decimal_string(s, scale),
+                    get_field_at(&records[i], idx).and_then(|v| match v {
+                        Value::Bytes(b) | Value::Fixed(_, b) => Some(bytes_to_i128_be(b)),
+                        Value::Decimal(d) => Vec::<u8>::try_from(d.clone())
+                            .ok()
+                            .map(|b| bytes_to_i128_be(&b)),
+                        Value::BigDecimal(bd) => parse_decimal_string(&bd.to_string(), scale),
                         _ => None,
                     })
                 })
@@ -445,14 +370,15 @@ fn build_column(
 }
 
 fn build_timestamp_column(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     name: &str,
     num_rows: usize,
     precision: u32,
     tz: Option<Arc<str>>,
 ) -> Arc<dyn arrow_array::Array> {
+    let idx = field_index(records, name);
     let values: Vec<Option<i64>> = (0..num_rows)
-        .map(|i| get_field(&records[i], name).and_then(|v| v.as_i64()))
+        .map(|i| get_field_at(&records[i], idx).and_then(value_as_i64))
         .collect();
     match precision {
         0..=3 => Arc::new(TimestampMillisecondArray::from(values).with_timezone_opt(tz)),
@@ -462,7 +388,7 @@ fn build_timestamp_column(
 }
 
 fn build_array_column(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     name: &str,
     element_type: &DataType,
     num_rows: usize,
@@ -471,16 +397,16 @@ fn build_array_column(
     let arrow_element_field =
         arrow_schema::Field::new("element", arrow_element_type, element_type.is_nullable());
 
+    let idx = field_index(records, name);
     let mut offsets = vec![0i32];
-    let mut element_records: Vec<HashMap<String, AvroValue>> = Vec::new();
+    let mut element_records: Vec<Value> = Vec::new();
 
     for record in records.iter().take(num_rows) {
-        match get_field(record, name) {
-            Some(AvroValue::Array(arr)) => {
+        match get_field_at(record, idx) {
+            Some(Value::Array(arr)) => {
                 for elem in arr {
-                    let mut m = HashMap::new();
-                    m.insert("element".to_string(), elem.clone());
-                    element_records.push(m);
+                    element_records
+                        .push(Value::Record(vec![("element".to_string(), elem.clone())]));
                 }
                 offsets.push(offsets.last().unwrap() + arr.len() as i32);
             }
@@ -500,7 +426,7 @@ fn build_array_column(
     let offsets_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
     let nulls = NullBuffer::new(BooleanBuffer::from(
         (0..num_rows)
-            .map(|i| get_field(&records[i], name).is_some())
+            .map(|i| get_field_at(&records[i], idx).is_some())
             .collect::<Vec<_>>(),
     ));
 
@@ -518,7 +444,7 @@ fn build_array_column(
 }
 
 fn build_map_column(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     name: &str,
     map_type: &MapType,
     num_rows: usize,
@@ -526,20 +452,20 @@ fn build_map_column(
     let arrow_key_type = crate::arrow::paimon_type_to_arrow(map_type.key_type())?;
     let arrow_value_type = crate::arrow::paimon_type_to_arrow(map_type.value_type())?;
 
+    let idx = field_index(records, name);
     let mut offsets = vec![0i32];
-    let mut key_records: Vec<HashMap<String, AvroValue>> = Vec::new();
-    let mut value_records: Vec<HashMap<String, AvroValue>> = Vec::new();
+    let mut key_records: Vec<Value> = Vec::new();
+    let mut value_records: Vec<Value> = Vec::new();
 
     for record in records.iter().take(num_rows) {
-        match get_field_raw(record, name) {
-            Some(AvroValue::Object(map)) => {
+        match get_field_at(record, idx) {
+            Some(Value::Map(map)) => {
                 for (k, v) in map {
-                    let mut km = HashMap::new();
-                    km.insert("key".to_string(), AvroValue::String(k.clone()));
-                    key_records.push(km);
-                    let mut vm = HashMap::new();
-                    vm.insert("value".to_string(), v.clone());
-                    value_records.push(vm);
+                    key_records.push(Value::Record(vec![(
+                        "key".to_string(),
+                        Value::String(k.clone()),
+                    )]));
+                    value_records.push(Value::Record(vec![("value".to_string(), v.clone())]));
                 }
                 offsets.push(offsets.last().unwrap() + map.len() as i32);
             }
@@ -584,7 +510,7 @@ fn build_map_column(
     let offsets_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
     let nulls = NullBuffer::new(BooleanBuffer::from(
         (0..num_rows)
-            .map(|i| get_field_raw(&records[i], name).is_some())
+            .map(|i| get_field_at(&records[i], idx).is_some())
             .collect::<Vec<_>>(),
     ));
 
@@ -603,15 +529,16 @@ fn build_map_column(
 }
 
 fn build_row_column(
-    records: &[HashMap<String, AvroValue>],
+    records: &[Value],
     name: &str,
     row_type: &RowType,
     num_rows: usize,
 ) -> crate::Result<Arc<dyn arrow_array::Array>> {
-    let sub_records: Vec<HashMap<String, AvroValue>> = (0..num_rows)
-        .map(|i| match get_field_raw(&records[i], name) {
-            Some(AvroValue::Object(obj)) => obj.clone(),
-            _ => HashMap::new(),
+    let idx = field_index(records, name);
+    let sub_records: Vec<Value> = (0..num_rows)
+        .map(|i| match get_field_at(&records[i], idx) {
+            Some(v @ Value::Record(_)) => v.clone(),
+            _ => Value::Record(vec![]),
         })
         .collect();
 
@@ -631,7 +558,7 @@ fn build_row_column(
 
     let nulls = NullBuffer::new(BooleanBuffer::from(
         (0..num_rows)
-            .map(|i| get_field_raw(&records[i], name).is_some())
+            .map(|i| get_field_at(&records[i], idx).is_some())
             .collect::<Vec<_>>(),
     ));
 
@@ -653,7 +580,7 @@ fn parse_decimal_string(s: &str, scale: i8) -> Option<i128> {
         None => (s, ""),
     };
     let frac_len = frac_part.len() as i8;
-    let combined = format!("{}{}", integer_part, frac_part);
+    let combined = format!("{integer_part}{frac_part}");
     let unscaled: i128 = combined.parse().ok()?;
     // Adjust if the fractional digits differ from the target scale.
     let result = if frac_len < scale {
@@ -679,36 +606,6 @@ fn bytes_to_i128_be(bytes: &[u8]) -> i128 {
     i128::from_be_bytes(buf)
 }
 
-/// Look up a field in an Avro record, unwrapping union encoding.
-fn get_field<'a>(record: &'a HashMap<String, AvroValue>, name: &str) -> Option<&'a AvroValue> {
-    record.get(name).and_then(unwrap_avro_union)
-}
-
-/// Look up a field without union unwrapping — for Map/Row types whose Object
-/// shape overlaps with union wrappers.
-fn get_field_raw<'a>(record: &'a HashMap<String, AvroValue>, name: &str) -> Option<&'a AvroValue> {
-    record.get(name).and_then(|v| match v {
-        AvroValue::Null => None,
-        other => Some(other),
-    })
-}
-
-/// Unwrap Avro union encoding: `{"type": value}` → `value`, or `"null"` → `None`.
-fn unwrap_avro_union(v: &AvroValue) -> Option<&AvroValue> {
-    match v {
-        AvroValue::Null => None,
-        AvroValue::Object(map) if map.len() == 1 => {
-            let (key, inner) = map.iter().next().unwrap();
-            if key == "null" {
-                None
-            } else {
-                Some(inner)
-            }
-        }
-        other => Some(other),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -718,78 +615,95 @@ mod tests {
     };
     use arrow_array::Array;
 
-    // Helper to build AvroValue variants concisely in tests.
-    fn av_int(v: i64) -> AvroValue {
-        AvroValue::Int(v)
+    // Helper to build Value variants concisely in tests.
+    fn av_int(v: i64) -> Value {
+        Value::Long(v)
     }
-    fn av_float(v: f64) -> AvroValue {
-        AvroValue::Float(v)
+    fn av_float(v: f64) -> Value {
+        Value::Double(v)
     }
-    fn av_bool(v: bool) -> AvroValue {
-        AvroValue::Bool(v)
+    fn av_bool(v: bool) -> Value {
+        Value::Boolean(v)
     }
-    fn av_str(v: &str) -> AvroValue {
-        AvroValue::String(v.to_string())
+    fn av_str(v: &str) -> Value {
+        Value::String(v.to_string())
     }
-    fn av_bytes(v: &[u8]) -> AvroValue {
-        AvroValue::Bytes(v.to_vec())
+    fn av_bytes(v: &[u8]) -> Value {
+        Value::Bytes(v.to_vec())
     }
-    fn av_null() -> AvroValue {
-        AvroValue::Null
+    fn av_null() -> Value {
+        Value::Null
     }
-    fn av_union(key: &str, val: AvroValue) -> AvroValue {
-        AvroValue::Object(HashMap::from([(key.to_string(), val)]))
+    fn av_union(val: Value) -> Value {
+        Value::Union(1, Box::new(val))
     }
 
     // -----------------------------------------------------------------------
-    // unwrap_avro_union
+    // unwrap_value
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_unwrap_avro_union_null() {
-        assert!(unwrap_avro_union(&av_null()).is_none());
+    fn test_unwrap_value_null() {
+        assert!(unwrap_value(&av_null()).is_none());
     }
 
     #[test]
-    fn test_unwrap_avro_union_plain_value() {
+    fn test_unwrap_value_plain() {
         let v = av_int(42);
-        assert_eq!(unwrap_avro_union(&v), Some(&av_int(42)));
+        assert_eq!(unwrap_value(&v), Some(&Value::Long(42)));
     }
 
     #[test]
-    fn test_unwrap_avro_union_wrapped_value() {
-        let v = av_union("int", av_int(42));
-        assert_eq!(unwrap_avro_union(&v), Some(&av_int(42)));
+    fn test_unwrap_value_union() {
+        let v = av_union(av_int(42));
+        assert_eq!(unwrap_value(&v), Some(&Value::Long(42)));
     }
 
     #[test]
-    fn test_unwrap_avro_union_null_key() {
-        let v = av_union("null", av_null());
-        assert!(unwrap_avro_union(&v).is_none());
+    fn test_unwrap_value_union_null() {
+        let v = Value::Union(0, Box::new(Value::Null));
+        assert!(unwrap_value(&v).is_none());
     }
 
     // -----------------------------------------------------------------------
-    // get_field
+    // get_field_at
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn test_get_field_present() {
-        let mut record = HashMap::new();
-        record.insert("name".to_string(), av_str("alice"));
-        assert_eq!(get_field(&record, "name"), Some(&av_str("alice")));
+    fn make_record(fields: Vec<(&str, Value)>) -> Value {
+        Value::Record(
+            fields
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+        )
     }
 
     #[test]
-    fn test_get_field_missing() {
-        let record: HashMap<String, AvroValue> = HashMap::new();
-        assert!(get_field(&record, "name").is_none());
+    fn test_get_field_at_present() {
+        let record = make_record(vec![("name", av_str("alice"))]);
+        assert_eq!(
+            get_field_at(&record, Some(0)),
+            Some(&Value::String("alice".to_string()))
+        );
     }
 
     #[test]
-    fn test_get_field_union_wrapped() {
-        let mut record = HashMap::new();
-        record.insert("age".to_string(), av_union("int", av_int(30)));
-        assert_eq!(get_field(&record, "age"), Some(&av_int(30)));
+    fn test_get_field_at_missing() {
+        let record = make_record(vec![]);
+        assert!(get_field_at(&record, None).is_none());
+    }
+
+    #[test]
+    fn test_get_field_at_union_wrapped() {
+        let record = make_record(vec![("age", av_union(av_int(30)))]);
+        assert_eq!(get_field_at(&record, Some(0)), Some(&Value::Long(30)));
+    }
+
+    #[test]
+    fn test_get_field_at_no_index() {
+        let record = make_record(vec![("x", av_int(1)), ("y", av_int(2))]);
+        // idx is None — returns None directly without linear search.
+        assert!(get_field_at(&record, None).is_none());
     }
 
     // -----------------------------------------------------------------------
@@ -821,13 +735,15 @@ mod tests {
     // build_column + records_to_batch
     // -----------------------------------------------------------------------
 
-    fn make_records(rows: Vec<Vec<(&str, AvroValue)>>) -> Vec<HashMap<String, AvroValue>> {
+    fn make_records(rows: Vec<Vec<(&str, Value)>>) -> Vec<Value> {
         rows.into_iter()
             .map(|fields| {
-                fields
-                    .into_iter()
-                    .map(|(k, v)| (k.to_string(), v))
-                    .collect()
+                Value::Record(
+                    fields
+                        .into_iter()
+                        .map(|(k, v)| (k.to_string(), v))
+                        .collect(),
+                )
             })
             .collect()
     }
@@ -967,6 +883,35 @@ mod tests {
     }
 
     #[test]
+    fn test_build_column_map_with_union() {
+        use std::collections::HashMap;
+        // Map field wrapped in a union (nullable map), as Avro encodes nullable types.
+        let mut map1 = HashMap::new();
+        map1.insert("k1".to_string(), av_int(10));
+        map1.insert("k2".to_string(), av_int(20));
+        let records = vec![
+            Value::Record(vec![(
+                "m".to_string(),
+                Value::Union(1, Box::new(Value::Map(map1))),
+            )]),
+            Value::Record(vec![(
+                "m".to_string(),
+                Value::Union(0, Box::new(av_null())),
+            )]),
+        ];
+        let map_type = MapType::new(
+            DataType::VarChar(VarCharType::new(100).unwrap()),
+            DataType::Int(IntType::new()),
+        );
+        let col = build_map_column(&records, "m", &map_type, 2).unwrap();
+        let arr = col.as_any().downcast_ref::<MapArray>().unwrap();
+        assert_eq!(arr.len(), 2);
+        // First row has 2 entries, second row is null.
+        assert!(!arr.is_null(0));
+        assert!(arr.is_null(1));
+    }
+
+    #[test]
     fn test_records_to_batch_basic() {
         let fields = vec![
             DataField::new(0, "id".to_string(), DataType::Int(IntType::new())),
@@ -994,7 +939,7 @@ mod tests {
             DataType::Int(IntType::new()),
         )];
         let schema = crate::arrow::build_target_arrow_schema(&fields).unwrap();
-        let records: Vec<HashMap<String, AvroValue>> = vec![];
+        let records: Vec<Value> = vec![];
         let batch = records_to_batch(&records, &fields, &schema).unwrap();
         assert_eq!(batch.num_rows(), 0);
     }

--- a/crates/paimon/src/error.rs
+++ b/crates/paimon/src/error.rs
@@ -70,6 +70,14 @@ pub enum Error {
     ConfigInvalid { message: String },
     #[snafu(
         visibility(pub(crate)),
+        display("Paimon hitting unexpected avro error {}: {:?}", message, source)
+    )]
+    DataUnexpected {
+        message: String,
+        source: Box<apache_avro::Error>,
+    },
+    #[snafu(
+        visibility(pub(crate)),
         display("Paimon hitting invalid file index format: {}", message)
     )]
     FileIndexFormatInvalid { message: String },
@@ -114,6 +122,15 @@ impl From<opendal::Error> for Error {
         // TODO: Simple use IoUnexpected for now
         Error::IoUnexpected {
             message: "IO operation failed on underlying storage".to_string(),
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<apache_avro::Error> for Error {
+    fn from(source: apache_avro::Error) -> Self {
+        Error::DataUnexpected {
+            message: "Failed to process Avro data".to_string(),
             source: Box::new(source),
         }
     }

--- a/crates/paimon/src/spec/index_manifest.rs
+++ b/crates/paimon/src/spec/index_manifest.rs
@@ -19,8 +19,6 @@ use crate::io::FileIO;
 use crate::spec::manifest_common::FileKind;
 use crate::spec::IndexFileMeta;
 use serde::{Deserialize, Serialize};
-use serde_avro_fast::object_container_file_encoding::Reader;
-use snafu::ResultExt;
 use std::fmt::{Display, Formatter};
 
 use crate::Result;
@@ -74,17 +72,13 @@ impl IndexManifest {
 
     /// Read index manifest entries from Avro-encoded bytes.
     pub fn read_from_bytes(bytes: &[u8]) -> Result<Vec<IndexManifestEntry>> {
-        let mut reader = Reader::from_slice(bytes)
-            .whatever_context::<_, crate::Error>("read index manifest avro")?;
-        reader
-            .deserialize::<IndexManifestEntry>()
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .whatever_context::<_, crate::Error>("deserialize index manifest entry")
+        crate::spec::from_avro_bytes(bytes)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use apache_avro::{from_avro_datum, from_value, to_avro_datum, to_value, types::Value, Schema};
     use indexmap::IndexMap;
 
     use super::*;
@@ -148,7 +142,7 @@ mod tests {
             },
         };
 
-        let schema: serde_avro_fast::Schema = r#"["null", {
+        let schema = Schema::parse_str(r#"["null", {
             "type": "record", 
             "name": "org.apache.paimon.avro.generated.record", 
             "fields": [
@@ -179,12 +173,16 @@ mod tests {
                 }
             ]
             }]"#
-            .parse().unwrap();
+        )
+        .unwrap();
 
-        let serializer_config = &mut serde_avro_fast::ser::SerializerConfig::new(&schema);
-        let encoded = serde_avro_fast::to_single_object_vec(&sample, serializer_config).unwrap();
-        let decoded: IndexManifestEntry =
-            serde_avro_fast::from_single_object_slice(encoded.as_slice(), &schema).unwrap();
+        let value = to_value(&sample).unwrap().resolve(&schema).unwrap();
+        let encoded = to_avro_datum(&schema, value).unwrap();
+        let decoded_value = from_avro_datum(&schema, &mut encoded.as_slice(), None).unwrap();
+        let decoded: IndexManifestEntry = match decoded_value {
+            Value::Union(_, inner) => from_value(inner.as_ref()).unwrap(),
+            other => from_value(&other).unwrap(),
+        };
         assert_eq!(sample, decoded);
     }
 }

--- a/crates/paimon/src/spec/manifest.rs
+++ b/crates/paimon/src/spec/manifest.rs
@@ -18,8 +18,6 @@
 use crate::io::FileIO;
 use crate::spec::manifest_entry::ManifestEntry;
 use crate::spec::manifest_entry::MANIFEST_ENTRY_SCHEMA;
-use serde_avro_fast::object_container_file_encoding::Reader;
-use snafu::ResultExt;
 
 use crate::Result;
 
@@ -46,12 +44,7 @@ impl Manifest {
 
     /// Read manifest entries from bytes.
     fn read_from_bytes(bytes: &[u8]) -> Result<Vec<ManifestEntry>> {
-        let mut reader =
-            Reader::from_slice(bytes).whatever_context::<_, crate::Error>("read manifest avro")?;
-        reader
-            .deserialize::<ManifestEntry>()
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .whatever_context::<_, crate::Error>("deserialize manifest entry")
+        crate::spec::from_avro_bytes(bytes)
     }
 
     /// Write manifest entries to a file.

--- a/crates/paimon/src/spec/objects_file.rs
+++ b/crates/paimon/src/spec/objects_file.rs
@@ -15,18 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use apache_avro::{from_value, to_value, Codec, Reader, Schema, Writer};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use serde_avro_fast::object_container_file_encoding::{Compression, Reader};
-use snafu::ResultExt;
 
 pub fn from_avro_bytes<T: DeserializeOwned>(bytes: &[u8]) -> crate::Result<Vec<T>> {
-    let mut reader = Reader::from_slice(bytes)
-        .whatever_context::<_, crate::Error>("read avro object container")?;
-    reader
-        .deserialize::<T>()
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .whatever_context::<_, crate::Error>("deserialize avro records")
+    Reader::new(bytes)?
+        .map(|r| {
+            let value = r?;
+            from_value::<T>(&value).map_err(crate::Error::from)
+        })
+        .collect()
 }
 
 /// Serialize records into Avro Object Container File bytes.
@@ -34,25 +33,13 @@ pub fn from_avro_bytes<T: DeserializeOwned>(bytes: &[u8]) -> crate::Result<Vec<T
 /// The `schema_json` must be a valid Avro schema JSON string that matches
 /// the serde serialization layout of `T`.
 pub fn to_avro_bytes<T: Serialize>(schema_json: &str, records: &[T]) -> crate::Result<Vec<u8>> {
-    let schema: serde_avro_fast::Schema =
-        schema_json
-            .parse()
-            .map_err(
-                |e: serde_avro_fast::schema::SchemaError| crate::Error::DataInvalid {
-                    message: format!("invalid avro schema: {e}"),
-                    source: Some(Box::new(e)),
-                },
-            )?;
-    serde_avro_fast::object_container_file_encoding::write_all(
-        &schema,
-        Compression::Null,
-        Vec::new(),
-        records.iter(),
-    )
-    .map_err(|e| crate::Error::DataInvalid {
-        message: format!("avro serialization failed: {e}"),
-        source: Some(Box::new(e)),
-    })
+    let schema = Schema::parse_str(schema_json)?;
+    let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
+    for record in records {
+        let value = to_value(record).and_then(|v| v.resolve(&schema))?;
+        writer.append(value)?;
+    }
+    Ok(writer.into_inner()?)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Purpose

Cherry-pick #276 to release-0.1 branch and update dependency list.

### Brief change log

- Cherry-pick `cb08370` (fix: replace serde_avro_fast with apache-avro and optimize Avro reading)
- Regenerate all `DEPENDENCIES.rust.tsv` files to reflect the dependency change

### Tests

All existing tests pass.

### API and Format

No API or storage format changes.

### Documentation

No.