### PR TITLE
build: fix clippy on Windows GNU with Rust 1.95

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[target.x86_64-pc-windows-gnu]
+linker = "rust-lld"


### PR DESCRIPTION
### Purpose

Linked issue: N/A

With Rust stable 1.95.0 on `x86_64-pc-windows-gnu`, `cargo clippy` can fail before reaching project lints because generated build-script executables are not runnable with the default GNU linker output (`os error 193`). A minimal `rustc` hello world has the same failure on this toolchain, while linking with `rust-lld` produces a runnable executable.

This configures the Windows GNU target to use the Rust-provided `rust-lld` linker so clippy can run normally.

### Brief change log

- Add `.cargo/config.toml` with `target.x86_64-pc-windows-gnu.linker = rust-lld`.
- Keep the change scoped to the Windows GNU target only.

### Tests

- `cargo clippy --all-targets --workspace --features fulltext,vortex -- -D warnings`

### API and Format

No API change.
No storage format change.

### Documentation

No documentation update required.