### PR TITLE
feat(datafusion): auto-register built-in table functions on catalog registration

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -31,6 +31,6 @@ arrow = { workspace = true, features = ["pyarrow"] }
 datafusion = { workspace = true }
 datafusion-ffi = { workspace = true }
 paimon = { path = "../../crates/paimon", features = ["storage-all"] }
-paimon-datafusion = { path = "../../crates/integrations/datafusion" }
+paimon-datafusion = { path = "../../crates/integrations/datafusion", features = ["fulltext"] }
 pyo3 = { version = "0.28", features = ["abi3-py310"] }
 tokio = { workspace = true }

--- a/bindings/python/src/context.rs
+++ b/bindings/python/src/context.rs
@@ -23,7 +23,10 @@ use datafusion::catalog::CatalogProvider;
 use datafusion_ffi::catalog_provider::FFI_CatalogProvider;
 use datafusion_ffi::proto::logical_extension_codec::FFI_LogicalExtensionCodec;
 use paimon::{CatalogFactory, Options};
-use paimon_datafusion::{PaimonCatalogProvider, SQLContext};
+use paimon_datafusion::{
+    register_full_text_search, register_vector_search, PaimonCatalogProvider, SQLContext,
+};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
 
@@ -146,6 +149,37 @@ impl PySQLContext {
         self.inner
             .register_temp_table(&name, Arc::new(mem_table))
             .map_err(df_to_py_err)
+    }
+
+    /// Registers a built-in Paimon table-valued function (UDTF) on the session
+    /// so it can be used in SQL, e.g.
+    /// `SELECT * FROM vector_search('items', 'embedding', '[1.0, 0.0]', 10)`.
+    ///
+    /// `name` selects the function; supported values are `vector_search` and
+    /// `full_text_search`. The function is bound to the current catalog, so a
+    /// catalog must already be registered (the first `register_catalog` call
+    /// also sets it current). `default_database` defaults to `"default"` and
+    /// resolves the table-name argument the function receives in SQL.
+    #[pyo3(signature = (name, default_database=None))]
+    fn register_table_function(
+        &self,
+        name: String,
+        default_database: Option<String>,
+    ) -> PyResult<()> {
+        let catalog = self.inner.current_catalog().map_err(df_to_py_err)?;
+        let default_database = default_database.as_deref().unwrap_or("default");
+        let ctx = self.inner.ctx();
+        match name.as_str() {
+            "vector_search" => register_vector_search(ctx, catalog, default_database),
+            "full_text_search" => register_full_text_search(ctx, catalog, default_database),
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown table function '{other}'; \
+                     supported: 'vector_search', 'full_text_search'"
+                )))
+            }
+        }
+        Ok(())
     }
 
     fn sql(&self, py: Python<'_>, sql: String) -> PyResult<Vec<Py<PyAny>>> {

--- a/bindings/python/src/context.rs
+++ b/bindings/python/src/context.rs
@@ -23,10 +23,7 @@ use datafusion::catalog::CatalogProvider;
 use datafusion_ffi::catalog_provider::FFI_CatalogProvider;
 use datafusion_ffi::proto::logical_extension_codec::FFI_LogicalExtensionCodec;
 use paimon::{CatalogFactory, Options};
-use paimon_datafusion::{
-    register_full_text_search, register_vector_search, PaimonCatalogProvider, SQLContext,
-};
-use pyo3::exceptions::PyValueError;
+use paimon_datafusion::{PaimonCatalogProvider, SQLContext};
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
 
@@ -149,37 +146,6 @@ impl PySQLContext {
         self.inner
             .register_temp_table(&name, Arc::new(mem_table))
             .map_err(df_to_py_err)
-    }
-
-    /// Registers a built-in Paimon table-valued function (UDTF) on the session
-    /// so it can be used in SQL, e.g.
-    /// `SELECT * FROM vector_search('items', 'embedding', '[1.0, 0.0]', 10)`.
-    ///
-    /// `name` selects the function; supported values are `vector_search` and
-    /// `full_text_search`. The function is bound to the current catalog, so a
-    /// catalog must already be registered (the first `register_catalog` call
-    /// also sets it current). `default_database` defaults to `"default"` and
-    /// resolves the table-name argument the function receives in SQL.
-    #[pyo3(signature = (name, default_database=None))]
-    fn register_table_function(
-        &self,
-        name: String,
-        default_database: Option<String>,
-    ) -> PyResult<()> {
-        let catalog = self.inner.current_catalog().map_err(df_to_py_err)?;
-        let default_database = default_database.as_deref().unwrap_or("default");
-        let ctx = self.inner.ctx();
-        match name.as_str() {
-            "vector_search" => register_vector_search(ctx, catalog, default_database),
-            "full_text_search" => register_full_text_search(ctx, catalog, default_database),
-            other => {
-                return Err(PyValueError::new_err(format!(
-                    "unknown table function '{other}'; \
-                     supported: 'vector_search', 'full_text_search'"
-                )))
-            }
-        }
-        Ok(())
     }
 
     fn sql(&self, py: Python<'_>, sql: String) -> PyResult<Vec<Py<PyAny>>> {

--- a/bindings/python/tests/test_datafusion.py
+++ b/bindings/python/tests/test_datafusion.py
@@ -179,50 +179,21 @@ def test_register_batch_invalid_catalog():
             assert "unknown_catalog" in str(e).lower() or "not a paimon" in str(e).lower() or "unknown" in str(e).lower()
 
 
-def test_register_table_function_vector_search():
+def test_table_functions_registered_with_catalog():
+    """register_catalog auto-registers the built-in table-valued functions, so
+    they are callable in SQL without any extra registration step."""
     with tempfile.TemporaryDirectory() as warehouse:
         ctx = SQLContext()
         ctx.register_catalog("paimon", {"warehouse": warehouse})
+        ctx.sql("CREATE SCHEMA paimon.test_db")
+        ctx.sql("CREATE TABLE paimon.test_db.t (id INT, name STRING)")
+        ctx.sql("INSERT INTO paimon.test_db.t VALUES (1, 'alice')")
 
-        # Registering against the current catalog should not raise.
-        ctx.register_table_function("vector_search")
+        referenced = ctx.sql("SELECT * FROM referenced_files_size('test_db.t')")
+        assert pa.Table.from_batches(referenced).num_rows > 0
 
+        physical = ctx.sql("SELECT * FROM physical_files_size('test_db.t')")
+        assert pa.Table.from_batches(physical).num_rows > 0
 
-def test_register_table_function_full_text_search():
-    with tempfile.TemporaryDirectory() as warehouse:
-        ctx = SQLContext()
-        ctx.register_catalog("paimon", {"warehouse": warehouse})
-
-        ctx.register_table_function("full_text_search")
-
-
-def test_register_table_function_with_default_database():
-    with tempfile.TemporaryDirectory() as warehouse:
-        ctx = SQLContext()
-        ctx.register_catalog("paimon", {"warehouse": warehouse})
-
-        # The optional default_database keyword is accepted.
-        ctx.register_table_function("vector_search", default_database="default")
-
-
-def test_register_table_function_unknown_name():
-    with tempfile.TemporaryDirectory() as warehouse:
-        ctx = SQLContext()
-        ctx.register_catalog("paimon", {"warehouse": warehouse})
-
-        try:
-            ctx.register_table_function("does_not_exist")
-            assert False, "Expected an error for an unknown table function"
-        except Exception as e:
-            assert "unknown table function" in str(e).lower()
-            assert "does_not_exist" in str(e)
-
-
-def test_register_table_function_without_catalog():
-    # With no catalog registered there is no current catalog to bind to.
-    ctx = SQLContext()
-    try:
-        ctx.register_table_function("vector_search")
-        assert False, "Expected an error when no catalog is registered"
-    except Exception as e:
-        assert "catalog" in str(e).lower()
+        ctx.sql("DROP TABLE paimon.test_db.t")
+        ctx.sql("DROP SCHEMA paimon.test_db")

--- a/bindings/python/tests/test_datafusion.py
+++ b/bindings/python/tests/test_datafusion.py
@@ -177,3 +177,52 @@ def test_register_batch_invalid_catalog():
             assert False, "Expected an error for unknown catalog"
         except Exception as e:
             assert "unknown_catalog" in str(e).lower() or "not a paimon" in str(e).lower() or "unknown" in str(e).lower()
+
+
+def test_register_table_function_vector_search():
+    with tempfile.TemporaryDirectory() as warehouse:
+        ctx = SQLContext()
+        ctx.register_catalog("paimon", {"warehouse": warehouse})
+
+        # Registering against the current catalog should not raise.
+        ctx.register_table_function("vector_search")
+
+
+def test_register_table_function_full_text_search():
+    with tempfile.TemporaryDirectory() as warehouse:
+        ctx = SQLContext()
+        ctx.register_catalog("paimon", {"warehouse": warehouse})
+
+        ctx.register_table_function("full_text_search")
+
+
+def test_register_table_function_with_default_database():
+    with tempfile.TemporaryDirectory() as warehouse:
+        ctx = SQLContext()
+        ctx.register_catalog("paimon", {"warehouse": warehouse})
+
+        # The optional default_database keyword is accepted.
+        ctx.register_table_function("vector_search", default_database="default")
+
+
+def test_register_table_function_unknown_name():
+    with tempfile.TemporaryDirectory() as warehouse:
+        ctx = SQLContext()
+        ctx.register_catalog("paimon", {"warehouse": warehouse})
+
+        try:
+            ctx.register_table_function("does_not_exist")
+            assert False, "Expected an error for an unknown table function"
+        except Exception as e:
+            assert "unknown table function" in str(e).lower()
+            assert "does_not_exist" in str(e)
+
+
+def test_register_table_function_without_catalog():
+    # With no catalog registered there is no current catalog to bind to.
+    ctx = SQLContext()
+    try:
+        ctx.register_table_function("vector_search")
+        assert False, "Expected an error when no catalog is registered"
+    except Exception as e:
+        assert "catalog" in str(e).lower()

--- a/bindings/python/tests/test_datafusion.py
+++ b/bindings/python/tests/test_datafusion.py
@@ -180,20 +180,17 @@ def test_register_batch_invalid_catalog():
 
 
 def test_table_functions_registered_with_catalog():
-    """register_catalog auto-registers the built-in table-valued functions, so
-    they are callable in SQL without any extra registration step."""
+    """register_catalog auto-registers vector_search / full_text_search as
+    UDTFs. Calling one with the wrong argument count surfaces the function's
+    own validation error, which proves it is registered — an unregistered
+    name would instead fail with 'table function not found'."""
     with tempfile.TemporaryDirectory() as warehouse:
         ctx = SQLContext()
         ctx.register_catalog("paimon", {"warehouse": warehouse})
-        ctx.sql("CREATE SCHEMA paimon.test_db")
-        ctx.sql("CREATE TABLE paimon.test_db.t (id INT, name STRING)")
-        ctx.sql("INSERT INTO paimon.test_db.t VALUES (1, 'alice')")
 
-        referenced = ctx.sql("SELECT * FROM referenced_files_size('test_db.t')")
-        assert pa.Table.from_batches(referenced).num_rows > 0
-
-        physical = ctx.sql("SELECT * FROM physical_files_size('test_db.t')")
-        assert pa.Table.from_batches(physical).num_rows > 0
-
-        ctx.sql("DROP TABLE paimon.test_db.t")
-        ctx.sql("DROP SCHEMA paimon.test_db")
+        for fn in ("vector_search", "full_text_search"):
+            try:
+                ctx.sql(f"SELECT * FROM {fn}('only_one_arg')")
+                assert False, f"expected {fn} to reject a single argument"
+            except Exception as e:
+                assert "requires 4 arguments" in str(e), str(e)

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -136,6 +136,25 @@ impl SQLContext {
                 self.dynamic_options.clone(),
             )),
         );
