### PR TITLE
ci: cherry-pick CI fixes from release-0.1 to main

### DIFF
--- a/.github/workflows/release-go-binding.yml
+++ b/.github/workflows/release-go-binding.yml
@@ -129,7 +129,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install zstd on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/release-go-binding.yml
+++ b/.github/workflows/release-go-binding.yml
@@ -116,10 +116,20 @@ jobs:
           ref: ${{ needs.validate.outputs.source_sha }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: |
+          rustup update stable
+          rustup default stable
 
       - name: Cache Rust build outputs
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install zstd on Linux
         if: runner.os == 'Linux'
@@ -197,12 +207,16 @@ jobs:
           git push origin "refs/tags/$TAG"
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ needs.validate.outputs.tag }}
-          generate_release_notes: true
-          files: |
-            bindings/go/libpaimon_c.linux.amd64.so.zst
-            bindings/go/libpaimon_c.linux.arm64.so.zst
-            bindings/go/libpaimon_c.darwin.amd64.dylib.zst
-            bindings/go/libpaimon_c.darwin.arm64.dylib.zst
+        env:
+          TAG: ${{ needs.validate.outputs.tag }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        working-directory: bindings/go
+        run: |
+          gh release create "$TAG" \
+            --title "Release Go binding $VERSION" \
+            --generate-notes \
+            libpaimon_c.linux.amd64.so.zst \
+            libpaimon_c.linux.arm64.so.zst \
+            libpaimon_c.darwin.amd64.dylib.zst \
+            libpaimon_c.darwin.arm64.dylib.zst

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -53,6 +53,8 @@ jobs:
           rustup default stable
 
       - name: Dry run
+        # Only dry-run paimon since paimon-datafusion depends on it
+        if: matrix.package == 'paimon'
         run: cargo publish -p ${{ matrix.package }} --all-features --dry-run
 
       - name: Publish ${{ matrix.package }} to crates.io
@@ -60,3 +62,14 @@ jobs:
         run: cargo publish -p ${{ matrix.package }} --all-features
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io to update
+        if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') && matrix.package == 'paimon'
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          for i in {1..10}; do
+            CURRENT=$(curl -s https://crates.io/api/v1/crates/paimon | jq -r '.crate.max_version')
+            [ "$CURRENT" = "$VERSION" ] && echo "✅ paimon $VERSION available" && exit 0
+            echo "Waiting for $VERSION (currently $CURRENT)... $i/10"
+            sleep 30
+          done

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -48,7 +48,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: |
+          rustup update stable
+          rustup default stable
 
       - name: Dry run
         run: cargo publish -p ${{ matrix.package }} --all-features --dry-run

--- a/.github/workflows/release_python_binding.yml
+++ b/.github/workflows/release_python_binding.yml
@@ -48,6 +48,8 @@ jobs:
           working-directory: bindings/python
           command: sdist
           args: -o dist
+          before-script-linux: |
+            yum install -y openssl-devel 2>/dev/null || apt-get update && apt-get install -y libssl-dev
 
       - name: Upload sdist
         uses: actions/upload-artifact@v7
@@ -75,6 +77,8 @@ jobs:
           command: build
           args: --release -o dist
           manylinux: ${{ matrix.manylinux || 'auto' }}
+          before-script-linux: |
+            yum install -y openssl-devel 2>/dev/null || apt-get update && apt-get install -y libssl-dev
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release_python_binding.yml
+++ b/.github/workflows/release_python_binding.yml
@@ -49,7 +49,7 @@ jobs:
           command: sdist
           args: -o dist
           before-script-linux: |
-            yum install -y openssl-devel 2>/dev/null || apt-get update && apt-get install -y libssl-dev
+            sudo apt-get update && sudo apt-get install -y libssl-dev
 
       - name: Upload sdist
         uses: actions/upload-artifact@v7
@@ -78,7 +78,58 @@ jobs:
           args: --release -o dist
           manylinux: ${{ matrix.manylinux || 'auto' }}
           before-script-linux: |
-            yum install -y openssl-devel 2>/dev/null || apt-get update && apt-get install -y libssl-dev
+            # Install OpenSSL for x86_64 (manylinux2014 with OpenSSL 1.1)
+            if [ "${{ matrix.target }}" = "x86_64" ]; then
+              yum install -y openssl11-devel
+              # Create symlinks so pkg-config finds openssl11 as openssl
+              ln -sf /usr/lib64/pkgconfig/openssl11.pc /usr/lib64/pkgconfig/openssl.pc
+              ln -sf /usr/lib64/pkgconfig/libssl11.pc /usr/lib64/pkgconfig/libssl.pc
+              ln -sf /usr/lib64/pkgconfig/libcrypto11.pc /usr/lib64/pkgconfig/libcrypto.pc
+            fi
+
+            # Install precompiled OpenSSL from Debian packages for aarch64
+            if [ "${{ matrix.target }}" = "aarch64" ]; then
+              set -e
+              echo "Installing OpenSSL for aarch64 from Debian packages..."
+
+              (cd /tmp
+              # Debian Bullseye arm64 packages (OpenSSL 1.1.1)
+              DEBIAN_MIRROR="http://ftp.debian.org/debian/pool/main/o/openssl"
+              curl -sLO "${DEBIAN_MIRROR}/libssl1.1_1.1.1w-0+deb11u1_arm64.deb"
+              curl -sLO "${DEBIAN_MIRROR}/libssl-dev_1.1.1w-0+deb11u1_arm64.deb"
+
+              # Extract .deb packages (ar format)
+              for deb in *.deb; do
+                ar x "$deb"
+                tar xf data.tar.*
+                rm -f debian-binary control.tar.* data.tar.*
+              done
+
+              # Install to maturin's expected location
+              TARGET_DIR="/usr/aarch64-unknown-linux-gnu"
+              mkdir -p "${TARGET_DIR}/include/openssl" "${TARGET_DIR}/lib"
+
+              # Copy main OpenSSL headers (architecture-independent)
+              cp -r usr/include/openssl/* "${TARGET_DIR}/include/openssl/"
+
+              # Overwrite with architecture-specific headers
+              cp -f usr/include/aarch64-linux-gnu/openssl/configuration.h "${TARGET_DIR}/include/openssl/" || true
+              cp -f usr/include/aarch64-linux-gnu/openssl/opensslconf.h "${TARGET_DIR}/include/openssl/" || true
+
+              # Copy libraries
+              cp -a usr/lib/aarch64-linux-gnu/libssl* "${TARGET_DIR}/lib/"
+              cp -a usr/lib/aarch64-linux-gnu/libcrypto* "${TARGET_DIR}/lib/"
+
+              # Verify
+              echo "✓ OpenSSL installed"
+              ls "${TARGET_DIR}/lib/libssl.a" && echo "✓ libssl.a found"
+              ls "${TARGET_DIR}/include/openssl/opensslv.h" && echo "✓ opensslv.h found"
+              ls "${TARGET_DIR}/include/openssl/opensslconf.h" && echo "✓ opensslconf.h found"
+              ) # End subshell
+
+              # Fix ring crate build: define ARM architecture version for aarch64
+              export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"
+            fi
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ arrow-row = "58.0"
 arrow-select = "58.0"
 datafusion = "53.0.0"
 datafusion-ffi = "53.0.0"
+paimon = { version = "0.2.0", path = "crates/paimon" }
 parquet = "58.0"
 constant_time_eq = ">=0.4.0, <0.4.3"
 tokio = "1.39.2"

--- a/crates/integrations/datafusion/Cargo.toml
+++ b/crates/integrations/datafusion/Cargo.toml
@@ -36,7 +36,7 @@ chrono = "0.4"
 constant_time_eq = { workspace = true }
 datafusion = { workspace = true }
 log = "0.4"
-paimon = { path = "../../paimon" }
+paimon = { workspace = true }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary

Cherry-pick CI fixes from `release-0.1` branch to `main`:

- **ci: fix release issue (#248)** — https://github.com/apache/paimon-rust/commit/2a7e5fc2408fadd4d09a34f951b891cba539a2b1
- **ci: fix publish paimon-datafusion and python issue (#253)** — https://github.com/apache/paimon-rust/commit/ca89546869cb0a4c00ebf1608c5257b852d7e8db
- **ci: include runner arch in cargo cache key to avoid cross-arch conflicts for go (#282)** — https://github.com/apache/paimon-rust/commit/6fa0f339cac10b1e7617af7e076e9b5d21cac005

## Test plan

- [ ] Verify CI workflows pass on this PR
- [ ] Confirm no unintended changes beyond the cherry-picked commits