### PR TITLE
fix(release): use distinct PyPI versions for each RC

### DIFF
--- a/.github/workflows/release_python_binding.yml
+++ b/.github/workflows/release_python_binding.yml
@@ -43,6 +43,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Patch version for pre-release
+        if: contains(github.ref, '-rc')
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          PEP_VERSION=$(echo "$TAG" | sed 's/-rc/rc/')
+          sed -i 's/dynamic = \["version"\]/version = "'"$PEP_VERSION"'"/' bindings/python/pyproject.toml
+          echo "Patched pyproject.toml version to $PEP_VERSION"
+
       - uses: PyO3/maturin-action@v1
         with:
           working-directory: bindings/python
@@ -69,6 +77,16 @@ jobs:
           - { os: ubuntu-latest, target: "aarch64", manylinux: "manylinux_2_28" }
     steps:
       - uses: actions/checkout@v6
+
+      - name: Patch version for pre-release
+        if: contains(github.ref, '-rc')
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          PEP_VERSION=$(echo "$TAG" | sed 's/-rc/rc/')
+          sed -i.bak 's/dynamic = \["version"\]/version = "'"$PEP_VERSION"'"/' bindings/python/pyproject.toml
+          rm -f bindings/python/pyproject.toml.bak
+          echo "Patched pyproject.toml version to $PEP_VERSION"
 
       - uses: PyO3/maturin-action@v1
         with:

--- a/docs/src/release/verifying-a-release-candidate.md
+++ b/docs/src/release/verifying-a-release-candidate.md
@@ -115,7 +115,7 @@ For any user-facing feature included in a release, we aim to ensure it is functi
 - **Python binding:** The RC is published to **TestPyPI**; install the client from TestPyPI and write your own test cases to verify:
 
     ```bash
-    pip install -i https://test.pypi.org/simple/ pypaimon==${RELEASE_VERSION}
+    pip install -i https://test.pypi.org/simple/ pypaimon-rust==${RELEASE_VERSION}rc${RC_NUM}
     ```
 
 - **Go binding:** The RC is published as a Go module tag `bindings/go/v${RELEASE_VERSION}-rc${RC_NUM}`; see [Go Binding](https://paimon.apache.org/docs/rust/go-binding/) for usage. Add it to your Go project and write test cases to verify:


### PR DESCRIPTION
## Summary
- For pre-release tags (e.g. `v0.2.0-rc1`), override the version in `pyproject.toml` so each RC gets a unique PEP 440 version (e.g. `0.2.0rc1`, `0.2.0rc2`), avoiding Test PyPI overwrite conflicts
- Maturin gives `pyproject.toml` precedence over `Cargo.toml`, so `Cargo.toml` remains untouched and Rust compilation is unaffected
- Fix verification docs: correct package name (`pypaimon-rust`) and include RC number in pip install version

## Test plan
- [x] Verified with `v0.1.0-rc0` tag on https://github.com/luoyuxia/paimon-rust — build succeeded and produced correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)