### PR TITLE
ci: trigger CI for release branch pushes and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,11 @@ on:
   push:
     branches:
       - main
+      - release-*
   pull_request:
     branches:
       - main
+      - release-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}


### PR DESCRIPTION
## Summary
- Add `release-*` branch pattern to both `push` and `pull_request` triggers in `ci.yml`
- This ensures PRs targeting release branches (e.g., `release-0.2`) and direct pushes to release branches also run the full CI pipeline

## Test plan
- [ ] Verify CI triggers on a PR targeting a `release-*` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)