### PR TITLE
fix: repair CI after partial-update merge

### DIFF
--- a/crates/integrations/datafusion/tests/pk_tables.rs
+++ b/crates/integrations/datafusion/tests/pk_tables.rs
@@ -79,9 +79,9 @@ async fn test_pk_basic_write_read() {
 /// Partial-update merge engine: keep latest non-null value for each field.
 #[tokio::test]
 async fn test_pk_partial_update_fixed_bucket_e2e() {
-    let (_tmp, handler) = setup_handler().await;
+    let (_tmp, sql_context) = setup_sql_context().await;
 
-    handler
+    sql_context
         .sql(
             "CREATE TABLE paimon.test_db.t_partial_update (
                 id INT NOT NULL, v_int INT, v_str STRING,
@@ -91,7 +91,7 @@ async fn test_pk_partial_update_fixed_bucket_e2e() {
         .await
         .unwrap();
 
-    handler
+    sql_context
         .sql(
             "INSERT INTO paimon.test_db.t_partial_update VALUES
              (1, 10, 'old-1'),
@@ -103,7 +103,7 @@ async fn test_pk_partial_update_fixed_bucket_e2e() {
         .await
         .unwrap();
 
-    handler
+    sql_context
         .sql(
             "INSERT INTO paimon.test_db.t_partial_update VALUES
              (1, CAST(NULL AS INT), 'new-1'),
@@ -116,7 +116,7 @@ async fn test_pk_partial_update_fixed_bucket_e2e() {
         .await
         .unwrap();
 
-    handler
+    sql_context
         .sql(
             "INSERT INTO paimon.test_db.t_partial_update VALUES
              (1, 111, CAST(NULL AS STRING))",
@@ -127,7 +127,7 @@ async fn test_pk_partial_update_fixed_bucket_e2e() {
         .await
         .unwrap();
 
-    let batches = handler
+    let batches = sql_context
         .sql("SELECT id, v_int, v_str FROM paimon.test_db.t_partial_update ORDER BY id")
         .await
         .unwrap()

--- a/crates/paimon/src/table/cow_writer.rs
+++ b/crates/paimon/src/table/cow_writer.rs
@@ -223,7 +223,6 @@ impl CopyOnWriteMergeWriter {
         let target_file_size = core_options.target_file_size();
         let file_compression = core_options.file_compression().to_string();
         let file_compression_zstd_level = core_options.file_compression_zstd_level();
-        let file_format = core_options.file_format().to_string();
         let write_buffer_size = core_options.write_parquet_buffer_size();
         let file_format = core_options.file_format().to_string();
         let schema_id = schema.id();

--- a/crates/paimon/src/table/table_write.rs
+++ b/crates/paimon/src/table/table_write.rs
@@ -926,7 +926,7 @@ mod tests {
             None,
         );
 
-        TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        TableWrite::new(&table, "test-user".to_string()).unwrap();
     }
 
     #[tokio::test]
@@ -952,7 +952,7 @@ mod tests {
             None,
         );
 
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
         let err = table_write
             .write_arrow_batch(&make_batch(vec![1], vec![10]))
             .await
@@ -987,7 +987,7 @@ mod tests {
             None,
         );
 
-        let mut table_write = TableWrite::new(&table, "test-user".to_string(), false).unwrap();
+        let mut table_write = TableWrite::new(&table, "test-user".to_string()).unwrap();
         let err = table_write
             .write_arrow_batch(&make_batch(vec![1], vec![10]))
             .await


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

related to #263 

This PR fixes CI failures on `main` after the partial-update changes were merged.

The failures were caused by stale call sites from the partial-update PR after upstream APIs and test helpers had changed on `main`:

  - `TableWrite::new` no longer accepts the old boolean argument.
  - `setup_handler()` no longer exists in the DataFusion PK table tests.
  - A duplicate `file_format` local variable triggered Clippy `-D warnings`.

The individual PR checks were green before merge, but the final merged result on `main` failed because the branch was not validated against the latest base before landing. A **merge queue**, or requiring branches to be up to date before merge, would help prevent this class of CI breakage.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
