### PR TITLE
Add explicit read-only permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add an explicit `permissions` block to `.github/workflows/ci.yml`.
- Set default token scope to `contents: read` for CI jobs.

## Why
The CI workflow only needs repository read access. Declaring this explicitly aligns with least-privilege workflow hardening.