### PR TITLE
feat(datafusion): add Hive-style INSERT OVERWRITE PARTITION support and simplify API

### DIFF
--- a/bindings/python/src/context.rs
+++ b/bindings/python/src/context.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use datafusion::catalog::CatalogProvider;
 use datafusion_ffi::catalog_provider::FFI_CatalogProvider;
@@ -36,11 +36,7 @@ fn build_paimon_catalog_provider(
     rt.block_on(async {
         let options = Options::from_map(catalog_options);
         let catalog = CatalogFactory::create(options).await.map_err(to_py_err)?;
-        let dynamic_options = Arc::new(RwLock::new(HashMap::new()));
-        Ok::<_, PyErr>(Arc::new(PaimonCatalogProvider::new(
-            catalog,
-            dynamic_options,
-        )))
+        Ok::<_, PyErr>(Arc::new(PaimonCatalogProvider::new(catalog)))
     })
 }
 

--- a/crates/integrations/datafusion/src/catalog.rs
+++ b/crates/integrations/datafusion/src/catalog.rs
@@ -53,10 +53,22 @@ impl Debug for PaimonCatalogProvider {
 }
 
 impl PaimonCatalogProvider {
-    /// Creates a new [`PaimonCatalogProvider`] with shared dynamic options.
+    /// Creates a new [`PaimonCatalogProvider`].
     ///
-    /// All data is loaded lazily when accessed.
-    pub fn new(catalog: Arc<dyn Catalog>, dynamic_options: DynamicOptions) -> Self {
+    /// For standalone use without `SET`/`RESET` support.
+    /// When used via [`PaimonSqlHandler`], the handler creates the provider
+    /// internally with shared dynamic options.
+    pub fn new(catalog: Arc<dyn Catalog>) -> Self {
+        PaimonCatalogProvider {
+            catalog,
+            dynamic_options: Default::default(),
+        }
+    }
+
+    pub(crate) fn with_dynamic_options(
+        catalog: Arc<dyn Catalog>,
+        dynamic_options: DynamicOptions,
+    ) -> Self {
         PaimonCatalogProvider {
             catalog,
             dynamic_options,

--- a/crates/integrations/datafusion/src/lib.rs
+++ b/crates/integrations/datafusion/src/lib.rs
@@ -56,10 +56,9 @@ use std::sync::{Arc, RwLock};
 
 /// Session-scoped dynamic options set via `SET 'paimon.key' = 'value'`.
 ///
-/// Shared across [`PaimonSqlHandler`], [`PaimonCatalogProvider`], and
-/// [`PaimonSchemaProvider`] so that SET/RESET mutations are visible to
-/// subsequent table scans.
-pub type DynamicOptions = Arc<RwLock<HashMap<String, String>>>;
+/// Shared internally across [`PaimonSqlHandler`] and [`PaimonCatalogProvider`]
+/// so that SET/RESET mutations are visible to subsequent table scans.
+pub(crate) type DynamicOptions = Arc<RwLock<HashMap<String, String>>>;
 
 pub use catalog::{PaimonCatalogProvider, PaimonSchemaProvider};
 pub use error::to_datafusion_error;

--- a/crates/integrations/datafusion/src/merge_into.rs
+++ b/crates/integrations/datafusion/src/merge_into.rs
@@ -1446,7 +1446,8 @@ mod tests {
         options.set(CatalogOptions::WAREHOUSE, warehouse);
         let catalog = Arc::new(FileSystemCatalog::new(options).unwrap());
 
-        let handler = PaimonSqlHandler::new(SessionContext::new(), catalog.clone(), "paimon");
+        let handler =
+            PaimonSqlHandler::new(SessionContext::new(), catalog.clone(), "paimon").unwrap();
         handler.sql("CREATE SCHEMA paimon.test_db").await.unwrap();
 
         (temp_dir, handler, catalog)

--- a/crates/integrations/datafusion/src/merge_into.rs
+++ b/crates/integrations/datafusion/src/merge_into.rs
@@ -1437,10 +1437,7 @@ mod tests {
     use paimon::{CatalogOptions, FileSystemCatalog, Options};
     use tempfile::TempDir;
 
-    use crate::{
-        DynamicOptions, PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler,
-        PaimonTableProvider,
-    };
+    use crate::{PaimonSqlHandler, PaimonTableProvider};
 
     async fn setup_handler() -> (TempDir, PaimonSqlHandler, Arc<FileSystemCatalog>) {
         let temp_dir = TempDir::new().unwrap();
@@ -1449,18 +1446,7 @@ mod tests {
         options.set(CatalogOptions::WAREHOUSE, warehouse);
         let catalog = Arc::new(FileSystemCatalog::new(options).unwrap());
 
-        let dynamic_options: DynamicOptions = Default::default();
-        let ctx = SessionContext::new();
-        ctx.register_catalog(
-            "paimon",
-            Arc::new(PaimonCatalogProvider::new(
-                catalog.clone(),
-                dynamic_options.clone(),
-            )),
-        );
-        ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
-            .unwrap();
-        let handler = PaimonSqlHandler::new(ctx, catalog.clone(), "paimon", dynamic_options);
+        let handler = PaimonSqlHandler::new(SessionContext::new(), catalog.clone(), "paimon");
         handler.sql("CREATE SCHEMA paimon.test_db").await.unwrap();
 
         (temp_dir, handler, catalog)

--- a/crates/integrations/datafusion/src/physical_plan/sink.rs
+++ b/crates/integrations/datafusion/src/physical_plan/sink.rs
@@ -100,7 +100,7 @@ impl DataSink for PaimonDataSink {
 
         if self.overwrite {
             commit
-                .overwrite(messages)
+                .overwrite(messages, None)
                 .await
                 .map_err(to_datafusion_error)?;
         } else {

--- a/crates/integrations/datafusion/src/physical_plan/sink.rs
+++ b/crates/integrations/datafusion/src/physical_plan/sink.rs
@@ -80,11 +80,11 @@ impl DataSink for PaimonDataSink {
         mut data: SendableRecordBatchStream,
         _context: &Arc<TaskContext>,
     ) -> DFResult<u64> {
-        let mut wb = self.table.new_write_builder();
-        if self.overwrite {
-            wb = wb.with_overwrite();
-        }
+        let wb = self.table.new_write_builder();
         let mut tw = wb.new_write().map_err(to_datafusion_error)?;
+        if self.overwrite {
+            tw = tw.with_overwrite();
+        }
         let mut row_count = 0u64;
 
         while let Some(batch) = data.next().await {

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -436,10 +436,9 @@ impl PaimonSqlHandler {
             .await
             .map_err(to_datafusion_error)?;
 
-        let partition_exprs = insert
-            .partitioned
-            .as_ref()
-            .expect("guarded by match: partitioned is Some and non-empty");
+        let partition_exprs = insert.partitioned.as_ref().ok_or_else(|| {
+            DataFusionError::Plan("INSERT OVERWRITE PARTITION requires a PARTITION clause".into())
+        })?;
         let partition_fields = table.schema().partition_fields();
         let static_partitions =
             parse_static_partitions(partition_exprs, &partition_fields, table.schema().fields())?;
@@ -456,7 +455,7 @@ impl PaimonSqlHandler {
             .filter(|f| !static_partitions.contains_key(f.name()))
             .count();
 
-        if let Some(first) = batches.iter().find(|b| b.num_rows() > 0) {
+        if let Some(first) = batches.first() {
             if first.num_columns() != expected_source_cols {
                 return Err(DataFusionError::Plan(format!(
                     "Source query has {} columns, but expected {} non-partition columns",
@@ -1059,9 +1058,6 @@ fn parse_number_datum(n: &str, data_type: &PaimonDataType, negate: bool) -> DFRe
                 DataFusionError::Plan(format!("Invalid DOUBLE: {e}"))
             })?))
         }
-        _ if negate => Err(DataFusionError::Plan(format!(
-            "Cannot negate value for type {data_type:?}"
-        ))),
         _ => Err(DataFusionError::Plan(format!(
             "Cannot convert {n} to {data_type:?}"
         ))),
@@ -1129,6 +1125,7 @@ fn append_partition_columns(
 }
 
 /// Create a constant Arrow array from a Datum value.
+/// Only variants produced by `sql_expr_to_datum` are supported here.
 fn datum_to_constant_array(
     datum: &Option<Datum>,
     data_type: &PaimonDataType,

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -457,8 +457,11 @@ impl PaimonSqlHandler {
             .filter(|f| !static_partitions.contains_key(f.name()))
             .count();
 
-        let wb = table.new_write_builder().with_overwrite();
-        let mut tw = wb.new_write().map_err(to_datafusion_error)?;
+        let wb = table.new_write_builder();
+        let mut tw = wb
+            .new_write()
+            .map_err(to_datafusion_error)?
+            .with_overwrite();
         let mut row_count = 0u64;
         let mut col_checked = false;
 

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -437,7 +437,10 @@ impl PaimonSqlHandler {
             .await
             .map_err(to_datafusion_error)?;
 
-        let partition_exprs = insert.partitioned.as_ref().unwrap();
+        let partition_exprs = insert
+            .partitioned
+            .as_ref()
+            .expect("guarded by match: partitioned is Some and non-empty");
         let partition_fields = table.schema().partition_fields();
         let static_partitions =
             parse_static_partitions(partition_exprs, &partition_fields, table.schema().fields())?;
@@ -448,7 +451,7 @@ impl PaimonSqlHandler {
         let batches = self.ctx.sql(&source.to_string()).await?.collect().await?;
 
         let all_fields = table.schema().fields();
-        let non_static_fields: Vec<_> = all_fields
+        let source_fields: Vec<_> = all_fields
             .iter()
             .filter(|f| !static_partitions.contains_key(f.name()))
             .collect();
@@ -464,7 +467,7 @@ impl PaimonSqlHandler {
             let augmented = append_partition_columns(
                 batch,
                 &static_partitions,
-                &non_static_fields,
+                &source_fields,
                 all_fields,
             )?;
             row_count += augmented.num_rows() as u64;
@@ -967,52 +970,19 @@ fn parse_static_partitions(
 
 /// Convert a SQL literal expression to a Paimon Datum.
 fn sql_expr_to_datum(expr: &SqlExpr, data_type: &PaimonDataType) -> DFResult<Datum> {
-    let value = match expr {
-        SqlExpr::Value(v) => &v.value,
+    let (value, negate) = match expr {
+        SqlExpr::Value(v) => (&v.value, false),
         SqlExpr::UnaryOp {
             op: datafusion::sql::sqlparser::ast::UnaryOperator::Minus,
             expr: inner,
         } => {
             if let SqlExpr::Value(v) = inner.as_ref() {
-                return match (&v.value, data_type) {
-                    (SqlValue::Number(n, _), PaimonDataType::TinyInt(_)) => {
-                        Ok(Datum::TinyInt(-n.parse::<i8>().map_err(|e| {
-                            DataFusionError::Plan(format!("Invalid TINYINT: {e}"))
-                        })?))
-                    }
-                    (SqlValue::Number(n, _), PaimonDataType::SmallInt(_)) => {
-                        Ok(Datum::SmallInt(-n.parse::<i16>().map_err(|e| {
-                            DataFusionError::Plan(format!("Invalid SMALLINT: {e}"))
-                        })?))
-                    }
-                    (SqlValue::Number(n, _), PaimonDataType::Int(_)) => {
-                        Ok(Datum::Int(-n.parse::<i32>().map_err(|e| {
-                            DataFusionError::Plan(format!("Invalid INT: {e}"))
-                        })?))
-                    }
-                    (SqlValue::Number(n, _), PaimonDataType::BigInt(_)) => {
-                        Ok(Datum::Long(-n.parse::<i64>().map_err(|e| {
-                            DataFusionError::Plan(format!("Invalid BIGINT: {e}"))
-                        })?))
-                    }
-                    (SqlValue::Number(n, _), PaimonDataType::Float(_)) => {
-                        Ok(Datum::Float(-n.parse::<f32>().map_err(|e| {
-                            DataFusionError::Plan(format!("Invalid FLOAT: {e}"))
-                        })?))
-                    }
-                    (SqlValue::Number(n, _), PaimonDataType::Double(_)) => {
-                        Ok(Datum::Double(-n.parse::<f64>().map_err(|e| {
-                            DataFusionError::Plan(format!("Invalid DOUBLE: {e}"))
-                        })?))
-                    }
-                    _ => Err(DataFusionError::Plan(format!(
-                        "Cannot negate value for type {data_type:?}"
-                    ))),
-                };
+                (&v.value, true)
+            } else {
+                return Err(DataFusionError::Plan(format!(
+                    "Unsupported partition value expression: {expr}"
+                )));
             }
-            return Err(DataFusionError::Plan(format!(
-                "Unsupported partition value expression: {expr}"
-            )));
         }
         other => {
             return Err(DataFusionError::Plan(format!(
@@ -1022,48 +992,64 @@ fn sql_expr_to_datum(expr: &SqlExpr, data_type: &PaimonDataType) -> DFResult<Dat
     };
 
     match (value, data_type) {
-        (SqlValue::Number(n, _), PaimonDataType::TinyInt(_)) => {
-            Ok(Datum::TinyInt(n.parse().map_err(|e| {
-                DataFusionError::Plan(format!("Invalid TINYINT: {e}"))
-            })?))
-        }
-        (SqlValue::Number(n, _), PaimonDataType::SmallInt(_)) => {
-            Ok(Datum::SmallInt(n.parse().map_err(|e| {
-                DataFusionError::Plan(format!("Invalid SMALLINT: {e}"))
-            })?))
-        }
-        (SqlValue::Number(n, _), PaimonDataType::Int(_)) => {
-            Ok(Datum::Int(n.parse().map_err(|e| {
-                DataFusionError::Plan(format!("Invalid INT: {e}"))
-            })?))
-        }
-        (SqlValue::Number(n, _), PaimonDataType::BigInt(_)) => {
-            Ok(Datum::Long(n.parse().map_err(|e| {
-                DataFusionError::Plan(format!("Invalid BIGINT: {e}"))
-            })?))
-        }
-        (SqlValue::Number(n, _), PaimonDataType::Float(_)) => {
-            Ok(Datum::Float(n.parse().map_err(|e| {
-                DataFusionError::Plan(format!("Invalid FLOAT: {e}"))
-            })?))
-        }
-        (SqlValue::Number(n, _), PaimonDataType::Double(_)) => {
-            Ok(Datum::Double(n.parse().map_err(|e| {
-                DataFusionError::Plan(format!("Invalid DOUBLE: {e}"))
-            })?))
-        }
-        (SqlValue::SingleQuotedString(s), PaimonDataType::VarChar(_)) => {
+        (SqlValue::Number(n, _), _) => parse_number_datum(n, data_type, negate),
+        (SqlValue::SingleQuotedString(s), PaimonDataType::VarChar(_)) if !negate => {
             Ok(Datum::String(s.clone()))
         }
-        (SqlValue::SingleQuotedString(s), PaimonDataType::Date(_)) => {
+        (SqlValue::SingleQuotedString(s), PaimonDataType::Date(_)) if !negate => {
             let date = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
                 .map_err(|e| DataFusionError::Plan(format!("Invalid DATE '{s}': {e}")))?;
             let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
             Ok(Datum::Date((date - epoch).num_days() as i32))
         }
-        (SqlValue::Boolean(b), PaimonDataType::Boolean(_)) => Ok(Datum::Bool(*b)),
+        (SqlValue::Boolean(b), PaimonDataType::Boolean(_)) if !negate => Ok(Datum::Bool(*b)),
+        _ if negate => Err(DataFusionError::Plan(format!(
+            "Cannot negate value for type {data_type:?}"
+        ))),
         _ => Err(DataFusionError::Plan(format!(
             "Cannot convert {value} to {data_type:?}"
+        ))),
+    }
+}
+
+fn parse_number_datum(n: &str, data_type: &PaimonDataType, negate: bool) -> DFResult<Datum> {
+    let sign: i8 = if negate { -1 } else { 1 };
+    match data_type {
+        PaimonDataType::TinyInt(_) => Ok(Datum::TinyInt(
+            sign as i8
+                * n.parse::<i8>()
+                    .map_err(|e| DataFusionError::Plan(format!("Invalid TINYINT: {e}")))?,
+        )),
+        PaimonDataType::SmallInt(_) => Ok(Datum::SmallInt(
+            sign as i16
+                * n.parse::<i16>()
+                    .map_err(|e| DataFusionError::Plan(format!("Invalid SMALLINT: {e}")))?,
+        )),
+        PaimonDataType::Int(_) => Ok(Datum::Int(
+            sign as i32
+                * n.parse::<i32>()
+                    .map_err(|e| DataFusionError::Plan(format!("Invalid INT: {e}")))?,
+        )),
+        PaimonDataType::BigInt(_) => Ok(Datum::Long(
+            sign as i64
+                * n.parse::<i64>()
+                    .map_err(|e| DataFusionError::Plan(format!("Invalid BIGINT: {e}")))?,
+        )),
+        PaimonDataType::Float(_) => Ok(Datum::Float(
+            sign as f32
+                * n.parse::<f32>()
+                    .map_err(|e| DataFusionError::Plan(format!("Invalid FLOAT: {e}")))?,
+        )),
+        PaimonDataType::Double(_) => Ok(Datum::Double(
+            sign as f64
+                * n.parse::<f64>()
+                    .map_err(|e| DataFusionError::Plan(format!("Invalid DOUBLE: {e}")))?,
+        )),
+        _ if negate => Err(DataFusionError::Plan(format!(
+            "Cannot negate value for type {data_type:?}"
+        ))),
+        _ => Err(DataFusionError::Plan(format!(
+            "Cannot convert {n} to {data_type:?}"
         ))),
     }
 }
@@ -1072,7 +1058,7 @@ fn sql_expr_to_datum(expr: &SqlExpr, data_type: &PaimonDataType) -> DFResult<Dat
 fn append_partition_columns(
     batch: &RecordBatch,
     partitions: &HashMap<String, Option<Datum>>,
-    non_partition_fields: &[&PaimonDataField],
+    source_fields: &[&PaimonDataField],
     all_fields: &[PaimonDataField],
 ) -> DFResult<RecordBatch> {
     let num_rows = batch.num_rows();
@@ -1111,11 +1097,11 @@ fn append_partition_columns(
         }
     }
 
-    if source_col_idx != batch.num_columns() && source_col_idx != non_partition_fields.len() {
+    if source_col_idx != batch.num_columns() && source_col_idx != source_fields.len() {
         return Err(DataFusionError::Plan(format!(
             "Source query has {} columns, but expected {} non-partition columns",
             batch.num_columns(),
-            non_partition_fields.len()
+            source_fields.len()
         )));
     }
 

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -68,7 +68,7 @@ use crate::DynamicOptions;
 /// # Example
 /// ```ignore
 /// let ctx = SessionContext::new();
-/// let handler = PaimonSqlHandler::new(ctx, catalog, "paimon");
+/// let handler = PaimonSqlHandler::new(ctx, catalog, "paimon")?;
 /// let df = handler.sql("ALTER TABLE paimon.db.t ADD COLUMN age INT").await?;
 /// ```
 pub struct PaimonSqlHandler {
@@ -89,7 +89,7 @@ impl PaimonSqlHandler {
         ctx: SessionContext,
         catalog: Arc<dyn Catalog>,
         catalog_name: impl Into<String>,
-    ) -> Self {
+    ) -> DFResult<Self> {
         let catalog_name = catalog_name.into();
         let dynamic_options: DynamicOptions = Default::default();
         ctx.register_catalog(
@@ -101,14 +101,13 @@ impl PaimonSqlHandler {
         );
         ctx.register_relation_planner(Arc::new(
             crate::relation_planner::PaimonRelationPlanner::new(),
-        ))
-        .expect("Failed to register PaimonRelationPlanner");
-        Self {
+        ))?;
+        Ok(Self {
             ctx,
             catalog,
             catalog_name,
             dynamic_options,
-        }
+        })
     }
 
     /// Returns a reference to the inner [`SessionContext`].
@@ -464,12 +463,8 @@ impl PaimonSqlHandler {
             if batch.num_rows() == 0 {
                 continue;
             }
-            let augmented = append_partition_columns(
-                batch,
-                &static_partitions,
-                &source_fields,
-                all_fields,
-            )?;
+            let augmented =
+                append_partition_columns(batch, &static_partitions, &source_fields, all_fields)?;
             row_count += augmented.num_rows() as u64;
             tw.write_arrow_batch(&augmented)
                 .await
@@ -1097,7 +1092,7 @@ fn append_partition_columns(
         }
     }
 
-    if source_col_idx != batch.num_columns() && source_col_idx != source_fields.len() {
+    if source_col_idx != batch.num_columns() || source_col_idx != source_fields.len() {
         return Err(DataFusionError::Plan(format!(
             "Source query has {} columns, but expected {} non-partition columns",
             batch.num_columns(),
@@ -1286,7 +1281,7 @@ mod tests {
     }
 
     fn make_handler(catalog: Arc<MockCatalog>) -> PaimonSqlHandler {
-        PaimonSqlHandler::new(SessionContext::new(), catalog, "paimon")
+        PaimonSqlHandler::new(SessionContext::new(), catalog, "paimon").unwrap()
     }
 
     fn assert_sql_type_to_paimon(

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -476,12 +476,15 @@ impl PaimonSqlHandler {
             let col_names: Vec<&str> = cols.iter().map(|id| id.value.as_str()).collect();
             let mut reorder = Vec::with_capacity(expected_source_cols);
             for field in &non_static_fields {
-                let pos = col_names.iter().position(|c| c == &field.name()).ok_or_else(|| {
-                    DataFusionError::Plan(format!(
-                        "Column '{}' not found in target column list",
-                        field.name()
-                    ))
-                })?;
+                let pos = col_names
+                    .iter()
+                    .position(|c| c == &field.name())
+                    .ok_or_else(|| {
+                        DataFusionError::Plan(format!(
+                            "Column '{}' not found in target column list",
+                            field.name()
+                        ))
+                    })?;
                 reorder.push(pos);
             }
             Some(reorder)

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -450,10 +450,10 @@ impl PaimonSqlHandler {
         let batches = self.ctx.sql(&source.to_string()).await?.collect().await?;
 
         let all_fields = table.schema().fields();
-        let source_fields: Vec<_> = all_fields
+        let expected_source_cols = all_fields
             .iter()
             .filter(|f| !static_partitions.contains_key(f.name()))
-            .collect();
+            .count();
 
         let wb = table.new_write_builder().with_overwrite();
         let mut tw = wb.new_write().map_err(to_datafusion_error)?;
@@ -464,7 +464,7 @@ impl PaimonSqlHandler {
                 continue;
             }
             let augmented =
-                append_partition_columns(batch, &static_partitions, &source_fields, all_fields)?;
+                append_partition_columns(batch, &static_partitions, expected_source_cols, all_fields)?;
             row_count += augmented.num_rows() as u64;
             tw.write_arrow_batch(&augmented)
                 .await
@@ -927,7 +927,7 @@ fn parse_static_partitions(
                         )))
                     }
                 };
-                (col, Some(right.as_ref()))
+                (col, right.as_ref())
             }
             // Dynamic partition: bare column name without value — skip it,
             // the column will be read from the source query.
@@ -956,7 +956,7 @@ fn parse_static_partitions(
         let field = field_map.get(col_name.as_str()).ok_or_else(|| {
             DataFusionError::Plan(format!("Column '{col_name}' not found in table schema"))
         })?;
-        let datum = sql_expr_to_datum(val_expr.unwrap(), field.data_type())?;
+        let datum = sql_expr_to_datum(val_expr, field.data_type())?;
         result.insert(col_name, Some(datum));
     }
 
@@ -1008,37 +1008,35 @@ fn sql_expr_to_datum(expr: &SqlExpr, data_type: &PaimonDataType) -> DFResult<Dat
 }
 
 fn parse_number_datum(n: &str, data_type: &PaimonDataType, negate: bool) -> DFResult<Datum> {
-    let sign: i8 = if negate { -1 } else { 1 };
+    let s: String = if negate {
+        format!("-{n}")
+    } else {
+        n.to_string()
+    };
     match data_type {
         PaimonDataType::TinyInt(_) => Ok(Datum::TinyInt(
-            sign as i8
-                * n.parse::<i8>()
-                    .map_err(|e| DataFusionError::Plan(format!("Invalid TINYINT: {e}")))?,
+            s.parse::<i8>()
+                .map_err(|e| DataFusionError::Plan(format!("Invalid TINYINT: {e}")))?,
         )),
         PaimonDataType::SmallInt(_) => Ok(Datum::SmallInt(
-            sign as i16
-                * n.parse::<i16>()
-                    .map_err(|e| DataFusionError::Plan(format!("Invalid SMALLINT: {e}")))?,
+            s.parse::<i16>()
+                .map_err(|e| DataFusionError::Plan(format!("Invalid SMALLINT: {e}")))?,
         )),
         PaimonDataType::Int(_) => Ok(Datum::Int(
-            sign as i32
-                * n.parse::<i32>()
-                    .map_err(|e| DataFusionError::Plan(format!("Invalid INT: {e}")))?,
+            s.parse::<i32>()
+                .map_err(|e| DataFusionError::Plan(format!("Invalid INT: {e}")))?,
         )),
         PaimonDataType::BigInt(_) => Ok(Datum::Long(
-            sign as i64
-                * n.parse::<i64>()
-                    .map_err(|e| DataFusionError::Plan(format!("Invalid BIGINT: {e}")))?,
+            s.parse::<i64>()
+                .map_err(|e| DataFusionError::Plan(format!("Invalid BIGINT: {e}")))?,
         )),
         PaimonDataType::Float(_) => Ok(Datum::Float(
-            sign as f32
-                * n.parse::<f32>()
-                    .map_err(|e| DataFusionError::Plan(format!("Invalid FLOAT: {e}")))?,
+            s.parse::<f32>()
+                .map_err(|e| DataFusionError::Plan(format!("Invalid FLOAT: {e}")))?,
         )),
         PaimonDataType::Double(_) => Ok(Datum::Double(
-            sign as f64
-                * n.parse::<f64>()
-                    .map_err(|e| DataFusionError::Plan(format!("Invalid DOUBLE: {e}")))?,
+            s.parse::<f64>()
+                .map_err(|e| DataFusionError::Plan(format!("Invalid DOUBLE: {e}")))?,
         )),
         _ if negate => Err(DataFusionError::Plan(format!(
             "Cannot negate value for type {data_type:?}"
@@ -1053,7 +1051,7 @@ fn parse_number_datum(n: &str, data_type: &PaimonDataType, negate: bool) -> DFRe
 fn append_partition_columns(
     batch: &RecordBatch,
     partitions: &HashMap<String, Option<Datum>>,
-    source_fields: &[&PaimonDataField],
+    expected_source_cols: usize,
     all_fields: &[PaimonDataField],
 ) -> DFResult<RecordBatch> {
     let num_rows = batch.num_rows();
@@ -1092,11 +1090,11 @@ fn append_partition_columns(
         }
     }
 
-    if source_col_idx != batch.num_columns() || source_col_idx != source_fields.len() {
+    if source_col_idx != batch.num_columns() || source_col_idx != expected_source_cols {
         return Err(DataFusionError::Plan(format!(
             "Source query has {} columns, but expected {} non-partition columns",
             batch.num_columns(),
-            source_fields.len()
+            expected_source_cols
         )));
     }
 

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -49,6 +49,7 @@ use datafusion::sql::sqlparser::ast::{
 };
 use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
+use futures::StreamExt;
 use paimon::catalog::{Catalog, Identifier};
 use paimon::spec::{
     ArrayType as PaimonArrayType, BigIntType, BlobType, BooleanType, DataField as PaimonDataField,
@@ -447,7 +448,8 @@ impl PaimonSqlHandler {
             DataFusionError::Plan("INSERT OVERWRITE requires a source query".into())
         })?;
         // Re-parse via to_string(); may lose dialect-specific syntax for complex queries.
-        let batches = self.ctx.sql(&source.to_string()).await?.collect().await?;
+        let df = self.ctx.sql(&source.to_string()).await?;
+        let mut stream = df.execute_stream().await?;
 
         let all_fields = table.schema().fields();
         let expected_source_cols = all_fields
@@ -455,26 +457,28 @@ impl PaimonSqlHandler {
             .filter(|f| !static_partitions.contains_key(f.name()))
             .count();
 
-        if let Some(first) = batches.first() {
-            if first.num_columns() != expected_source_cols {
-                return Err(DataFusionError::Plan(format!(
-                    "Source query has {} columns, but expected {} non-partition columns",
-                    first.num_columns(),
-                    expected_source_cols
-                )));
-            }
-        }
-
         let wb = table.new_write_builder().with_overwrite();
         let mut tw = wb.new_write().map_err(to_datafusion_error)?;
         let mut row_count = 0u64;
+        let mut col_checked = false;
 
-        for batch in &batches {
+        while let Some(batch_result) = stream.next().await {
+            let batch = batch_result?;
             if batch.num_rows() == 0 {
                 continue;
             }
+            if !col_checked {
+                if batch.num_columns() != expected_source_cols {
+                    return Err(DataFusionError::Plan(format!(
+                        "Source query has {} columns, but expected {} non-partition columns",
+                        batch.num_columns(),
+                        expected_source_cols
+                    )));
+                }
+                col_checked = true;
+            }
             let augmented = append_partition_columns(
-                batch,
+                &batch,
                 &static_partitions,
                 expected_source_cols,
                 all_fields,

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -30,24 +30,29 @@
 //! - `ALTER TABLE db.t RENAME COLUMN old TO new`
 //! - `ALTER TABLE db.t RENAME TO new_name`
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use datafusion::arrow::array::StringArray;
+use datafusion::arrow::array::{
+    new_null_array, ArrayRef, BooleanArray, Date32Array, Float32Array, Float64Array, Int16Array,
+    Int32Array, Int64Array, Int8Array, StringArray,
+};
+use datafusion::arrow::compute::cast;
 use datafusion::arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::sql::sqlparser::ast::{
-    AlterTableOperation, ColumnDef, CreateTable, CreateTableOptions, Delete, FromTable, Merge,
-    ObjectName, RenameTableNameKind, Reset, ResetStatement, Set, SqlOption, Statement, TableFactor,
-    Update,
+    AlterTableOperation, ColumnDef, CreateTable, CreateTableOptions, Delete, Expr as SqlExpr,
+    FromTable, Insert, Merge, ObjectName, RenameTableNameKind, Reset, ResetStatement, Set,
+    SqlOption, Statement, TableFactor, TableObject, Update, Value as SqlValue,
 };
 use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
 use paimon::catalog::{Catalog, Identifier};
 use paimon::spec::{
     ArrayType as PaimonArrayType, BigIntType, BlobType, BooleanType, DataField as PaimonDataField,
-    DataType as PaimonDataType, DateType, DecimalType, DoubleType, FloatType, IntType,
+    DataType as PaimonDataType, DateType, Datum, DecimalType, DoubleType, FloatType, IntType,
     LocalZonedTimestampType, MapType as PaimonMapType, RowType as PaimonRowType, SchemaChange,
     SmallIntType, TimestampType, TinyIntType, VarBinaryType, VarCharType,
 };
@@ -62,8 +67,8 @@ use crate::DynamicOptions;
 ///
 /// # Example
 /// ```ignore
-/// let dynamic_options: DynamicOptions = Default::default();
-/// let handler = PaimonSqlHandler::new(ctx, catalog, "paimon", dynamic_options);
+/// let ctx = SessionContext::new();
+/// let handler = PaimonSqlHandler::new(ctx, catalog, "paimon");
 /// let df = handler.sql("ALTER TABLE paimon.db.t ADD COLUMN age INT").await?;
 /// ```
 pub struct PaimonSqlHandler {
@@ -76,21 +81,32 @@ pub struct PaimonSqlHandler {
 }
 
 impl PaimonSqlHandler {
-    /// Creates a new handler with shared dynamic options.
+    /// Creates a new handler that registers the Paimon catalog and relation planner
+    /// on the given [`SessionContext`].
     ///
-    /// The same `DynamicOptions` should also be passed to
-    /// [`PaimonCatalogProvider::new`] so that `SET` mutations
-    /// are visible to subsequent table scans.
+    /// Dynamic options for `SET`/`RESET` are managed internally.
     pub fn new(
         ctx: SessionContext,
         catalog: Arc<dyn Catalog>,
         catalog_name: impl Into<String>,
-        dynamic_options: DynamicOptions,
     ) -> Self {
+        let catalog_name = catalog_name.into();
+        let dynamic_options: DynamicOptions = Default::default();
+        ctx.register_catalog(
+            &catalog_name,
+            Arc::new(crate::catalog::PaimonCatalogProvider::with_dynamic_options(
+                catalog.clone(),
+                dynamic_options.clone(),
+            )),
+        );
+        ctx.register_relation_planner(Arc::new(
+            crate::relation_planner::PaimonRelationPlanner::new(),
+        ))
+        .expect("Failed to register PaimonRelationPlanner");
         Self {
             ctx,
             catalog,
-            catalog_name: catalog_name.into(),
+            catalog_name,
             dynamic_options,
         }
     }
@@ -100,8 +116,8 @@ impl PaimonSqlHandler {
         &self.ctx
     }
 
-    /// Returns a reference to the shared dynamic options.
-    pub fn dynamic_options(&self) -> &DynamicOptions {
+    #[cfg(test)]
+    pub(crate) fn dynamic_options(&self) -> &DynamicOptions {
         &self.dynamic_options
     }
 
@@ -139,6 +155,12 @@ impl PaimonSqlHandler {
             Statement::Merge(merge) => self.handle_merge_into(merge).await,
             Statement::Update(update) => self.handle_update(update).await,
             Statement::Delete(delete) => self.handle_delete(delete).await,
+            Statement::Insert(insert)
+                if insert.overwrite
+                    && insert.partitioned.as_ref().is_some_and(|p| !p.is_empty()) =>
+            {
+                self.handle_insert_overwrite_partition(insert).await
+            }
             Statement::Set(Set::SingleAssignment {
                 variable, values, ..
             }) => {
@@ -397,6 +419,69 @@ impl PaimonSqlHandler {
 
         let table_ref = table_name.to_string();
         crate::delete::execute_delete(&self.ctx, delete, table, &table_ref).await
+    }
+
+    async fn handle_insert_overwrite_partition(&self, insert: &Insert) -> DFResult<DataFrame> {
+        let table_name = match &insert.table {
+            TableObject::TableName(name) => name.clone(),
+            other => {
+                return Err(DataFusionError::Plan(format!(
+                    "Unsupported target table in INSERT OVERWRITE: {other}"
+                )))
+            }
+        };
+        let identifier = self.resolve_table_name(&table_name)?;
+        let table = self
+            .catalog
+            .get_table(&identifier)
+            .await
+            .map_err(to_datafusion_error)?;
+
+        let partition_exprs = insert.partitioned.as_ref().unwrap();
+        let partition_fields = table.schema().partition_fields();
+        let static_partitions =
+            parse_static_partitions(partition_exprs, &partition_fields, table.schema().fields())?;
+
+        let source = insert.source.as_ref().ok_or_else(|| {
+            DataFusionError::Plan("INSERT OVERWRITE requires a source query".into())
+        })?;
+        let batches = self.ctx.sql(&source.to_string()).await?.collect().await?;
+
+        let all_fields = table.schema().fields();
+        let non_static_fields: Vec<_> = all_fields
+            .iter()
+            .filter(|f| !static_partitions.contains_key(f.name()))
+            .collect();
+
+        let wb = table.new_write_builder().with_overwrite();
+        let mut tw = wb.new_write().map_err(to_datafusion_error)?;
+        let mut row_count = 0u64;
+
+        for batch in &batches {
+            if batch.num_rows() == 0 {
+                continue;
+            }
+            let augmented = append_partition_columns(
+                batch,
+                &static_partitions,
+                &non_static_fields,
+                all_fields,
+            )?;
+            row_count += augmented.num_rows() as u64;
+            tw.write_arrow_batch(&augmented)
+                .await
+                .map_err(to_datafusion_error)?;
+        }
+
+        let messages = tw.prepare_commit().await.map_err(to_datafusion_error)?;
+        let commit = wb.new_commit();
+
+        commit
+            .overwrite(messages, Some(static_partitions))
+            .await
+            .map_err(to_datafusion_error)?;
+
+        crate::merge_into::ok_result(&self.ctx, row_count)
     }
 
     /// Resolve an ObjectName like `paimon.db.table` or `db.table` to a Paimon Identifier.
@@ -816,6 +901,262 @@ fn extract_options(opts: &CreateTableOptions) -> DFResult<Vec<(String, String)>>
         .collect()
 }
 
+/// Parse static partition assignments from `PARTITION (col = val, ...)` expressions.
+/// Dynamic partition columns (bare identifiers without `= val`) are skipped —
+/// they will be read from the source query.
+fn parse_static_partitions(
+    exprs: &[SqlExpr],
+    partition_fields: &[PaimonDataField],
+    all_fields: &[PaimonDataField],
+) -> DFResult<HashMap<String, Option<Datum>>> {
+    let mut result = HashMap::new();
+    let field_map: HashMap<&str, &PaimonDataField> =
+        all_fields.iter().map(|f| (f.name(), f)).collect();
+    let partition_names: Vec<&str> = partition_fields.iter().map(|f| f.name()).collect();
+
+    for expr in exprs {
+        let (col_name, val_expr) = match expr {
+            SqlExpr::BinaryOp {
+                left,
+                op: datafusion::sql::sqlparser::ast::BinaryOperator::Eq,
+                right,
+            } => {
+                let col = match left.as_ref() {
+                    SqlExpr::Identifier(ident) => ident.value.clone(),
+                    other => {
+                        return Err(DataFusionError::Plan(format!(
+                            "Expected column name in PARTITION clause, got: {other}"
+                        )))
+                    }
+                };
+                (col, Some(right.as_ref()))
+            }
+            // Dynamic partition: bare column name without value — skip it,
+            // the column will be read from the source query.
+            SqlExpr::Identifier(ident) => {
+                let col_name = &ident.value;
+                if !partition_names.contains(&col_name.as_str()) {
+                    return Err(DataFusionError::Plan(format!(
+                        "Column '{col_name}' is not a partition column"
+                    )));
+                }
+                continue;
+            }
+            other => {
+                return Err(DataFusionError::Plan(format!(
+                    "Unsupported expression in PARTITION clause: {other}"
+                )))
+            }
+        };
+
+        if !partition_names.contains(&col_name.as_str()) {
+            return Err(DataFusionError::Plan(format!(
+                "Column '{col_name}' is not a partition column"
+            )));
+        }
+
+        let field = field_map.get(col_name.as_str()).ok_or_else(|| {
+            DataFusionError::Plan(format!("Column '{col_name}' not found in table schema"))
+        })?;
+        let datum = sql_expr_to_datum(val_expr.unwrap(), field.data_type())?;
+        result.insert(col_name, Some(datum));
+    }
+
+    Ok(result)
+}
+
+/// Convert a SQL literal expression to a Paimon Datum.
+fn sql_expr_to_datum(expr: &SqlExpr, data_type: &PaimonDataType) -> DFResult<Datum> {
+    let value = match expr {
+        SqlExpr::Value(v) => &v.value,
+        SqlExpr::UnaryOp {
+            op: datafusion::sql::sqlparser::ast::UnaryOperator::Minus,
+            expr: inner,
+        } => {
+            if let SqlExpr::Value(v) = inner.as_ref() {
+                return match (&v.value, data_type) {
+                    (SqlValue::Number(n, _), PaimonDataType::TinyInt(_)) => {
+                        Ok(Datum::TinyInt(-n.parse::<i8>().map_err(|e| {
+                            DataFusionError::Plan(format!("Invalid TINYINT: {e}"))
+                        })?))
+                    }
+                    (SqlValue::Number(n, _), PaimonDataType::SmallInt(_)) => {
+                        Ok(Datum::SmallInt(-n.parse::<i16>().map_err(|e| {
+                            DataFusionError::Plan(format!("Invalid SMALLINT: {e}"))
+                        })?))
+                    }
+                    (SqlValue::Number(n, _), PaimonDataType::Int(_)) => {
+                        Ok(Datum::Int(-n.parse::<i32>().map_err(|e| {
+                            DataFusionError::Plan(format!("Invalid INT: {e}"))
+                        })?))
+                    }
+                    (SqlValue::Number(n, _), PaimonDataType::BigInt(_)) => {
+                        Ok(Datum::Long(-n.parse::<i64>().map_err(|e| {
+                            DataFusionError::Plan(format!("Invalid BIGINT: {e}"))
+                        })?))
+                    }
+                    (SqlValue::Number(n, _), PaimonDataType::Float(_)) => {
+                        Ok(Datum::Float(-n.parse::<f32>().map_err(|e| {
+                            DataFusionError::Plan(format!("Invalid FLOAT: {e}"))
+                        })?))
+                    }
+                    (SqlValue::Number(n, _), PaimonDataType::Double(_)) => {
+                        Ok(Datum::Double(-n.parse::<f64>().map_err(|e| {
+                            DataFusionError::Plan(format!("Invalid DOUBLE: {e}"))
+                        })?))
+                    }
+                    _ => Err(DataFusionError::Plan(format!(
+                        "Cannot negate value for type {data_type:?}"
+                    ))),
+                };
+            }
+            return Err(DataFusionError::Plan(format!(
+                "Unsupported partition value expression: {expr}"
+            )));
+        }
+        other => {
+            return Err(DataFusionError::Plan(format!(
+                "Unsupported partition value expression: {other}"
+            )))
+        }
+    };
+
+    match (value, data_type) {
+        (SqlValue::Number(n, _), PaimonDataType::TinyInt(_)) => {
+            Ok(Datum::TinyInt(n.parse().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid TINYINT: {e}"))
+            })?))
+        }
+        (SqlValue::Number(n, _), PaimonDataType::SmallInt(_)) => {
+            Ok(Datum::SmallInt(n.parse().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid SMALLINT: {e}"))
+            })?))
+        }
+        (SqlValue::Number(n, _), PaimonDataType::Int(_)) => {
+            Ok(Datum::Int(n.parse().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid INT: {e}"))
+            })?))
+        }
+        (SqlValue::Number(n, _), PaimonDataType::BigInt(_)) => {
+            Ok(Datum::Long(n.parse().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid BIGINT: {e}"))
+            })?))
+        }
+        (SqlValue::Number(n, _), PaimonDataType::Float(_)) => {
+            Ok(Datum::Float(n.parse().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid FLOAT: {e}"))
+            })?))
+        }
+        (SqlValue::Number(n, _), PaimonDataType::Double(_)) => {
+            Ok(Datum::Double(n.parse().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid DOUBLE: {e}"))
+            })?))
+        }
+        (SqlValue::SingleQuotedString(s), PaimonDataType::VarChar(_)) => {
+            Ok(Datum::String(s.clone()))
+        }
+        (SqlValue::SingleQuotedString(s), PaimonDataType::Date(_)) => {
+            let date = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
+                .map_err(|e| DataFusionError::Plan(format!("Invalid DATE '{s}': {e}")))?;
+            let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+            Ok(Datum::Date((date - epoch).num_days() as i32))
+        }
+        (SqlValue::Boolean(b), PaimonDataType::Boolean(_)) => Ok(Datum::Bool(*b)),
+        _ => Err(DataFusionError::Plan(format!(
+            "Cannot convert {value} to {data_type:?}"
+        ))),
+    }
+}
+
+/// Append static partition columns to a RecordBatch.
+fn append_partition_columns(
+    batch: &RecordBatch,
+    partitions: &HashMap<String, Option<Datum>>,
+    non_partition_fields: &[&PaimonDataField],
+    all_fields: &[PaimonDataField],
+) -> DFResult<RecordBatch> {
+    let num_rows = batch.num_rows();
+
+    let mut columns: Vec<(String, ArrayRef)> = Vec::with_capacity(all_fields.len());
+
+    let mut source_col_idx = 0;
+    for field in all_fields {
+        let name = field.name().to_string();
+        if let Some(datum_opt) = partitions.get(&name) {
+            let array = datum_to_constant_array(datum_opt, field.data_type(), num_rows)?;
+            columns.push((name, array));
+        } else {
+            if source_col_idx >= batch.num_columns() {
+                return Err(DataFusionError::Plan(format!(
+                    "Source query has fewer columns than expected non-partition columns. \
+                     Expected column '{name}' at position {source_col_idx}"
+                )));
+            }
+            let col = batch.column(source_col_idx).clone();
+            let target_type = paimon::arrow::paimon_type_to_arrow(field.data_type())
+                .map_err(to_datafusion_error)?;
+            let col = if col.data_type() != &target_type {
+                cast(&col, &target_type).map_err(|e| {
+                    DataFusionError::Plan(format!(
+                        "Cannot cast column '{name}' from {:?} to {:?}: {e}",
+                        col.data_type(),
+                        target_type
+                    ))
+                })?
+            } else {
+                col
+            };
+            columns.push((name, col));
+            source_col_idx += 1;
+        }
+    }
+
+    if source_col_idx != batch.num_columns() && source_col_idx != non_partition_fields.len() {
+        return Err(DataFusionError::Plan(format!(
+            "Source query has {} columns, but expected {} non-partition columns",
+            batch.num_columns(),
+            non_partition_fields.len()
+        )));
+    }
+
+    let fields: Vec<Field> = columns
+        .iter()
+        .map(|(name, arr)| Field::new(name, arr.data_type().clone(), true))
+        .collect();
+    let schema = Arc::new(Schema::new(fields));
+    let arrays: Vec<ArrayRef> = columns.into_iter().map(|(_, arr)| arr).collect();
+    RecordBatch::try_new(schema, arrays).map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+}
+
+/// Create a constant Arrow array from a Datum value.
+fn datum_to_constant_array(
+    datum: &Option<Datum>,
+    data_type: &PaimonDataType,
+    num_rows: usize,
+) -> DFResult<ArrayRef> {
+    match datum {
+        None => {
+            let arrow_type =
+                paimon::arrow::paimon_type_to_arrow(data_type).map_err(to_datafusion_error)?;
+            Ok(new_null_array(&arrow_type, num_rows))
+        }
+        Some(d) => match d {
+            Datum::Bool(v) => Ok(Arc::new(BooleanArray::from(vec![*v; num_rows]))),
+            Datum::TinyInt(v) => Ok(Arc::new(Int8Array::from(vec![*v; num_rows]))),
+            Datum::SmallInt(v) => Ok(Arc::new(Int16Array::from(vec![*v; num_rows]))),
+            Datum::Int(v) => Ok(Arc::new(Int32Array::from(vec![*v; num_rows]))),
+            Datum::Long(v) => Ok(Arc::new(Int64Array::from(vec![*v; num_rows]))),
+            Datum::Float(v) => Ok(Arc::new(Float32Array::from(vec![*v; num_rows]))),
+            Datum::Double(v) => Ok(Arc::new(Float64Array::from(vec![*v; num_rows]))),
+            Datum::String(v) => Ok(Arc::new(StringArray::from(vec![v.as_str(); num_rows]))),
+            Datum::Date(v) => Ok(Arc::new(Date32Array::from(vec![*v; num_rows]))),
+            other => Err(DataFusionError::Plan(format!(
+                "Unsupported datum type for partition column: {other}"
+            ))),
+        },
+    }
+}
+
 /// Return an empty DataFrame with a single "result" column containing "OK".
 fn ok_result(ctx: &SessionContext) -> DFResult<DataFrame> {
     let schema = Arc::new(Schema::new(vec![Field::new(
@@ -959,7 +1300,7 @@ mod tests {
     }
 
     fn make_handler(catalog: Arc<MockCatalog>) -> PaimonSqlHandler {
-        PaimonSqlHandler::new(SessionContext::new(), catalog, "paimon", Default::default())
+        PaimonSqlHandler::new(SessionContext::new(), catalog, "paimon")
     }
 
     fn assert_sql_type_to_paimon(

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -447,15 +447,58 @@ impl PaimonSqlHandler {
         let source = insert.source.as_ref().ok_or_else(|| {
             DataFusionError::Plan("INSERT OVERWRITE requires a source query".into())
         })?;
-        // Re-parse via to_string(); may lose dialect-specific syntax for complex queries.
         let df = self.ctx.sql(&source.to_string()).await?;
-        let mut stream = df.execute_stream().await?;
 
         let all_fields = table.schema().fields();
-        let expected_source_cols = all_fields
+        let non_static_fields: Vec<&PaimonDataField> = all_fields
             .iter()
             .filter(|f| !static_partitions.contains_key(f.name()))
-            .count();
+            .collect();
+        let expected_source_cols = non_static_fields.len();
+
+        // Resolve target column mapping from the explicit column list.
+        // `columns` = before PARTITION, `after_columns` = after PARTITION (Hive-style).
+        let target_columns = if !insert.columns.is_empty() {
+            Some(&insert.columns)
+        } else if !insert.after_columns.is_empty() {
+            Some(&insert.after_columns)
+        } else {
+            None
+        };
+        let column_reorder: Option<Vec<usize>> = if let Some(cols) = target_columns {
+            if cols.len() != expected_source_cols {
+                return Err(DataFusionError::Plan(format!(
+                    "Column list has {} columns, but expected {} non-partition columns",
+                    cols.len(),
+                    expected_source_cols
+                )));
+            }
+            let col_names: Vec<&str> = cols.iter().map(|id| id.value.as_str()).collect();
+            let mut reorder = Vec::with_capacity(expected_source_cols);
+            for field in &non_static_fields {
+                let pos = col_names.iter().position(|c| c == &field.name()).ok_or_else(|| {
+                    DataFusionError::Plan(format!(
+                        "Column '{}' not found in target column list",
+                        field.name()
+                    ))
+                })?;
+                reorder.push(pos);
+            }
+            Some(reorder)
+        } else {
+            None
+        };
+
+        // Validate column count from the DataFrame schema before consuming any batches.
+        let source_col_count = df.schema().fields().len();
+        if source_col_count != expected_source_cols {
+            return Err(DataFusionError::Plan(format!(
+                "Source query has {} columns, but expected {} non-partition columns",
+                source_col_count, expected_source_cols
+            )));
+        }
+
+        let mut stream = df.execute_stream().await?;
 
         let wb = table.new_write_builder();
         let mut tw = wb
@@ -463,23 +506,25 @@ impl PaimonSqlHandler {
             .map_err(to_datafusion_error)?
             .with_overwrite();
         let mut row_count = 0u64;
-        let mut col_checked = false;
 
         while let Some(batch_result) = stream.next().await {
             let batch = batch_result?;
             if batch.num_rows() == 0 {
                 continue;
             }
-            if !col_checked {
-                if batch.num_columns() != expected_source_cols {
-                    return Err(DataFusionError::Plan(format!(
-                        "Source query has {} columns, but expected {} non-partition columns",
-                        batch.num_columns(),
-                        expected_source_cols
-                    )));
-                }
-                col_checked = true;
-            }
+            let batch = if let Some(ref reorder) = column_reorder {
+                let reordered_cols: Vec<ArrayRef> =
+                    reorder.iter().map(|&i| batch.column(i).clone()).collect();
+                let reordered_fields: Vec<Field> = reorder
+                    .iter()
+                    .map(|&i| batch.schema().field(i).clone())
+                    .collect();
+                let reordered_schema = Arc::new(Schema::new(reordered_fields));
+                RecordBatch::try_new(reordered_schema, reordered_cols)
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?
+            } else {
+                batch
+            };
             let augmented = append_partition_columns(
                 &batch,
                 &static_partitions,
@@ -495,8 +540,13 @@ impl PaimonSqlHandler {
         let messages = tw.prepare_commit().await.map_err(to_datafusion_error)?;
         let commit = wb.new_commit();
 
+        let overwrite_partitions = if static_partitions.is_empty() {
+            None
+        } else {
+            Some(static_partitions)
+        };
         commit
-            .overwrite(messages, Some(static_partitions))
+            .overwrite(messages, overwrite_partitions)
             .await
             .map_err(to_datafusion_error)?;
 

--- a/crates/integrations/datafusion/src/sql_handler.rs
+++ b/crates/integrations/datafusion/src/sql_handler.rs
@@ -447,6 +447,7 @@ impl PaimonSqlHandler {
         let source = insert.source.as_ref().ok_or_else(|| {
             DataFusionError::Plan("INSERT OVERWRITE requires a source query".into())
         })?;
+        // Re-parse via to_string(); may lose dialect-specific syntax for complex queries.
         let batches = self.ctx.sql(&source.to_string()).await?.collect().await?;
 
         let all_fields = table.schema().fields();
@@ -454,6 +455,16 @@ impl PaimonSqlHandler {
             .iter()
             .filter(|f| !static_partitions.contains_key(f.name()))
             .count();
+
+        if let Some(first) = batches.iter().find(|b| b.num_rows() > 0) {
+            if first.num_columns() != expected_source_cols {
+                return Err(DataFusionError::Plan(format!(
+                    "Source query has {} columns, but expected {} non-partition columns",
+                    first.num_columns(),
+                    expected_source_cols
+                )));
+            }
+        }
 
         let wb = table.new_write_builder().with_overwrite();
         let mut tw = wb.new_write().map_err(to_datafusion_error)?;
@@ -463,8 +474,12 @@ impl PaimonSqlHandler {
             if batch.num_rows() == 0 {
                 continue;
             }
-            let augmented =
-                append_partition_columns(batch, &static_partitions, expected_source_cols, all_fields)?;
+            let augmented = append_partition_columns(
+                batch,
+                &static_partitions,
+                expected_source_cols,
+                all_fields,
+            )?;
             row_count += augmented.num_rows() as u64;
             tw.write_arrow_batch(&augmented)
                 .await
@@ -1014,30 +1029,36 @@ fn parse_number_datum(n: &str, data_type: &PaimonDataType, negate: bool) -> DFRe
         n.to_string()
     };
     match data_type {
-        PaimonDataType::TinyInt(_) => Ok(Datum::TinyInt(
-            s.parse::<i8>()
-                .map_err(|e| DataFusionError::Plan(format!("Invalid TINYINT: {e}")))?,
-        )),
-        PaimonDataType::SmallInt(_) => Ok(Datum::SmallInt(
-            s.parse::<i16>()
-                .map_err(|e| DataFusionError::Plan(format!("Invalid SMALLINT: {e}")))?,
-        )),
-        PaimonDataType::Int(_) => Ok(Datum::Int(
-            s.parse::<i32>()
-                .map_err(|e| DataFusionError::Plan(format!("Invalid INT: {e}")))?,
-        )),
-        PaimonDataType::BigInt(_) => Ok(Datum::Long(
-            s.parse::<i64>()
-                .map_err(|e| DataFusionError::Plan(format!("Invalid BIGINT: {e}")))?,
-        )),
-        PaimonDataType::Float(_) => Ok(Datum::Float(
-            s.parse::<f32>()
-                .map_err(|e| DataFusionError::Plan(format!("Invalid FLOAT: {e}")))?,
-        )),
-        PaimonDataType::Double(_) => Ok(Datum::Double(
-            s.parse::<f64>()
-                .map_err(|e| DataFusionError::Plan(format!("Invalid DOUBLE: {e}")))?,
-        )),
+        PaimonDataType::TinyInt(_) => {
+            Ok(Datum::TinyInt(s.parse::<i8>().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid TINYINT: {e}"))
+            })?))
+        }
+        PaimonDataType::SmallInt(_) => {
+            Ok(Datum::SmallInt(s.parse::<i16>().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid SMALLINT: {e}"))
+            })?))
+        }
+        PaimonDataType::Int(_) => {
+            Ok(Datum::Int(s.parse::<i32>().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid INT: {e}"))
+            })?))
+        }
+        PaimonDataType::BigInt(_) => {
+            Ok(Datum::Long(s.parse::<i64>().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid BIGINT: {e}"))
+            })?))
+        }
+        PaimonDataType::Float(_) => {
+            Ok(Datum::Float(s.parse::<f32>().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid FLOAT: {e}"))
+            })?))
+        }
+        PaimonDataType::Double(_) => {
+            Ok(Datum::Double(s.parse::<f64>().map_err(|e| {
+                DataFusionError::Plan(format!("Invalid DOUBLE: {e}"))
+            })?))
+        }
         _ if negate => Err(DataFusionError::Plan(format!(
             "Cannot negate value for type {data_type:?}"
         ))),
@@ -1129,8 +1150,12 @@ fn datum_to_constant_array(
             Datum::Double(v) => Ok(Arc::new(Float64Array::from(vec![*v; num_rows]))),
             Datum::String(v) => Ok(Arc::new(StringArray::from(vec![v.as_str(); num_rows]))),
             Datum::Date(v) => Ok(Arc::new(Date32Array::from(vec![*v; num_rows]))),
-            other => Err(DataFusionError::Plan(format!(
-                "Unsupported datum type for partition column: {other}"
+            Datum::Time(_)
+            | Datum::Timestamp { .. }
+            | Datum::LocalZonedTimestamp { .. }
+            | Datum::Decimal { .. }
+            | Datum::Bytes(_) => Err(DataFusionError::Plan(format!(
+                "Unsupported datum type for partition column: {d}"
             ))),
         },
     }

--- a/crates/integrations/datafusion/src/update.rs
+++ b/crates/integrations/datafusion/src/update.rs
@@ -335,10 +335,7 @@ mod tests {
     use paimon::{CatalogOptions, FileSystemCatalog, Options};
     use tempfile::TempDir;
 
-    use crate::{
-        DynamicOptions, PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler,
-        PaimonTableProvider,
-    };
+    use crate::{PaimonSqlHandler, PaimonTableProvider};
 
     async fn setup_handler() -> (TempDir, PaimonSqlHandler, Arc<FileSystemCatalog>) {
         let temp_dir = TempDir::new().unwrap();
@@ -347,18 +344,7 @@ mod tests {
         options.set(CatalogOptions::WAREHOUSE, warehouse);
         let catalog = Arc::new(FileSystemCatalog::new(options).unwrap());
 
-        let dynamic_options: DynamicOptions = Default::default();
-        let ctx = SessionContext::new();
-        ctx.register_catalog(
-            "paimon",
-            Arc::new(PaimonCatalogProvider::new(
-                catalog.clone(),
-                dynamic_options.clone(),
-            )),
-        );
-        ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
-            .unwrap();
-        let handler = PaimonSqlHandler::new(ctx, catalog.clone(), "paimon", dynamic_options);
+        let handler = PaimonSqlHandler::new(SessionContext::new(), catalog.clone(), "paimon");
         handler.sql("CREATE SCHEMA paimon.test_db").await.unwrap();
 
         (temp_dir, handler, catalog)

--- a/crates/integrations/datafusion/src/update.rs
+++ b/crates/integrations/datafusion/src/update.rs
@@ -344,7 +344,8 @@ mod tests {
         options.set(CatalogOptions::WAREHOUSE, warehouse);
         let catalog = Arc::new(FileSystemCatalog::new(options).unwrap());
 
-        let handler = PaimonSqlHandler::new(SessionContext::new(), catalog.clone(), "paimon");
+        let handler =
+            PaimonSqlHandler::new(SessionContext::new(), catalog.clone(), "paimon").unwrap();
         handler.sql("CREATE SCHEMA paimon.test_db").await.unwrap();
 
         (temp_dir, handler, catalog)

--- a/crates/integrations/datafusion/tests/common/mod.rs
+++ b/crates/integrations/datafusion/tests/common/mod.rs
@@ -38,7 +38,7 @@ pub fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
 
 pub fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
     let ctx = SessionContext::new();
-    PaimonSqlHandler::new(ctx, catalog, "paimon")
+    PaimonSqlHandler::new(ctx, catalog, "paimon").unwrap()
 }
 
 #[allow(dead_code)]

--- a/crates/integrations/datafusion/tests/common/mod.rs
+++ b/crates/integrations/datafusion/tests/common/mod.rs
@@ -17,15 +17,12 @@
 
 //! Shared test helpers for DataFusion integration tests.
 
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use datafusion::arrow::array::{Int32Array, StringArray};
 use datafusion::prelude::SessionContext;
 use paimon::{CatalogOptions, FileSystemCatalog, Options};
-use paimon_datafusion::{
-    DynamicOptions, PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler,
-};
+use paimon_datafusion::PaimonSqlHandler;
 use tempfile::TempDir;
 
 use arrow_array::{Array, RecordBatch, UInt64Array};
@@ -40,18 +37,8 @@ pub fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
 }
 
 pub fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
-    let dynamic_options: DynamicOptions = Arc::new(RwLock::new(HashMap::new()));
     let ctx = SessionContext::new();
-    ctx.register_catalog(
-        "paimon",
-        Arc::new(PaimonCatalogProvider::new(
-            catalog.clone(),
-            dynamic_options.clone(),
-        )),
-    );
-    ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
-        .expect("Failed to register relation planner");
-    PaimonSqlHandler::new(ctx, catalog, "paimon", dynamic_options)
+    PaimonSqlHandler::new(ctx, catalog, "paimon")
 }
 
 #[allow(dead_code)]

--- a/crates/integrations/datafusion/tests/merge_into_tests.rs
+++ b/crates/integrations/datafusion/tests/merge_into_tests.rs
@@ -44,7 +44,7 @@ fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
 
 fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
     let ctx = SessionContext::new();
-    PaimonSqlHandler::new(ctx, catalog, "paimon")
+    PaimonSqlHandler::new(ctx, catalog, "paimon").unwrap()
 }
 
 async fn setup_data_evolution_table(handler: &PaimonSqlHandler) {

--- a/crates/integrations/datafusion/tests/merge_into_tests.rs
+++ b/crates/integrations/datafusion/tests/merge_into_tests.rs
@@ -28,9 +28,7 @@ use datafusion::prelude::SessionContext;
 use paimon::catalog::Identifier;
 use paimon::table::SnapshotManager;
 use paimon::{Catalog, CatalogOptions, FileSystemCatalog, Options};
-use paimon_datafusion::{
-    DynamicOptions, PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler,
-};
+use paimon_datafusion::PaimonSqlHandler;
 use tempfile::TempDir;
 
 // ======================= Helpers =======================
@@ -45,18 +43,8 @@ fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
 }
 
 fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
-    let dynamic_options: DynamicOptions = Default::default();
     let ctx = SessionContext::new();
-    ctx.register_catalog(
-        "paimon",
-        Arc::new(PaimonCatalogProvider::new(
-            catalog.clone(),
-            dynamic_options.clone(),
-        )),
-    );
-    ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
-        .expect("Failed to register relation planner");
-    PaimonSqlHandler::new(ctx, catalog, "paimon", dynamic_options)
+    PaimonSqlHandler::new(ctx, catalog, "paimon")
 }
 
 async fn setup_data_evolution_table(handler: &PaimonSqlHandler) {

--- a/crates/integrations/datafusion/tests/pk_tables.rs
+++ b/crates/integrations/datafusion/tests/pk_tables.rs
@@ -926,6 +926,200 @@ async fn test_pk_insert_overwrite_partition_non_partition_column_error() {
     );
 }
 
+/// All-dynamic PARTITION clause (no static values) should use dynamic partition overwrite,
+/// not drop all partitions.
+#[tokio::test]
+async fn test_pk_insert_overwrite_dynamic_partition_preserves_other_partitions() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_dyn (
+                dt STRING, id INT NOT NULL, name STRING,
+                PRIMARY KEY (dt, id)
+            ) PARTITIONED BY (dt)
+            WITH ('bucket' = '1')",
+        )
+        .await
+        .unwrap();
+
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_dyn VALUES \
+             ('2024-01-01', 1, 'alice'), ('2024-01-02', 2, 'bob')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Dynamic partition overwrite: PARTITION (dt) with no static value.
+    // Should only overwrite partitions present in the source data.
+    handler
+        .sql(
+            "INSERT OVERWRITE paimon.test_db.t_dyn PARTITION (dt) \
+             VALUES ('2024-01-01', 10, 'new_alice')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let batches = handler
+        .sql("SELECT dt, id, name FROM paimon.test_db.t_dyn ORDER BY dt, id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let dts = batch
+            .column_by_name("dt")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        let ids = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .unwrap();
+        let names = batch
+            .column_by_name("name")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            rows.push((
+                dts.value(i).to_string(),
+                ids.value(i),
+                names.value(i).to_string(),
+            ));
+        }
+    }
+
+    // dt='2024-01-01' overwritten, dt='2024-01-02' preserved
+    assert_eq!(
+        rows,
+        vec![
+            ("2024-01-01".to_string(), 10, "new_alice".to_string()),
+            ("2024-01-02".to_string(), 2, "bob".to_string()),
+        ]
+    );
+}
+
+/// Source query with wrong column count should fail even when the result is empty.
+#[tokio::test]
+async fn test_pk_insert_overwrite_empty_source_wrong_columns_error() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_empty_err (
+                dt STRING, id INT NOT NULL, name STRING,
+                PRIMARY KEY (dt, id)
+            ) PARTITIONED BY (dt)
+            WITH ('bucket' = '1')",
+        )
+        .await
+        .unwrap();
+
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_empty_err VALUES \
+             ('2024-01-01', 1, 'alice')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Source only produces `id` but target expects `id, name` — should fail
+    let result = handler
+        .sql(
+            "INSERT OVERWRITE paimon.test_db.t_empty_err PARTITION (dt = '2024-01-01') \
+             SELECT id FROM paimon.test_db.t_empty_err WHERE false",
+        )
+        .await;
+
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("expected 2 non-partition columns"),
+        "Expected column count mismatch error, got: {err_msg}"
+    );
+}
+
+/// Explicit target column list after PARTITION should reorder source columns to match schema.
+#[tokio::test]
+async fn test_pk_insert_overwrite_with_after_columns_reorder() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_reorder (
+                dt STRING, id INT NOT NULL, name STRING,
+                PRIMARY KEY (dt, id)
+            ) PARTITIONED BY (dt)
+            WITH ('bucket' = '1')",
+        )
+        .await
+        .unwrap();
+
+    // Insert with columns in reversed order: (name, id) instead of schema order (id, name)
+    handler
+        .sql(
+            "INSERT OVERWRITE paimon.test_db.t_reorder (name, id) PARTITION (dt = '2024-01-01') \
+             VALUES ('alice', 1), ('bob', 2)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let batches = handler
+        .sql("SELECT dt, id, name FROM paimon.test_db.t_reorder ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let dts = batch
+            .column_by_name("dt")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        let ids = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .unwrap();
+        let names = batch
+            .column_by_name("name")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            rows.push((
+                dts.value(i).to_string(),
+                ids.value(i),
+                names.value(i).to_string(),
+            ));
+        }
+    }
+
+    // Values should be correctly mapped: name='alice'/id=1, name='bob'/id=2
+    assert_eq!(
+        rows,
+        vec![
+            ("2024-01-01".to_string(), 1, "alice".to_string()),
+            ("2024-01-01".to_string(), 2, "bob".to_string()),
+        ]
+    );
+}
+
 // ======================= Composite Primary Key =======================
 
 /// Composite PK with multiple columns.

--- a/crates/integrations/datafusion/tests/pk_tables.rs
+++ b/crates/integrations/datafusion/tests/pk_tables.rs
@@ -817,6 +817,115 @@ async fn test_pk_insert_overwrite_partial_partition_clause() {
     );
 }
 
+/// INSERT OVERWRITE with PARTITION clause and empty source truncates the partition.
+#[tokio::test]
+async fn test_pk_insert_overwrite_partition_truncate() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_trunc (
+                dt STRING, id INT NOT NULL, name STRING,
+                PRIMARY KEY (dt, id)
+            ) PARTITIONED BY (dt)
+            WITH ('bucket' = '1')",
+        )
+        .await
+        .unwrap();
+
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_trunc VALUES \
+             ('2024-01-01', 1, 'alice'), ('2024-01-01', 2, 'bob'), \
+             ('2024-01-02', 3, 'carol')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Overwrite dt='2024-01-01' with empty source — should truncate that partition
+    handler
+        .sql(
+            "INSERT OVERWRITE paimon.test_db.t_trunc PARTITION (dt = '2024-01-01') \
+             SELECT id, name FROM paimon.test_db.t_trunc WHERE false",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let batches = handler
+        .sql("SELECT dt, id, name FROM paimon.test_db.t_trunc ORDER BY dt, id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let dts = batch
+            .column_by_name("dt")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        let ids = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .unwrap();
+        let names = batch
+            .column_by_name("name")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            rows.push((
+                dts.value(i).to_string(),
+                ids.value(i),
+                names.value(i).to_string(),
+            ));
+        }
+    }
+
+    // dt='2024-01-01' truncated, dt='2024-01-02' untouched
+    assert_eq!(
+        rows,
+        vec![("2024-01-02".to_string(), 3, "carol".to_string()),]
+    );
+}
+
+/// PARTITION clause with a non-partition column should fail.
+#[tokio::test]
+async fn test_pk_insert_overwrite_partition_non_partition_column_error() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_err (
+                dt STRING, id INT NOT NULL, name STRING,
+                PRIMARY KEY (dt, id)
+            ) PARTITIONED BY (dt)
+            WITH ('bucket' = '1')",
+        )
+        .await
+        .unwrap();
+
+    let result = handler
+        .sql(
+            "INSERT OVERWRITE paimon.test_db.t_err PARTITION (name = 'alice') \
+             VALUES (1)",
+        )
+        .await;
+
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("not a partition column"),
+        "Expected 'not a partition column' error, got: {err_msg}"
+    );
+}
+
 // ======================= Composite Primary Key =======================
 
 /// Composite PK with multiple columns.

--- a/crates/integrations/datafusion/tests/pk_tables.rs
+++ b/crates/integrations/datafusion/tests/pk_tables.rs
@@ -631,6 +631,192 @@ async fn test_pk_insert_overwrite_partitioned() {
     );
 }
 
+/// INSERT OVERWRITE with explicit PARTITION clause (Hive-style static partition).
+#[tokio::test]
+async fn test_pk_insert_overwrite_with_partition_clause() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_ow_part (
+                dt STRING, id INT NOT NULL, name STRING,
+                PRIMARY KEY (dt, id)
+            ) PARTITIONED BY (dt)
+            WITH ('bucket' = '1')",
+        )
+        .await
+        .unwrap();
+
+    // Insert data into two partitions
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_ow_part VALUES \
+             ('2024-01-01', 1, 'alice'), ('2024-01-01', 2, 'bob'), \
+             ('2024-01-02', 3, 'carol')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Overwrite partition dt='2024-01-01' using Hive-style PARTITION clause.
+    // The SELECT only provides non-partition columns (id, name).
+    handler
+        .sql(
+            "INSERT OVERWRITE paimon.test_db.t_ow_part PARTITION (dt = '2024-01-01') \
+             VALUES (10, 'new_alice'), (20, 'new_bob')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let batches = handler
+        .sql("SELECT dt, id, name FROM paimon.test_db.t_ow_part ORDER BY dt, id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let dts = batch
+            .column_by_name("dt")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        let ids = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .unwrap();
+        let names = batch
+            .column_by_name("name")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            rows.push((
+                dts.value(i).to_string(),
+                ids.value(i),
+                names.value(i).to_string(),
+            ));
+        }
+    }
+
+    // Partition 2024-01-01 overwritten, 2024-01-02 untouched
+    assert_eq!(
+        rows,
+        vec![
+            ("2024-01-01".to_string(), 10, "new_alice".to_string()),
+            ("2024-01-01".to_string(), 20, "new_bob".to_string()),
+            ("2024-01-02".to_string(), 3, "carol".to_string()),
+        ]
+    );
+}
+
+/// INSERT OVERWRITE with partial PARTITION clause on a multi-level partitioned table.
+/// Only specifies dt, region comes from the source query (dynamic partition).
+#[tokio::test]
+async fn test_pk_insert_overwrite_partial_partition_clause() {
+    let (_tmp, handler) = setup_handler().await;
+
+    handler
+        .sql(
+            "CREATE TABLE paimon.test_db.t_multi_part (
+                dt STRING, region STRING, id INT NOT NULL, name STRING,
+                PRIMARY KEY (dt, region, id)
+            ) PARTITIONED BY (dt, region)
+            WITH ('bucket' = '1')",
+        )
+        .await
+        .unwrap();
+
+    // Insert data into multiple partitions
+    handler
+        .sql(
+            "INSERT INTO paimon.test_db.t_multi_part VALUES \
+             ('2024-01-01', 'us', 1, 'alice'), \
+             ('2024-01-01', 'eu', 2, 'bob'), \
+             ('2024-01-02', 'us', 3, 'carol')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    // Overwrite only dt='2024-01-01', region comes from VALUES (dynamic).
+    // This should overwrite all sub-partitions under dt='2024-01-01' that appear in the data.
+    handler
+        .sql(
+            "INSERT OVERWRITE paimon.test_db.t_multi_part PARTITION (dt = '2024-01-01') \
+             VALUES ('us', 10, 'new_alice')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let batches = handler
+        .sql("SELECT dt, region, id, name FROM paimon.test_db.t_multi_part ORDER BY dt, region, id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let dts = batch
+            .column_by_name("dt")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        let regions = batch
+            .column_by_name("region")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        let ids = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .unwrap();
+        let names = batch
+            .column_by_name("name")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        for i in 0..batch.num_rows() {
+            rows.push((
+                dts.value(i).to_string(),
+                regions.value(i).to_string(),
+                ids.value(i),
+                names.value(i).to_string(),
+            ));
+        }
+    }
+
+    // dt='2024-01-01' fully overwritten (static partition overwrite deletes all sub-partitions).
+    // dt='2024-01-01'/region='eu' (bob) is deleted because the entire dt='2024-01-01' partition is replaced.
+    // dt='2024-01-02'/region='us' untouched.
+    assert_eq!(
+        rows,
+        vec![
+            (
+                "2024-01-01".to_string(),
+                "us".to_string(),
+                10,
+                "new_alice".to_string()
+            ),
+            (
+                "2024-01-02".to_string(),
+                "us".to_string(),
+                3,
+                "carol".to_string()
+            ),
+        ]
+    );
+}
+
 // ======================= Composite Primary Key =======================
 
 /// Composite PK with multiple columns.

--- a/crates/integrations/datafusion/tests/read_tables.rs
+++ b/crates/integrations/datafusion/tests/read_tables.rs
@@ -507,7 +507,7 @@ async fn test_residual_filter_limit_keeps_connector_limit_and_correctness() {
 #[tokio::test]
 async fn test_query_via_catalog_provider() {
     let catalog = create_catalog();
-    let provider = PaimonCatalogProvider::new(Arc::new(catalog), Default::default());
+    let provider = PaimonCatalogProvider::new(Arc::new(catalog));
 
     let ctx = SessionContext::new();
     ctx.register_catalog("paimon", Arc::new(provider));
@@ -525,7 +525,7 @@ async fn test_query_via_catalog_provider() {
 #[tokio::test]
 async fn test_missing_database_returns_no_schema() {
     let catalog = create_catalog();
-    let provider = PaimonCatalogProvider::new(Arc::new(catalog), Default::default());
+    let provider = PaimonCatalogProvider::new(Arc::new(catalog));
 
     assert!(
         provider.schema("definitely_missing_database").is_none(),
@@ -543,10 +543,7 @@ async fn create_time_travel_context() -> SessionContext {
     let ctx = SessionContext::new_with_config(config);
     ctx.register_catalog(
         "paimon",
-        Arc::new(PaimonCatalogProvider::new(
-            Arc::new(catalog),
-            Default::default(),
-        )),
+        Arc::new(PaimonCatalogProvider::new(Arc::new(catalog))),
     );
     ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
         .expect("Failed to register relation planner");
@@ -966,10 +963,7 @@ mod fulltext_tests {
         let ctx = SessionContext::new();
         ctx.register_catalog(
             "paimon",
-            Arc::new(PaimonCatalogProvider::new(
-                Arc::clone(&catalog),
-                Default::default(),
-            )),
+            Arc::new(PaimonCatalogProvider::new(Arc::clone(&catalog))),
         );
         register_full_text_search(&ctx, catalog, "default");
         (ctx, tmp)

--- a/crates/integrations/datafusion/tests/sql_handler_tests.rs
+++ b/crates/integrations/datafusion/tests/sql_handler_tests.rs
@@ -24,9 +24,7 @@ use datafusion::prelude::SessionContext;
 use paimon::catalog::Identifier;
 use paimon::spec::{ArrayType, BlobType, DataType, IntType, MapType, VarCharType};
 use paimon::{Catalog, CatalogOptions, FileSystemCatalog, Options};
-use paimon_datafusion::{
-    DynamicOptions, PaimonCatalogProvider, PaimonRelationPlanner, PaimonSqlHandler,
-};
+use paimon_datafusion::{PaimonCatalogProvider, PaimonSqlHandler};
 use tempfile::TempDir;
 
 fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
@@ -39,18 +37,8 @@ fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
 }
 
 fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
-    let dynamic_options: DynamicOptions = Default::default();
     let ctx = SessionContext::new();
-    ctx.register_catalog(
-        "paimon",
-        Arc::new(PaimonCatalogProvider::new(
-            catalog.clone(),
-            dynamic_options.clone(),
-        )),
-    );
-    ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))
-        .expect("Failed to register relation planner");
-    PaimonSqlHandler::new(ctx, catalog, "paimon", dynamic_options)
+    PaimonSqlHandler::new(ctx, catalog, "paimon")
 }
 
 // ======================= CREATE / DROP SCHEMA =======================
@@ -97,7 +85,7 @@ async fn test_drop_schema() {
 #[tokio::test]
 async fn test_schema_names_via_catalog_provider() {
     let (_tmp, catalog) = create_test_env();
-    let provider = PaimonCatalogProvider::new(catalog.clone(), Default::default());
+    let provider = PaimonCatalogProvider::new(catalog.clone());
 
     catalog
         .create_database("db_a", false, Default::default())

--- a/crates/integrations/datafusion/tests/sql_handler_tests.rs
+++ b/crates/integrations/datafusion/tests/sql_handler_tests.rs
@@ -38,7 +38,7 @@ fn create_test_env() -> (TempDir, Arc<FileSystemCatalog>) {
 
 fn create_handler(catalog: Arc<FileSystemCatalog>) -> PaimonSqlHandler {
     let ctx = SessionContext::new();
-    PaimonSqlHandler::new(ctx, catalog, "paimon")
+    PaimonSqlHandler::new(ctx, catalog, "paimon").unwrap()
 }
 
 // ======================= CREATE / DROP SCHEMA =======================

--- a/crates/integrations/datafusion/tests/system_tables.rs
+++ b/crates/integrations/datafusion/tests/system_tables.rs
@@ -56,10 +56,7 @@ async fn create_context() -> (SessionContext, Arc<dyn Catalog>, tempfile::TempDi
     let ctx = SessionContext::new();
     ctx.register_catalog(
         "paimon",
-        Arc::new(PaimonCatalogProvider::new(
-            Arc::clone(&catalog),
-            Default::default(),
-        )),
+        Arc::new(PaimonCatalogProvider::new(Arc::clone(&catalog))),
     );
     (ctx, catalog, tmp)
 }

--- a/crates/paimon/src/table/bucket_assigner.rs
+++ b/crates/paimon/src/table/bucket_assigner.rs
@@ -97,4 +97,10 @@ impl BucketAssignerEnum {
             Self::CrossPartition(a) => a.prepare_commit_index(file_io, index_dir).await,
         }
     }
+
+    pub fn set_overwrite(&mut self, is_overwrite: bool) {
+        if let Self::Dynamic(a) = self {
+            a.set_overwrite(is_overwrite);
+        }
+    }
 }

--- a/crates/paimon/src/table/bucket_assigner_dynamic.rs
+++ b/crates/paimon/src/table/bucket_assigner_dynamic.rs
@@ -353,6 +353,10 @@ impl DynamicBucketAssigner {
         }
     }
 
+    pub fn set_overwrite(&mut self, is_overwrite: bool) {
+        self.is_overwrite = is_overwrite;
+    }
+
     /// Load all index manifest entries from the latest snapshot (cached).
     /// Overwrite mode skips loading — old index is irrelevant.
     async fn ensure_index_entries_loaded(&mut self) -> Result<()> {

--- a/crates/paimon/src/table/table_commit.rs
+++ b/crates/paimon/src/table/table_commit.rs
@@ -106,26 +106,75 @@ impl TableCommit {
         .await
     }
 
-    /// Overwrite with dynamic partition detection.
+    /// Overwrite partitions with new data.
     ///
-    /// Extracts the set of partitions touched by `commit_messages` and overwrites
-    /// only those partitions. For unpartitioned tables this is a full table overwrite.
-    pub async fn overwrite(&self, commit_messages: Vec<CommitMessage>) -> Result<()> {
-        if commit_messages.is_empty() {
+    /// When `static_partitions` is `None`, extracts the set of partitions
+    /// touched by `commit_messages` and overwrites only those (dynamic partition overwrite).
+    /// When `static_partitions` is `Some`, uses the caller-provided partition spec
+    /// to determine which partitions to replace (static partition overwrite).
+    /// A partial spec (not all partition keys specified) uses predicate-based filtering
+    /// so that all matching partitions are overwritten.
+    /// For unpartitioned tables this is a full table overwrite.
+    pub async fn overwrite(
+        &self,
+        commit_messages: Vec<CommitMessage>,
+        static_partitions: Option<HashMap<String, Option<Datum>>>,
+    ) -> Result<()> {
+        if commit_messages.is_empty() && static_partitions.is_none() {
             return Ok(());
         }
 
         let new_entries = self.messages_to_entries(&commit_messages);
         let new_index_entries = self.messages_to_index_entries(&commit_messages);
-        let partition_filter = self.build_dynamic_partition_filter(&commit_messages)?;
-        let overwrite_partitions = self.collect_overwrite_partitions(&commit_messages);
+
+        let partition_filter = if let Some(sp) = static_partitions {
+            let partition_keys = self.table.schema().partition_keys();
+            let partition_fields = self.table.schema().partition_fields();
+            let is_full_spec = partition_keys.iter().all(|k| sp.contains_key(k));
+
+            if is_full_spec {
+                let bytes = self.partitions_to_bytes(&[sp]);
+                Some(PartitionFilter::from_partition_set(
+                    bytes,
+                    &partition_fields,
+                )?)
+            } else {
+                Some(self.build_static_partition_predicate(&sp, &partition_fields)?)
+            }
+        } else {
+            self.build_dynamic_partition_filter(&commit_messages)?
+        };
+
         self.try_commit(CommitEntriesPlan::Overwrite {
             partition_filter,
             new_entries,
             new_index_entries,
-            overwrite_partitions: Some(overwrite_partitions),
         })
         .await
+    }
+
+    /// Build a predicate-based partition filter from a partial static partition spec.
+    fn build_static_partition_predicate(
+        &self,
+        static_partitions: &HashMap<String, Option<Datum>>,
+        partition_fields: &[crate::spec::DataField],
+    ) -> Result<PartitionFilter> {
+        use crate::spec::PredicateBuilder;
+        let pb = PredicateBuilder::new(partition_fields);
+        let mut predicates = Vec::new();
+        for (key, value) in static_partitions {
+            let pred = match value {
+                Some(datum) => pb.equal(key, datum.clone())?,
+                None => pb.is_null(key)?,
+            };
+            predicates.push(pred);
+        }
+        let combined = if predicates.len() == 1 {
+            predicates.into_iter().next().unwrap()
+        } else {
+            crate::spec::Predicate::and(predicates)
+        };
+        Ok(PartitionFilter::from_predicate(combined, partition_fields))
     }
 
     /// Build a dynamic partition filter from the partitions present in commit messages.
@@ -176,17 +225,6 @@ impl TableCommit {
         )?))
     }
 
-    /// Collect the set of unique partition bytes from commit messages.
-    ///
-    /// For unpartitioned tables, returns an empty set (meaning full table overwrite).
-    fn collect_overwrite_partitions(&self, commit_messages: &[CommitMessage]) -> HashSet<Vec<u8>> {
-        let mut partitions = HashSet::new();
-        for msg in commit_messages {
-            partitions.insert(msg.partition.clone());
-        }
-        partitions
-    }
-
     /// Drop specific partitions (OVERWRITE with only deletes).
     pub async fn truncate_partitions(
         &self,
@@ -196,10 +234,27 @@ impl TableCommit {
             return Ok(());
         }
 
-        // Build partition bytes for index cleanup
+        let partition_fields = self.table.schema().partition_fields();
+        let partition_filter = PartitionFilter::from_partition_set(
+            self.partitions_to_bytes(&partitions),
+            &partition_fields,
+        )?;
+
+        self.try_commit(CommitEntriesPlan::Overwrite {
+            partition_filter: Some(partition_filter),
+            new_entries: vec![],
+            new_index_entries: vec![],
+        })
+        .await
+    }
+
+    fn partitions_to_bytes(
+        &self,
+        partitions: &[HashMap<String, Option<Datum>>],
+    ) -> HashSet<Vec<u8>> {
         let partition_fields = self.table.schema().partition_fields();
         let partition_keys = self.table.schema().partition_keys();
-        let overwrite_partitions: HashSet<Vec<u8>> = partitions
+        partitions
             .iter()
             .map(|p| {
                 let owned_datums: Vec<(Option<Datum>, DataType)> = partition_keys
@@ -215,18 +270,7 @@ impl TableCommit {
                     owned_datums.iter().map(|(d, t)| (d, t)).collect();
                 datums_to_binary_row(&refs)
             })
-            .collect();
-
-        let partition_filter =
-            PartitionFilter::from_partition_set(overwrite_partitions.clone(), &partition_fields)?;
-
-        self.try_commit(CommitEntriesPlan::Overwrite {
-            partition_filter: Some(partition_filter),
-            new_entries: vec![],
-            new_index_entries: vec![],
-            overwrite_partitions: Some(overwrite_partitions),
-        })
-        .await
+            .collect()
     }
 
     /// Truncate the entire table (OVERWRITE with no filter, only deletes).
@@ -235,7 +279,6 @@ impl TableCommit {
             partition_filter: None,
             new_entries: vec![],
             new_index_entries: vec![],
-            overwrite_partitions: Some(HashSet::new()),
         })
         .await
     }
@@ -536,7 +579,6 @@ impl TableCommit {
                 partition_filter,
                 new_entries,
                 new_index_entries,
-                overwrite_partitions,
             } => {
                 let entries = self
                     .generate_overwrite_entries(
@@ -548,11 +590,10 @@ impl TableCommit {
 
                 let mut all =
                     Self::read_prev_index_entries(file_io, &manifest_dir, latest_snapshot).await?;
-                if let Some(partitions) = overwrite_partitions {
-                    if partitions.is_empty() {
-                        all.clear();
-                    } else {
-                        all.retain(|e| !partitions.contains(&e.partition));
+                match partition_filter.as_ref() {
+                    None => all.clear(),
+                    Some(filter) => {
+                        all.retain(|e| !filter.matches_entry(&e.partition).unwrap_or(false));
                     }
                 }
                 all.extend_from_slice(new_index_entries);
@@ -1011,7 +1052,6 @@ enum CommitEntriesPlan {
         partition_filter: Option<PartitionFilter>,
         new_entries: Vec<ManifestEntry>,
         new_index_entries: Vec<IndexManifestEntry>,
-        overwrite_partitions: Option<HashSet<Vec<u8>>>,
     },
 }
 
@@ -1301,11 +1341,14 @@ mod tests {
 
         // Overwrite partition "a" with new data (dynamic partition overwrite)
         commit
-            .overwrite(vec![CommitMessage::new(
-                partition_bytes("a"),
-                0,
-                vec![test_data_file("data-a2.parquet", 50)],
-            )])
+            .overwrite(
+                vec![CommitMessage::new(
+                    partition_bytes("a"),
+                    0,
+                    vec![test_data_file("data-a2.parquet", 50)],
+                )],
+                None,
+            )
             .await
             .unwrap();
 
@@ -1549,11 +1592,14 @@ mod tests {
 
         // Overwrite NULL partition only — should NOT affect "a" or "b"
         commit
-            .overwrite(vec![CommitMessage::new(
-                null_partition_bytes(),
-                0,
-                vec![test_data_file("data-null2.parquet", 50)],
-            )])
+            .overwrite(
+                vec![CommitMessage::new(
+                    null_partition_bytes(),
+                    0,
+                    vec![test_data_file("data-null2.parquet", 50)],
+                )],
+                None,
+            )
             .await
             .unwrap();
 

--- a/crates/paimon/src/table/table_commit.rs
+++ b/crates/paimon/src/table/table_commit.rs
@@ -115,6 +115,9 @@ impl TableCommit {
     /// A partial spec (not all partition keys specified) uses predicate-based filtering
     /// so that all matching partitions are overwritten.
     /// For unpartitioned tables this is a full table overwrite.
+    ///
+    /// When `static_partitions` is `Some` but `commit_messages` is empty,
+    /// the specified partitions are truncated (all existing data removed, nothing written).
     pub async fn overwrite(
         &self,
         commit_messages: Vec<CommitMessage>,
@@ -593,7 +596,13 @@ impl TableCommit {
                 match partition_filter.as_ref() {
                     None => all.clear(),
                     Some(filter) => {
-                        all.retain(|e| !filter.matches_entry(&e.partition).unwrap_or(false));
+                        let mut retained = Vec::new();
+                        for e in all {
+                            if !filter.matches_entry(&e.partition)? {
+                                retained.push(e);
+                            }
+                        }
+                        all = retained;
                     }
                 }
                 all.extend_from_slice(new_index_entries);

--- a/crates/paimon/src/table/table_commit.rs
+++ b/crates/paimon/src/table/table_commit.rs
@@ -166,6 +166,8 @@ impl TableCommit {
         let pb = PredicateBuilder::new(partition_fields);
         let mut predicates = Vec::new();
         for (key, value) in static_partitions {
+            // Currently all values from parse_static_partitions are Some;
+            // None would represent an explicit NULL partition value.
             let pred = match value {
                 Some(datum) => pb.equal(key, datum.clone())?,
                 None => pb.is_null(key)?,

--- a/crates/paimon/src/table/table_write.rs
+++ b/crates/paimon/src/table/table_write.rs
@@ -109,11 +109,8 @@ pub struct TableWrite {
 }
 
 impl TableWrite {
-    pub(crate) fn new(
-        table: &Table,
-        commit_user: String,
-        is_overwrite: bool,
-    ) -> crate::Result<Self> {
+    pub(crate) fn new(table: &Table, commit_user: String) -> crate::Result<Self> {
+        let is_overwrite = false;
         let schema = table.schema();
         let core_options = CoreOptions::new(schema.options());
         let blob_descriptor_fields = core_options.blob_descriptor_fields();
@@ -340,6 +337,15 @@ impl TableWrite {
             partitions,
             &partition_fields,
         )?))
+    }
+
+    /// Mark this write as an overwrite operation.
+    ///
+    /// Overwrite skips restoring sequence numbers and bucket index loading
+    /// since old data will be fully replaced at commit time.
+    pub fn with_overwrite(mut self) -> Self {
+        self.is_overwrite = true;
+        self
     }
 
     /// Write an Arrow RecordBatch. Rows are routed to the correct partition and bucket.
@@ -791,7 +797,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         let batch = make_batch(vec![1, 2, 3], vec![10, 20, 30]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -822,7 +828,7 @@ mod tests {
             None,
         );
 
-        assert!(TableWrite::new(&table, "test-user".to_string(), false).is_ok());
+        assert!(TableWrite::new(&table, "test-user".to_string()).is_ok());
     }
 
     #[tokio::test]
@@ -839,7 +845,7 @@ mod tests {
             None,
         );
 
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         let schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new("id", ArrowDataType::Int32, false),
@@ -898,7 +904,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_partitioned_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         let batch = make_partitioned_batch(vec!["a", "b", "a"], vec![1, 2, 3]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -929,7 +935,7 @@ mod tests {
         let file_io = test_file_io();
         let table_path = "memory:/test_table_write_empty";
         let table = test_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         let batch = make_batch(vec![], vec![]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -945,7 +951,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         // First write + prepare_commit
         table_write
@@ -977,7 +983,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         table_write
             .write_arrow_batch(&make_batch(vec![1, 2], vec![10, 20]))
@@ -1041,7 +1047,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_bucketed_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         // Row with NULL bucket key should not panic
         let batch = make_nullable_id_batch(vec![None, Some(1), None], vec![10, 20, 30]);
@@ -1063,7 +1069,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_bucketed_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         // Two NULLs should land in the same bucket
         let batch = make_nullable_id_batch(vec![None, None], vec![10, 20]);
@@ -1091,7 +1097,7 @@ mod tests {
 
         // Compute bucket for NULL key
         let fields = table.schema().fields().to_vec();
-        let mut tw = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut tw = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         let batch_null = make_nullable_id_batch(vec![None], vec![10]);
         let out_null = tw
@@ -1162,7 +1168,7 @@ mod tests {
                 None,
             );
 
-            let mut tw = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+            let mut tw = TableWrite::new(&table, "test-user".to_string()).unwrap();
             let fields = table.schema().fields().to_vec();
 
             // Build a batch: d=NULL, ltz=NULL, ntz=NULL, k=1
@@ -1241,7 +1247,7 @@ mod tests {
             None,
         );
 
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         // Write multiple batches — each should roll to a new file
         table_write
@@ -1294,7 +1300,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         let batch = make_batch(vec![3, 1, 2], vec![30, 10, 20]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -1329,7 +1335,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         // Write unsorted data
         let batch = make_batch(vec![5, 2, 4, 1, 3], vec![50, 20, 40, 10, 30]);
@@ -1387,7 +1393,7 @@ mod tests {
         let table = test_pk_table(&file_io, table_path);
 
         // First commit: id=1,2,3
-        let mut tw1 = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut tw1 = TableWrite::new(&table, "test-user".to_string()).unwrap();
         tw1.write_arrow_batch(&make_batch(vec![1, 2, 3], vec![10, 20, 30]))
             .await
             .unwrap();
@@ -1396,7 +1402,7 @@ mod tests {
         commit.commit(msgs1).await.unwrap();
 
         // Second commit: id=2,3,4 with updated values, higher sequence numbers
-        let mut tw2 = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut tw2 = TableWrite::new(&table, "test-user".to_string()).unwrap();
         tw2.write_arrow_batch(&make_batch(vec![2, 3, 4], vec![200, 300, 400]))
             .await
             .unwrap();
@@ -1449,7 +1455,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         let batch = make_batch(vec![1, 2], vec![10, 20]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -1533,7 +1539,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_postpone_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         let batch = make_batch(vec![3, 1, 2], vec![30, 10, 20]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -1559,7 +1565,7 @@ mod tests {
         let file_io = test_file_io();
         let table_path = "memory:/test_postpone_empty";
         let table = test_postpone_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         let batch = make_batch(vec![], vec![]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -1575,7 +1581,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_postpone_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         table_write
             .write_arrow_batch(&make_batch(vec![1, 2], vec![10, 20]))
@@ -1601,7 +1607,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_postpone_partitioned_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         let batch =
             make_partitioned_batch_3col(vec!["a", "b", "a"], vec![1, 2, 3], vec![10, 20, 30]);
@@ -1639,7 +1645,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_postpone_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         // First write + prepare_commit
         table_write
@@ -1671,7 +1677,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_postpone_pk_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "my-commit-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "my-commit-user".to_string()).unwrap();
 
         let batch = make_batch(vec![3, 1, 2], vec![30, 10, 20]);
         table_write.write_arrow_batch(&batch).await.unwrap();
@@ -1765,7 +1771,7 @@ mod tests {
 
         // Cross-partition: PK=id, partition=pt, bucket=-1
         let table = test_cross_partition_table(&file_io, table_path);
-        let tw = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let tw = TableWrite::new(&table, "test-user".to_string()).unwrap();
         assert!(matches!(
             tw.bucket_assigner,
             BucketAssignerEnum::CrossPartition(_)
@@ -1787,7 +1793,7 @@ mod tests {
             TableSchema::new(0, &schema),
             None,
         );
-        let tw2 = TableWrite::new(&table2, "test-user".to_string(), false).unwrap();
+        let tw2 = TableWrite::new(&table2, "test-user".to_string()).unwrap();
         assert!(matches!(
             tw2.bucket_assigner,
             BucketAssignerEnum::Dynamic(_)
@@ -1801,7 +1807,7 @@ mod tests {
         setup_dirs(&file_io, table_path).await;
 
         let table = test_cross_partition_table(&file_io, table_path);
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
 
         // All rows in same partition — no cross-partition deletes
         let batch =
@@ -1829,7 +1835,7 @@ mod tests {
         let table = test_cross_partition_table(&file_io, table_path);
 
         // First commit: id=1 in partition "a"
-        let mut tw1 = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut tw1 = TableWrite::new(&table, "test-user".to_string()).unwrap();
         let batch1 = make_partitioned_batch_3col(vec!["a"], vec![1], vec![10]);
         tw1.write_arrow_batch(&batch1).await.unwrap();
         let msgs1 = tw1.prepare_commit().await.unwrap();
@@ -1837,7 +1843,7 @@ mod tests {
         commit.commit(msgs1).await.unwrap();
 
         // Second commit: id=1 moves to partition "b"
-        let mut tw2 = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut tw2 = TableWrite::new(&table, "test-user".to_string()).unwrap();
         let batch2 = make_partitioned_batch_3col(vec!["b"], vec![1], vec![20]);
         tw2.write_arrow_batch(&batch2).await.unwrap();
         let msgs2 = tw2.prepare_commit().await.unwrap();

--- a/crates/paimon/src/table/table_write.rs
+++ b/crates/paimon/src/table/table_write.rs
@@ -345,6 +345,7 @@ impl TableWrite {
     /// since old data will be fully replaced at commit time.
     pub fn with_overwrite(mut self) -> Self {
         self.is_overwrite = true;
+        self.bucket_assigner.set_overwrite(true);
         self
     }
 

--- a/crates/paimon/src/table/write_builder.rs
+++ b/crates/paimon/src/table/write_builder.rs
@@ -29,7 +29,6 @@ use uuid::Uuid;
 pub struct WriteBuilder<'a> {
     table: &'a Table,
     commit_user: String,
-    is_overwrite: bool,
 }
 
 impl<'a> WriteBuilder<'a> {
@@ -37,17 +36,7 @@ impl<'a> WriteBuilder<'a> {
         Self {
             table,
             commit_user: Uuid::new_v4().to_string(),
-            is_overwrite: false,
         }
-    }
-
-    /// Mark this write as an overwrite operation.
-    ///
-    /// Overwrite skips restoring sequence numbers and bucket index loading
-    /// since old data will be fully replaced at commit time.
-    pub fn with_overwrite(mut self) -> Self {
-        self.is_overwrite = true;
-        self
     }
 
     /// Create a new TableCommit for committing write results.
@@ -60,6 +49,6 @@ impl<'a> WriteBuilder<'a> {
     /// For primary-key tables, sequence numbers are lazily scanned per partition
     /// when the first writer for that partition is created.
     pub fn new_write(&self) -> crate::Result<TableWrite> {
-        TableWrite::new(self.table, self.commit_user.clone(), self.is_overwrite)
+        TableWrite::new(self.table, self.commit_user.clone())
     }
 }

--- a/docs/src/datafusion.md
+++ b/docs/src/datafusion.md
@@ -41,14 +41,17 @@ use datafusion::prelude::SessionContext;
 use paimon::{CatalogOptions, FileSystemCatalog, Options};
 use paimon_datafusion::PaimonSqlHandler;
 
-let mut options = Options::new();
-options.set(CatalogOptions::WAREHOUSE, "file:///tmp/paimon-warehouse");
-let catalog = Arc::new(FileSystemCatalog::new(options)?);
+async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    let mut options = Options::new();
+    options.set(CatalogOptions::WAREHOUSE, "file:///tmp/paimon-warehouse");
+    let catalog = Arc::new(FileSystemCatalog::new(options)?);
 
-let ctx = SessionContext::new();
-let handler = PaimonSqlHandler::new(ctx, catalog, "paimon")?;
-let df = handler.sql("SELECT * FROM paimon.default.my_table").await?;
-df.show().await?;
+    let ctx = SessionContext::new();
+    let handler = PaimonSqlHandler::new(ctx, catalog, "paimon")?;
+    let df = handler.sql("SELECT * FROM paimon.default.my_table").await?;
+    df.show().await?;
+    Ok(())
+}
 ```
 
 `PaimonSqlHandler::new` automatically registers the Paimon catalog provider and relation planner on the session context. It also manages session-scoped dynamic options internally for `SET`/`RESET` support.

--- a/docs/src/datafusion.md
+++ b/docs/src/datafusion.md
@@ -38,7 +38,12 @@ Register an entire Paimon catalog so all databases and tables are accessible via
 ```rust
 use std::sync::Arc;
 use datafusion::prelude::SessionContext;
+use paimon::{CatalogOptions, FileSystemCatalog, Options};
 use paimon_datafusion::PaimonSqlHandler;
+
+let mut options = Options::new();
+options.set(CatalogOptions::WAREHOUSE, "file:///tmp/paimon-warehouse");
+let catalog = Arc::new(FileSystemCatalog::new(options)?);
 
 let ctx = SessionContext::new();
 let handler = PaimonSqlHandler::new(ctx, catalog, "paimon")?;

--- a/docs/src/datafusion.md
+++ b/docs/src/datafusion.md
@@ -19,7 +19,7 @@ under the License.
 
 # DataFusion Integration
 
-[Apache DataFusion](https://datafusion.apache.org/) is a fast, extensible query engine for building data-centric systems in Rust. The `paimon-datafusion` crate provides a read-only integration that lets you query Paimon tables using SQL.
+[Apache DataFusion](https://datafusion.apache.org/) is a fast, extensible query engine for building data-centric systems in Rust. The `paimon-datafusion` crate provides a full SQL integration that lets you create, query, and modify Paimon tables.
 
 ## Setup
 
@@ -31,39 +31,300 @@ datafusion = "53"
 tokio = { version = "1", features = ["full"] }
 ```
 
-## Registering Tables
+## Registering Catalog
 
-Register an entire Paimon catalog so all databases and tables are accessible via `catalog.database.table` syntax:
+Register an entire Paimon catalog so all databases and tables are accessible via `paimon.database.table` syntax:
 
 ```rust
 use std::sync::Arc;
 use datafusion::prelude::SessionContext;
-use paimon_datafusion::PaimonCatalogProvider;
+use paimon_datafusion::PaimonSqlHandler;
 
 let ctx = SessionContext::new();
-ctx.register_catalog("paimon", Arc::new(PaimonCatalogProvider::new(Arc::new(catalog))));
-
-let df = ctx.sql("SELECT * FROM paimon.default.my_table").await?;
+let handler = PaimonSqlHandler::new(ctx, catalog, "paimon");
+let df = handler.sql("SELECT * FROM paimon.default.my_table").await?;
 df.show().await?;
 ```
 
+`PaimonSqlHandler::new` automatically registers the Paimon catalog provider and relation planner on the session context. It also manages session-scoped dynamic options internally for `SET`/`RESET` support.
+
+## Data Types
+
+The following SQL data types are supported in CREATE TABLE and mapped to their corresponding Paimon types:
+
+| SQL Type | Paimon Type | Notes |
+|---|---|---|
+| `BOOLEAN` | BooleanType | |
+| `TINYINT` | TinyIntType | |
+| `SMALLINT` | SmallIntType | |
+| `INT` / `INTEGER` | IntType | |
+| `BIGINT` | BigIntType | |
+| `FLOAT` / `REAL` | FloatType | |
+| `DOUBLE` / `DOUBLE PRECISION` | DoubleType | |
+| `VARCHAR` / `TEXT` / `STRING` / `CHAR` | VarCharType | |
+| `BINARY` / `VARBINARY` / `BYTEA` | VarBinaryType | |
+| `BLOB` | BlobType | Binary large object |
+| `DATE` | DateType | |
+| `TIMESTAMP[(p)]` | TimestampType | Precision p: 0/3/6/9, default 3 |
+| `TIMESTAMP WITH TIME ZONE` | LocalZonedTimestampType | |
+| `DECIMAL(p, s)` | DecimalType | |
+| `ARRAY<element>` | ArrayType | e.g. `ARRAY<INT>` |
+| `MAP(key, value)` | MapType | e.g. `MAP(STRING, INT)` |
+| `STRUCT<field TYPE, ...>` | RowType | e.g. `STRUCT<city STRING, zip INT>` |
+
+## DDL
+
+### CREATE SCHEMA / DROP SCHEMA
+
+```sql
+CREATE SCHEMA paimon.my_db;
+DROP SCHEMA paimon.my_db CASCADE;
+```
+
+### CREATE TABLE
+
+```sql
+CREATE TABLE paimon.my_db.users (
+    id INT NOT NULL,
+    name STRING,
+    age INT,
+    PRIMARY KEY (id)
+) WITH ('bucket' = '4');
+```
+
+`IF NOT EXISTS` is supported:
+
+```sql
+CREATE TABLE IF NOT EXISTS paimon.my_db.users (
+    id INT NOT NULL
+);
+```
+
+Unsupported syntax (will return an error):
+- `CREATE EXTERNAL TABLE`
+- `LOCATION`
+- `CREATE TABLE AS SELECT`
+
+### Partitioned Tables
+
+Use `PARTITIONED BY` to specify partition columns. Partition columns must already be declared in the column definitions and must not include a type:
+
+```sql
+CREATE TABLE paimon.my_db.events (
+    id INT NOT NULL,
+    name STRING,
+    dt STRING,
+    PRIMARY KEY (id, dt)
+) PARTITIONED BY (dt)
+WITH ('bucket' = '2');
+```
+
+Invalid usage (will return an error):
+
+```sql
+-- Partition columns must not specify a type
+CREATE TABLE paimon.my_db.events (
+    id INT NOT NULL,
+    dt STRING
+) PARTITIONED BY (dt STRING);
+```
+
+### Complex Types
+
+```sql
+CREATE TABLE paimon.my_db.complex_types (
+    id INT NOT NULL,
+    tags ARRAY<STRING>,
+    props MAP(STRING, INT),
+    address STRUCT<city STRING, zip INT>,
+    PRIMARY KEY (id)
+);
+```
+
+### DROP TABLE
+
+```sql
+DROP TABLE paimon.my_db.users;
+```
+
+### ALTER TABLE
+
+```sql
+-- Add a column
+ALTER TABLE paimon.my_db.users ADD COLUMN email STRING;
+
+-- Drop a column
+ALTER TABLE paimon.my_db.users DROP COLUMN age;
+
+-- Rename a column
+ALTER TABLE paimon.my_db.users RENAME COLUMN name TO username;
+
+-- Rename a table
+ALTER TABLE paimon.my_db.users RENAME TO members;
+
+-- Set table properties
+ALTER TABLE paimon.my_db.users SET TBLPROPERTIES('data-evolution.enabled' = 'true');
+```
+
+`IF EXISTS` is supported:
+
+```sql
+ALTER TABLE IF EXISTS paimon.my_db.users ADD COLUMN age INT;
+```
+
+## DML
+
+### INSERT INTO
+
+```sql
+INSERT INTO paimon.my_db.users VALUES (1, 'alice'), (2, 'bob'), (3, 'carol');
+```
+
+`INSERT INTO ... SELECT ...` is also supported:
+
+```sql
+INSERT INTO paimon.my_db.users SELECT * FROM source_table;
+```
+
+For primary-key tables, records with duplicate keys are deduplicated according to the merge engine (default: Deduplicate engine, where the last written value wins).
+
+### INSERT OVERWRITE
+
+For partitioned tables, `INSERT OVERWRITE` replaces only the affected partitions. For unpartitioned tables, it replaces the entire table:
+
+```sql
+-- Dynamic partition overwrite: overwrites only the dt='2024-01-01' partition
+INSERT OVERWRITE paimon.my_db.events VALUES ('2024-01-01', 10, 'new_alice');
+```
+
+Hive-style static partition overwrite is also supported via the `PARTITION` clause. The source query provides only non-partition columns, and partition values are specified explicitly:
+
+```sql
+-- Static partition overwrite: explicitly specify the target partition
+INSERT OVERWRITE paimon.my_db.events PARTITION (dt = '2024-01-01')
+VALUES (10, 'new_alice'), (20, 'new_bob');
+
+-- With a SELECT source
+INSERT OVERWRITE paimon.my_db.events PARTITION (dt = '2024-01-01')
+SELECT id, name FROM source_table;
+```
+
+For multi-level partitioned tables, you can specify a subset of partition columns. Unspecified partition columns are read from the source query (dynamic partition). All sub-partitions under the specified partition are replaced:
+
+```sql
+-- Only dt is static; all data under dt='2024-01-01' is replaced.
+-- region comes from the source data.
+INSERT OVERWRITE paimon.my_db.events PARTITION (dt = '2024-01-01')
+VALUES ('us', 10, 'alice'), ('eu', 20, 'bob');
+```
+
+### UPDATE
+
+For append-only tables (no primary key), updates are executed using Copy-on-Write:
+
+```sql
+UPDATE paimon.my_db.t SET name = 'a_new' WHERE id = 1;
+```
+
+For primary-key tables, `data-evolution.enabled` must be enabled to perform UPDATE.
+
+### DELETE
+
+For append-only tables, deletes are executed using Copy-on-Write:
+
+```sql
+DELETE FROM paimon.my_db.t WHERE name = 'b';
+```
+
+### MERGE INTO
+
+Standard SQL MERGE INTO syntax is supported, allowing INSERT, UPDATE, and DELETE in a single statement:
+
+```sql
+MERGE INTO paimon.my_db.target
+USING source ON target.a = source.a
+WHEN MATCHED THEN UPDATE SET a = source.a, b = source.b, c = source.c
+WHEN NOT MATCHED THEN INSERT (a, b, c) VALUES (source.a, source.b, source.c);
+```
+
+Delete matched rows only:
+
+```sql
+MERGE INTO paimon.my_db.target
+USING source ON target.a = source.a
+WHEN MATCHED THEN DELETE;
+```
+
+UPDATE + INSERT combination:
+
+```sql
+MERGE INTO paimon.my_db.target
+USING source ON target.a = source.a
+WHEN MATCHED THEN UPDATE SET b = source.b
+WHEN NOT MATCHED THEN INSERT (a, b, c) VALUES (source.a, source.b, source.c);
+```
+
+The source can also be a subquery:
+
+```sql
+MERGE INTO paimon.my_db.target
+USING (SELECT * FROM other_table WHERE active = true) AS source
+ON target.id = source.id
+WHEN MATCHED THEN UPDATE SET name = source.name;
+```
+
+For data-evolution tables, MERGE INTO uses the `_ROW_ID` virtual column for row-level tracking. For append-only tables, it uses Copy-on-Write file rewriting.
+
+## Queries
+
+### Basic Queries
+
+All DataFusion query capabilities are supported (JOINs, aggregations, subqueries, CTEs, etc.):
+
+```sql
+SELECT id, name FROM paimon.my_db.users WHERE id > 10 ORDER BY id LIMIT 100;
+```
+
+### Column Projection
+
+Only the required columns are read, reducing I/O:
+
+```sql
+SELECT name FROM paimon.my_db.users;
+```
+
+### Filter Pushdown
+
+The following filter predicates are pushed down to the Paimon storage layer:
+
+- Comparison: `=`, `!=`, `<`, `<=`, `>`, `>=`
+- Logical: `AND`, `OR`
+- Null checks: `IS NULL`, `IS NOT NULL`
+- Range: `IN`, `NOT IN`, `BETWEEN`
+
+Filters on partition columns enable exact partition pruning, avoiding scans of irrelevant data.
+
+### COUNT(*) Pushdown
+
+When the following conditions are met, `COUNT(*)` retrieves exact row counts directly from split metadata without a full table scan:
+
+- All splits have a known `merged_row_count`
+- No LIMIT clause
+- Filter predicates only involve partition columns (Exact level)
+
 ## Time Travel
 
-Paimon supports time travel queries to read historical data. In DataFusion, this is done via the `VERSION AS OF` and `TIMESTAMP AS OF` clauses.
+Paimon supports time travel queries to read historical data.
 
 ### By Snapshot ID
 
-Read data from a specific snapshot by passing an integer:
-
 ```sql
-SELECT * FROM paimon.default.my_table VERSION AS OF 1
+SELECT * FROM paimon.default.my_table VERSION AS OF 1;
 ```
-
-This sets the `scan.version` option. At scan time, the value is resolved as a snapshot ID.
 
 ### By Tag Name
 
-Read data from a named tag. Since `VERSION AS OF` in SQL only accepts numeric values, tag-based time travel is done via the `scan.version` table option:
+`VERSION AS OF` in SQL only accepts numeric values. Tag-based time travel is done via the `scan.version` table option:
 
 ```rust
 let table = table.copy_with_options(HashMap::from([
@@ -71,34 +332,164 @@ let table = table.copy_with_options(HashMap::from([
 ]));
 ```
 
-At scan time, the version value is resolved by first checking if a tag with that name exists, then trying to parse it as a snapshot ID. If neither matches, an error is returned.
+Resolution order: first checks if a tag with that name exists, then tries to parse it as a snapshot ID.
 
 ### By Timestamp
 
-Read data as of a specific point in time by passing a timestamp string in `YYYY-MM-DD HH:MM:SS` format:
+Read data as of a specific point in time. The format is `YYYY-MM-DD HH:MM:SS`:
 
 ```sql
-SELECT * FROM paimon.default.my_table TIMESTAMP AS OF '2024-01-01 00:00:00'
+SELECT * FROM paimon.default.my_table TIMESTAMP AS OF '2024-01-01 00:00:00';
 ```
 
 This finds the latest snapshot whose commit time is less than or equal to the given timestamp. The timestamp is interpreted in the local timezone.
 
 ### Enabling Time Travel Syntax
 
-DataFusion requires the Databricks SQL dialect to parse `VERSION AS OF` and `TIMESTAMP AS OF`. You also need to register the `PaimonRelationPlanner`:
+DataFusion requires the Databricks SQL dialect to parse `VERSION AS OF` and `TIMESTAMP AS OF`:
 
 ```rust
-use std::sync::Arc;
 use datafusion::prelude::{SessionConfig, SessionContext};
-use paimon_datafusion::{PaimonCatalogProvider, PaimonRelationPlanner};
 
 let config = SessionConfig::new()
     .set_str("datafusion.sql_parser.dialect", "Databricks");
 let ctx = SessionContext::new_with_config(config);
 
-ctx.register_catalog("paimon", Arc::new(PaimonCatalogProvider::new(Arc::new(catalog))));
+ctx.register_catalog("paimon", Arc::new(PaimonCatalogProvider::new(catalog)));
 ctx.register_relation_planner(Arc::new(PaimonRelationPlanner::new()))?;
+```
 
-// Now time travel queries work
-let df = ctx.sql("SELECT * FROM paimon.default.my_table VERSION AS OF 1").await?;
+## Dynamic Options (SET / RESET)
+
+Use `SET` to configure session-scoped Paimon dynamic options that apply to subsequent table loads:
+
+```sql
+-- Set an option
+SET 'paimon.scan.version' = '1';
+
+-- Reset an option
+RESET 'paimon.scan.version';
+```
+
+Options prefixed with `paimon.` are handled by Paimon; all others are delegated to DataFusion. Dynamic options are applied at table load time via `table.copy_with_options()`.
+
+Example — enable BLOB descriptor mode:
+
+```sql
+SET 'paimon.blob-as-descriptor' = 'true';
+SELECT * FROM paimon.my_db.assets;
+RESET 'paimon.blob-as-descriptor';
+```
+
+## System Tables
+
+Access table metadata via the `$` syntax.
+
+### $options
+
+View all configuration options for a table:
+
+```sql
+SELECT key, value FROM paimon.default.my_table$options;
+```
+
+Returns two columns: `key` (STRING) and `value` (STRING).
+
+### $schemas
+
+View the schema history of a table:
+
+```sql
+SELECT * FROM paimon.default.my_table$schemas;
+```
+
+Columns:
+
+| Column | Type | Description |
+|---|---|---|
+| `schema_id` | BIGINT | Schema ID |
+| `fields` | STRING | Field definitions (JSON) |
+| `partition_keys` | STRING | Partition keys (JSON) |
+| `primary_keys` | STRING | Primary keys (JSON) |
+| `options` | STRING | Table options (JSON) |
+| `comment` | STRING | Comment |
+| `update_time` | TIMESTAMP | Update time |
+
+### Branch References
+
+System tables support branch syntax:
+
+```sql
+SELECT * FROM paimon.default.my_table$branch_main$options;
+```
+
+## Table Options
+
+Set via `WITH ('key' = 'value')` at table creation time, or dynamically via `SET`.
+
+### Bucket Configuration
+
+| Option | Description |
+|---|---|
+| `'bucket' = 'N'` | Fixed N buckets (e.g. 1, 2, 4) |
+| `'bucket' = '-1'` | Dynamic bucket mode (HASH index) |
+| `'bucket' = '-2'` | Postpone bucket mode (deferred assignment) |
+| `'bucket-key' = 'col'` | Explicit bucket key column |
+
+### Merge Engine
+
+| Option | Description |
+|---|---|
+| `'merge-engine' = 'deduplicate'` | Deduplicate engine (default for PK tables), last write wins |
+| `'merge-engine' = 'first-row'` | Keeps the first written row |
+
+### Other Options
+
+| Option | Description |
+|---|---|
+| `'sequence.field' = 'col'` | Sequence field used to determine which record wins during deduplication |
+| `'data-evolution.enabled' = 'true'` | Enable data evolution (partial-column writes, row-level UPDATE/MERGE) |
+| `'deletion-vectors.enabled' = 'true'` | Enable deletion vectors |
+| `'cross-partition-update.enabled' = 'true'` | Allow cross-partition updates |
+| `'changelog-producer' = 'input'` | Changelog producer (PK tables with input mode reject writes) |
+
+## Full Example
+
+```rust
+use std::sync::Arc;
+use datafusion::prelude::SessionContext;
+use paimon::{CatalogOptions, FileSystemCatalog, Options};
+use paimon_datafusion::PaimonSqlHandler;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create catalog
+    let mut options = Options::new();
+    options.set(CatalogOptions::WAREHOUSE, "file:///tmp/paimon-warehouse");
+    let catalog = Arc::new(FileSystemCatalog::new(options)?);
+
+    // Create handler (registers catalog provider and relation planner automatically)
+    let ctx = SessionContext::new();
+    let handler = PaimonSqlHandler::new(ctx, catalog, "paimon");
+
+    // Create database and table
+    handler.sql("CREATE SCHEMA paimon.my_db").await?;
+    handler.sql(
+        "CREATE TABLE paimon.my_db.users (
+            id INT NOT NULL,
+            name STRING,
+            PRIMARY KEY (id)
+        ) WITH ('bucket' = '1')"
+    ).await?;
+
+    // Insert data
+    handler.sql("INSERT INTO paimon.my_db.users VALUES (1, 'alice'), (2, 'bob')")
+        .await?.collect().await?;
+
+    // Query
+    let df = handler.sql("SELECT * FROM paimon.my_db.users ORDER BY id").await?;
+    df.show().await?;
+
+    Ok(())
+}
 ```

--- a/docs/src/datafusion.md
+++ b/docs/src/datafusion.md
@@ -41,7 +41,7 @@ use datafusion::prelude::SessionContext;
 use paimon_datafusion::PaimonSqlHandler;
 
 let ctx = SessionContext::new();
-let handler = PaimonSqlHandler::new(ctx, catalog, "paimon");
+let handler = PaimonSqlHandler::new(ctx, catalog, "paimon")?;
 let df = handler.sql("SELECT * FROM paimon.default.my_table").await?;
 df.show().await?;
 ```
@@ -470,7 +470,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create handler (registers catalog provider and relation planner automatically)
     let ctx = SessionContext::new();
-    let handler = PaimonSqlHandler::new(ctx, catalog, "paimon");
+    let handler = PaimonSqlHandler::new(ctx, catalog, "paimon")?;
 
     // Create database and table
     handler.sql("CREATE SCHEMA paimon.my_db").await?;


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Add static partition overwrite via PARTITION clause (e.g. INSERT OVERWRITE t PARTITION (dt = 'value') SELECT ...). Partial partition specs use predicate-based filtering to overwrite all matching sub-partitions. Simplify PaimonSqlHandler::new to 3 args (ctx, catalog, name) with internal DynamicOptions management, catalog registration, and relation planner setup. Remove redundant overwrite_partitions from CommitEntriesPlan, unifying all overwrite filtering through PartitionFilter.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
