### PR TITLE
ci: include runner arch in cargo cache key to avoid cross-arch conflicts for go

### DIFF
--- a/.github/workflows/release-go-binding.yml
+++ b/.github/workflows/release-go-binding.yml
@@ -129,7 +129,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install zstd on Linux
         if: runner.os == 'Linux'


### PR DESCRIPTION
### Purpose

Fix the Go binding release workflow failure caused by cross-architecture cargo cache pollution.

The `release-go-binding.yml` workflow uses `actions/cache` with key `${{ runner.os }}-cargo-...`, which doesn't distinguish between CPU architectures. When both `ubuntu-latest` (x86_64) and `ubuntu-24.04-arm` (arm64) share the same cache key, the arm64 runner may save its cargo binaries first. Subsequent runs on x86_64 restore the arm64 cargo binary, resulting in `Exec format error`. The same issue affects `macos-14` (ARM) vs `macos-15-intel` (x86_64), causing `command not found`.

### Brief change log

- Add `runner.arch` to the cargo cache key in `release-go-binding.yml`, changing the key from `${{ runner.os }}-cargo-<hash>` to `${{ runner.os }}-${{ runner.arch }}-cargo-<hash>`. This ensures each architecture maintains its own cache (e.g., `Linux-X64-cargo-...` vs `Linux-ARM64-cargo-...`).

### Tests

- The fix can be verified by triggering the Go binding release workflow — all four build jobs (linux amd64/arm64, darwin amd64/arm64) should pass.

### API and Format

No.

### Documentation

No.