+        // Register the built-in table-valued functions against this catalog so
+        // they are usable in SQL without any extra registration call.
+        crate::vector_search::register_vector_search(&self.ctx, catalog.clone(), default_db);
+        #[cfg(feature = "fulltext")]
+        crate::full_text_search::register_full_text_search(
+            &self.ctx,
+            catalog.clone(),
+            default_db,
+        );
+        crate::referenced_files_size::register_referenced_files_size(
+            &self.ctx,
+            catalog.clone(),
+            default_db,
+        );
+        crate::physical_files_size::register_physical_files_size(
+            &self.ctx,
+            catalog.clone(),
+            default_db,
+        );
         self.catalogs.insert(catalog_name.clone(), catalog);
         if is_first {
             self.set_current_catalog(catalog_name).await?;
@@ -1220,12 +1239,7 @@ impl SQLContext {
             .clone()
     }
 
-    /// Returns the Paimon catalog currently set as default.
-    ///
-    /// Exposed so callers that need the registered [`Catalog`] (for example to
-    /// register a table-valued function against it) can retrieve it without
-    /// keeping a duplicate handle of their own.
-    pub fn current_catalog(&self) -> DFResult<Arc<dyn Catalog>> {
+    fn current_catalog(&self) -> DFResult<Arc<dyn Catalog>> {
         let name = self.current_catalog_name();
         self.catalogs.get(&name).cloned().ok_or_else(|| {
             DataFusionError::Plan(

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -141,16 +141,6 @@ impl SQLContext {
         crate::vector_search::register_vector_search(&self.ctx, catalog.clone(), default_db);
         #[cfg(feature = "fulltext")]
         crate::full_text_search::register_full_text_search(&self.ctx, catalog.clone(), default_db);
-        crate::referenced_files_size::register_referenced_files_size(
-            &self.ctx,
-            catalog.clone(),
-            default_db,
-        );
-        crate::physical_files_size::register_physical_files_size(
-            &self.ctx,
-            catalog.clone(),
-            default_db,
-        );
         self.catalogs.insert(catalog_name.clone(), catalog);
         if is_first {
             self.set_current_catalog(catalog_name).await?;

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -140,11 +140,7 @@ impl SQLContext {
         // they are usable in SQL without any extra registration call.
         crate::vector_search::register_vector_search(&self.ctx, catalog.clone(), default_db);
         #[cfg(feature = "fulltext")]
-        crate::full_text_search::register_full_text_search(
-            &self.ctx,
-            catalog.clone(),
-            default_db,
-        );
+        crate::full_text_search::register_full_text_search(&self.ctx, catalog.clone(), default_db);
         crate::referenced_files_size::register_referenced_files_size(
             &self.ctx,
             catalog.clone(),

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -136,11 +136,7 @@ impl SQLContext {
                 self.dynamic_options.clone(),
             )),
         );
-        // Register the built-in table-valued functions against this catalog so
-        // they are usable in SQL without any extra registration call.
-        crate::vector_search::register_vector_search(&self.ctx, catalog.clone(), default_db);
-        #[cfg(feature = "fulltext")]
-        crate::full_text_search::register_full_text_search(&self.ctx, catalog.clone(), default_db);
+        register_table_functions(&self.ctx, &catalog, default_db);
         self.catalogs.insert(catalog_name.clone(), catalog);
         if is_first {
             self.set_current_catalog(catalog_name).await?;
@@ -2305,6 +2301,19 @@ fn ok_result(ctx: &SessionContext) -> DFResult<DataFrame> {
     )?;
     let df = ctx.read_batch(batch)?;
     Ok(df)
+}
+
+/// Registers the built-in table-valued functions against `catalog` so they can
+/// be used in SQL without any extra setup call. Called for every catalog
+/// registered on the context; add new built-in table functions here.
+fn register_table_functions(
+    ctx: &SessionContext,
+    catalog: &Arc<dyn Catalog>,
+    default_database: &str,
+) {
+    crate::vector_search::register_vector_search(ctx, Arc::clone(catalog), default_database);
+    #[cfg(feature = "fulltext")]
+    crate::full_text_search::register_full_text_search(ctx, Arc::clone(catalog), default_database);
 }
 
 #[cfg(test)]

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -1220,7 +1220,12 @@ impl SQLContext {
             .clone()
     }
 
-    fn current_catalog(&self) -> DFResult<Arc<dyn Catalog>> {
+    /// Returns the Paimon catalog currently set as default.
+    ///
+    /// Exposed so callers that need the registered [`Catalog`] (for example to
+    /// register a table-valued function against it) can retrieve it without
+    /// keeping a duplicate handle of their own.
+    pub fn current_catalog(&self) -> DFResult<Arc<dyn Catalog>> {
         let name = self.current_catalog_name();
         self.catalogs.get(&name).cloned().ok_or_else(|| {
             DataFusionError::Plan(

--- a/docs/src/sql.md
+++ b/docs/src/sql.md
@@ -53,7 +53,7 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-`SQLContext::new` creates a session context with the Paimon relation planner pre-registered. Use `register_catalog` to add one or more Paimon catalogs. It also manages session-scoped dynamic options internally for `SET`/`RESET` support.
+`SQLContext::new` creates a session context with the Paimon relation planner pre-registered. Use `register_catalog` to add one or more Paimon catalogs; registering a catalog also registers the built-in table-valued functions (`vector_search`, `full_text_search`) against it. It also manages session-scoped dynamic options internally for `SET`/`RESET` support.
 
 ## Data Types
 
@@ -445,6 +445,10 @@ Paimon supports approximate nearest neighbor (ANN) vector search via the Lumina 
 
 ### Registration
 
+When you use a `SQLContext`, `vector_search` is registered automatically for every catalog you register — no extra setup is needed.
+
+With a raw DataFusion `SessionContext`, register it explicitly:
+
 ```rust
 use paimon_datafusion::register_vector_search;
 
@@ -509,6 +513,10 @@ paimon-datafusion = { version = "0.1.0", features = ["fulltext"] }
 ```
 
 ### Registration
+
+When you use a `SQLContext`, `full_text_search` is registered automatically for every catalog you register (when the `fulltext` feature is enabled) — no extra setup is needed.
+
+With a raw DataFusion `SessionContext`, register it explicitly:
 
 ```rust
 use paimon_datafusion::register_full_text_search;


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx

The `vector_search` and `full_text_search` table-valued functions could only be made available by manually calling their `register_*` function on a `SessionContext`. `SQLContext` users (including the Python binding / pypaimon) had no way to reach `register_udtf`, so these functions were effectively unusable through `SQLContext`.

This registers them automatically, in Rust, when a catalog is registered, so no caller-side setup is needed.

### Brief change log

- `SQLContext::register_catalog` now registers `vector_search` and `full_text_search` against the catalog being registered. Any `SQLContext` with a catalog gets them with no extra call.
- `full_text_search` registration is `#[cfg(feature = "fulltext")]`-gated, so builds without the feature are unaffected.
- The Python binding (`bindings/python/Cargo.toml`) enables the `fulltext` feature on `paimon-datafusion` so `full_text_search` is compiled into the binding.

Note: `referenced_files_size` / `physical_files_size` are intentionally not covered — they are system tables (`table$referenced_files_size`), not UDTFs, so they need no registration.

### Tests

`bindings/python/tests/test_datafusion.py` — `test_table_functions_registered_with_catalog`: after `register_catalog`, calling `vector_search` / `full_text_search` with the wrong argument count surfaces each function's own validation error, proving it is registered (an unregistered name would instead fail with "table function
not found").

### API and Format

- Behavior change: `SQLContext::register_catalog` now also registers the `vector_search` and `full_text_search` table functions. No new public API, no signature change.
- Build: the Python binding enables `paimon-datafusion/fulltext` (adds the pure-Rust `tantivy` dependency).
- No storage format change.

### Documentation

`docs/src/sql.md` is updated: the Vector Search / Full-Text Search registration sections now state that a `SQLContext` registers these functions automatically when a catalog is registered, and that the explicit `register_*` call is only needed with a raw `SessionContext`.