### PR TITLE
chore: update dependency list for release 0.2.0

### DIFF
--- a/DEPENDENCIES.rust.tsv
+++ b/DEPENDENCIES.rust.tsv
@@ -1,479 +1,525 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
-abi_stable@0.11.3		X										X						
-abi_stable_derive@0.11.3		X										X						
-abi_stable_shared@0.11.0		X										X						
-adler2@2.0.1	X	X										X						
-aes@0.8.4		X										X						
-ahash@0.8.12		X										X						
-aho-corasick@1.1.4												X				X		
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6	zlib-acknowledgement
+abi_stable@0.11.3		X									X							
+abi_stable_derive@0.11.3		X									X							
+abi_stable_shared@0.11.0		X									X							
+adler2@2.0.1	X	X									X							
+aes@0.8.4		X									X							
+ahash@0.8.12		X									X							
+aho-corasick@1.1.4											X				X			
 alloc-no-stdlib@2.0.4					X													
 alloc-stdlib@0.2.2					X													
-allocator-api2@0.2.21		X										X						
-android_system_properties@0.1.5		X										X						
-anyhow@1.0.102		X										X						
+allocator-api2@0.2.21		X									X							
+android_system_properties@0.1.5		X									X							
+anyhow@1.0.102		X									X							
+apache-avro@0.21.0		X																
 ar_archive_writer@0.5.1			X															
+arc-swap@1.9.1		X									X							
 arrayref@0.3.9				X														
-arrayvec@0.7.6		X										X						
-arrow@58.1.0		X																
-arrow-arith@58.1.0		X																
-arrow-array@58.1.0		X																
-arrow-buffer@58.1.0		X																
-arrow-cast@58.1.0		X																
-arrow-csv@58.1.0		X																
-arrow-data@58.1.0		X																
-arrow-ipc@58.1.0		X																
-arrow-json@58.1.0		X																
-arrow-ord@58.1.0		X																
-arrow-pyarrow@58.1.0		X																
-arrow-row@58.1.0		X																
-arrow-schema@58.1.0		X																
-arrow-select@58.1.0		X																
-arrow-string@58.1.0		X																
-as_derive_utils@0.11.0		X										X						
-async-compression@0.4.41		X										X						
-async-ffi@0.5.0												X						
-async-stream@0.3.6												X						
-async-stream-impl@0.3.6												X						
-async-trait@0.1.89		X										X						
-atoi@2.0.0												X						
-atomic-waker@1.1.2		X										X						
-autocfg@1.5.0		X										X						
+arrayvec@0.7.6		X									X							
+arrow@58.3.0		X																
+arrow-arith@58.3.0		X																
+arrow-array@58.3.0		X									X							
+arrow-buffer@58.3.0		X																
+arrow-cast@58.3.0		X																
+arrow-csv@58.3.0		X																
+arrow-data@58.3.0		X																
+arrow-ipc@58.3.0		X																
+arrow-json@58.3.0		X																
+arrow-ord@58.3.0		X																
+arrow-pyarrow@58.3.0		X																
+arrow-row@58.3.0		X																
+arrow-schema@58.3.0		X																
+arrow-select@58.3.0		X																
+arrow-string@58.3.0		X																
+as_derive_utils@0.11.0		X									X							
+async-compression@0.4.42		X									X							
+async-ffi@0.5.0											X							
+async-stream@0.3.6											X							
+async-stream-impl@0.3.6											X							
+async-trait@0.1.89		X									X							
+atoi@2.0.0											X							
+atomic-waker@1.1.2		X									X							
+autocfg@1.5.0		X									X							
 backon@1.6.0		X																
-base64@0.22.1		X										X						
-bigdecimal@0.4.10		X										X						
-bitflags@2.9.1		X										X						
-blake2@0.10.6		X										X						
-blake3@1.8.3		X	X				X											
-block-buffer@0.10.4		X										X						
-block-padding@0.3.3		X										X						
-brotli@8.0.2					X							X						
-brotli-decompressor@5.0.0					X							X						
-bumpalo@3.19.0		X										X						
-bytemuck@1.25.0		X										X					X	
-byteorder@1.5.0												X				X		
-bytes@1.11.1												X						
-bzip2@0.6.1		X										X						
-cbc@0.1.2		X										X						
-cc@1.2.56		X										X						
-cfg-if@1.0.1		X										X						
-chacha20@0.10.0		X										X						
-chrono@0.4.44		X										X						
-chrono-tz@0.10.4		X										X						
-cipher@0.4.4		X										X						
-comfy-table@7.2.2												X						
-compression-codecs@0.4.37		X										X						
-compression-core@0.4.31		X										X						
-const-oid@0.9.6		X										X						
-const-random@0.1.18		X										X						
-const-random-macro@0.1.16		X										X						
-const_panic@0.2.15																	X	
-constant_time_eq@0.4.2		X					X						X					
-core-foundation@0.10.1		X										X						
-core-foundation@0.9.4		X										X						
-core-foundation-sys@0.8.7		X										X						
-core_extensions@1.5.4		X										X						
-core_extensions_proc_macros@1.5.4		X										X						
-cpufeatures@0.2.17		X										X						
-cpufeatures@0.3.0		X										X						
-crc@3.4.0		X										X						
-crc-catalog@2.4.0		X										X						
-crc32c@0.6.8		X										X						
-crc32fast@1.5.0		X										X						
-crossbeam-channel@0.5.15		X										X						
-crossbeam-utils@0.8.21		X										X						
-crunchy@0.2.4												X						
-crypto-common@0.1.6		X										X						
-csv@1.4.0												X				X		
-csv-core@0.1.13												X				X		
-ctr@0.9.2		X										X						
-darling@0.20.11												X						
-darling_core@0.20.11												X						
-darling_macro@0.20.11												X						
-dashmap@6.1.0												X						
-datafusion@53.0.0		X																
-datafusion-catalog@53.0.0		X																
-datafusion-catalog-listing@53.0.0		X																
-datafusion-common@53.0.0		X																
-datafusion-common-runtime@53.0.0		X																
-datafusion-datasource@53.0.0		X																
-datafusion-datasource-arrow@53.0.0		X																
-datafusion-datasource-csv@53.0.0		X																
-datafusion-datasource-json@53.0.0		X																
-datafusion-datasource-parquet@53.0.0		X																
-datafusion-doc@53.0.0		X																
-datafusion-execution@53.0.0		X																
-datafusion-expr@53.0.0		X																
-datafusion-expr-common@53.0.0		X																
-datafusion-ffi@53.0.0		X																
-datafusion-functions@53.0.0		X																
-datafusion-functions-aggregate@53.0.0		X																
-datafusion-functions-aggregate-common@53.0.0		X																
-datafusion-functions-nested@53.0.0		X																
-datafusion-functions-table@53.0.0		X																
-datafusion-functions-window@53.0.0		X																
-datafusion-functions-window-common@53.0.0		X																
-datafusion-macros@53.0.0		X																
-datafusion-optimizer@53.0.0		X																
-datafusion-physical-expr@53.0.0		X																
-datafusion-physical-expr-adapter@53.0.0		X																
-datafusion-physical-expr-common@53.0.0		X																
-datafusion-physical-optimizer@53.0.0		X																
-datafusion-physical-plan@53.0.0		X																
-datafusion-proto@53.0.0		X																
-datafusion-proto-common@53.0.0		X																
-datafusion-pruning@53.0.0		X																
-datafusion-session@53.0.0		X																
-datafusion-sql@53.0.0		X																
-des@0.8.1		X										X						
-diff@0.1.13		X										X						
-digest@0.10.7		X										X						
-displaydoc@0.2.5		X										X						
-dns-lookup@3.0.1		X										X						
-either@1.15.0		X										X						
-encoding_rs@0.8.35		X			X							X						
-equivalent@1.0.2		X										X						
-errno@0.3.14		X										X						
-fallible-streaming-iterator@0.1.9		X										X						
-fastrand@2.3.0		X										X						
-find-msvc-tools@0.1.9		X										X						
-fixedbitset@0.5.7		X										X						
+base64@0.22.1		X									X							
+bigdecimal@0.4.10		X									X							
+bitflags@2.11.1		X									X							
+bitpacking@0.9.3											X							
+blake2@0.10.6		X									X							
+blake3@1.8.5		X	X				X											
+block-buffer@0.10.4		X									X							
+block-padding@0.3.3		X									X							
+bon@3.9.1		X									X							
+bon-macros@3.9.1		X									X							
+brotli@8.0.2					X						X							
+brotli-decompressor@5.0.0					X						X							
+bumpalo@3.20.2		X									X							
+bytemuck@1.25.0		X									X					X		
+byteorder@1.5.0											X				X			
+bytes@1.11.1											X							
+bzip2@0.6.1		X									X							
+cbc@0.1.2		X									X							
+cc@1.2.62		X									X							
+census@0.4.2											X							
+cfg-if@1.0.4		X									X							
+chrono@0.4.44		X									X							
+chrono-tz@0.10.4		X									X							
+cipher@0.4.4		X									X							
+comfy-table@7.2.2											X							
+compression-codecs@0.4.38		X									X							
+compression-core@0.4.32		X									X							
+const-oid@0.9.6		X									X							
+const-random@0.1.18		X									X							
+const-random-macro@0.1.16		X									X							
+const_panic@0.2.15																X		
+constant_time_eq@0.4.2		X					X					X						
+core-foundation@0.10.1		X									X							
+core-foundation@0.9.4		X									X							
+core-foundation-sys@0.8.7		X									X							
+core_extensions@1.5.4		X									X							
+core_extensions_proc_macros@1.5.4		X									X							
+cpufeatures@0.2.17		X									X							
+cpufeatures@0.3.0		X									X							
+crc@3.4.0		X									X							
+crc-catalog@2.5.0		X									X							
+crc32c@0.6.8		X									X							
+crc32fast@1.5.0		X									X							
+crossbeam-channel@0.5.15		X									X							
+crossbeam-deque@0.8.6		X									X							
+crossbeam-epoch@0.9.18		X									X							
+crossbeam-utils@0.8.21		X									X							
+crunchy@0.2.4											X							
+crypto-common@0.1.7		X									X							
+csv@1.4.0											X				X			
+csv-core@0.1.13											X				X			
+ctr@0.9.2		X									X							
+darling@0.23.0											X							
+darling_core@0.23.0											X							
+darling_macro@0.23.0											X							
+dashmap@6.2.1											X							
+datafusion@53.1.0		X																
+datafusion-catalog@53.1.0		X																
+datafusion-catalog-listing@53.1.0		X																
+datafusion-common@53.1.0		X																
+datafusion-common-runtime@53.1.0		X																
+datafusion-datasource@53.1.0		X																
+datafusion-datasource-arrow@53.1.0		X																
+datafusion-datasource-csv@53.1.0		X																
+datafusion-datasource-json@53.1.0		X																
+datafusion-datasource-parquet@53.1.0		X																
+datafusion-doc@53.1.0		X																
+datafusion-execution@53.1.0		X																
+datafusion-expr@53.1.0		X																
+datafusion-expr-common@53.1.0		X																
+datafusion-ffi@53.1.0		X																
+datafusion-functions@53.1.0		X																
+datafusion-functions-aggregate@53.1.0		X																
+datafusion-functions-aggregate-common@53.1.0		X																
+datafusion-functions-nested@53.1.0		X																
+datafusion-functions-table@53.1.0		X																
+datafusion-functions-window@53.1.0		X																
+datafusion-functions-window-common@53.1.0		X																
+datafusion-macros@53.1.0		X																
+datafusion-optimizer@53.1.0		X																
+datafusion-physical-expr@53.1.0		X																
+datafusion-physical-expr-adapter@53.1.0		X																
+datafusion-physical-expr-common@53.1.0		X																
+datafusion-physical-optimizer@53.1.0		X																
+datafusion-physical-plan@53.1.0		X																
+datafusion-proto@53.1.0		X																
+datafusion-proto-common@53.1.0		X																
+datafusion-pruning@53.1.0		X																
+datafusion-session@53.1.0		X																
+datafusion-sql@53.1.0		X																
+deranged@0.5.8		X									X							
+des@0.8.1		X									X							
+diff@0.1.13		X									X							
+digest@0.10.7		X									X							
+displaydoc@0.2.5		X									X							
+dlv-list@0.5.2		X									X							
+dns-lookup@3.0.1		X									X							
+downcast-rs@1.2.1		X									X							
+either@1.15.0		X									X							
+encoding_rs@0.8.35		X			X						X							
+equivalent@1.0.2		X									X							
+errno@0.3.14		X									X							
+fallible-streaming-iterator@0.1.9		X									X							
+fastdivide@0.4.2											X							X
+fastrand@2.4.1		X									X							
+find-msvc-tools@0.1.9		X									X							
+fixedbitset@0.5.7		X									X							
 flatbuffers@25.12.19		X																
-flate2@1.1.9		X										X						
-fnv@1.0.7		X										X						
-foldhash@0.1.5																	X	
-foldhash@0.2.0																	X	
-foreign-types@0.3.2		X										X						
-foreign-types-shared@0.1.1		X										X						
-form_urlencoded@1.2.2		X										X						
-futures@0.3.31		X										X						
-futures-channel@0.3.31		X										X						
-futures-core@0.3.31		X										X						
-futures-executor@0.3.31		X										X						
-futures-io@0.3.31		X										X						
-futures-macro@0.3.31		X										X						
-futures-sink@0.3.31		X										X						
-futures-task@0.3.31		X										X						
-futures-util@0.3.31		X										X						
-g2gen@1.2.2		X										X						
-g2p@1.2.2		X										X						
-g2poly@1.2.2		X										X						
-generational-arena@0.2.9														X				
-generic-array@0.14.7												X						
-getrandom@0.2.16		X										X						
-getrandom@0.3.3		X										X						
-getrandom@0.4.1		X										X						
-glob@0.3.3		X										X						
-gloo-timers@0.3.0		X										X						
-h2@0.4.13												X						
-half@2.7.1		X										X						
-hashbrown@0.14.5		X										X						
-hashbrown@0.15.4		X										X						
-hashbrown@0.16.1		X										X						
+flate2@1.1.9		X									X							
+fnv@1.0.7		X									X							
+foldhash@0.1.5																X		
+foldhash@0.2.0																X		
+foreign-types@0.3.2		X									X							
+foreign-types-shared@0.1.1		X									X							
+form_urlencoded@1.2.2		X									X							
+fs4@0.8.4		X									X							
+futures@0.3.32		X									X							
+futures-channel@0.3.32		X									X							
+futures-core@0.3.32		X									X							
+futures-executor@0.3.32		X									X							
+futures-io@0.3.32		X									X							
+futures-macro@0.3.32		X									X							
+futures-sink@0.3.32		X									X							
+futures-task@0.3.32		X									X							
+futures-util@0.3.32		X									X							
+g2gen@1.2.2		X									X							
+g2p@1.2.2		X									X							
+g2poly@1.2.2		X									X							
+generational-arena@0.2.9													X					
+generic-array@0.14.7											X							
+getrandom@0.2.17		X									X							
+getrandom@0.3.4		X									X							
+getrandom@0.4.2		X									X							
+glob@0.3.3		X									X							
+gloo-timers@0.3.0		X									X							
+h2@0.4.14											X							
+half@2.7.1		X									X							
+hashbrown@0.14.5		X									X							
+hashbrown@0.15.5		X									X							
+hashbrown@0.16.1		X									X							
+hashbrown@0.17.1		X									X							
 hdfs-native@0.13.5		X																
-heck@0.5.0		X										X						
-hex@0.4.3		X										X						
-hmac@0.12.1		X										X						
-home@0.5.12		X										X						
-http@1.3.1		X										X						
-http-body@1.0.1												X						
-http-body-util@0.1.3												X						
-httparse@1.10.1		X										X						
-httpdate@1.0.3		X										X						
-humantime@2.3.0		X										X						
-hyper@1.6.0												X						
-hyper-rustls@0.27.7		X							X			X						
-hyper-tls@0.6.0		X										X						
-hyper-util@0.1.15												X						
-iana-time-zone@0.1.63		X										X						
-iana-time-zone-haiku@0.1.2		X										X						
-icu_collections@2.0.0															X			
-icu_locale_core@2.0.0															X			
-icu_normalizer@2.0.0															X			
-icu_normalizer_data@2.0.0															X			
-icu_properties@2.0.1															X			
-icu_properties_data@2.0.1															X			
-icu_provider@2.0.0															X			
-ident_case@1.0.1		X										X						
-idna@1.1.0		X										X						
-idna_adapter@1.2.1		X										X						
-indexmap@2.13.0		X										X						
-inout@0.1.4		X										X						
-integer-encoding@3.0.4												X						
-integer-encoding@4.1.0												X						
-ipnet@2.11.0		X										X						
-iri-string@0.7.8		X										X						
-itertools@0.14.0		X										X						
-itoa@1.0.15		X										X						
-jiff@0.2.23												X				X		
-jiff-tzdb@0.1.6												X				X		
-jiff-tzdb-platform@0.1.3												X				X		
-jobserver@0.1.34		X										X						
-js-sys@0.3.77		X										X						
-lexical-core@1.0.6		X										X						
-lexical-parse-float@1.0.6		X										X						
-lexical-parse-integer@1.0.6		X										X						
-lexical-util@1.0.7		X										X						
-lexical-write-float@1.0.6		X										X						
-lexical-write-integer@1.0.6		X										X						
-libbz2-rs-sys@0.2.2																		X
-libc@0.2.182		X										X						
+heck@0.5.0		X									X							
+hermit-abi@0.5.2		X									X							
+hex@0.4.3		X									X							
+hmac@0.12.1		X									X							
+home@0.5.12		X									X							
+htmlescape@0.3.1		X									X		X					
+http@1.4.0		X									X							
+http-body@1.0.1											X							
+http-body-util@0.1.3											X							
+httparse@1.10.1		X									X							
+httpdate@1.0.3		X									X							
+humantime@2.3.0		X									X							
+hyper@1.9.0											X							
+hyper-rustls@0.27.9		X							X		X							
+hyper-tls@0.6.0		X									X							
+hyper-util@0.1.20											X							
+iana-time-zone@0.1.65		X									X							
+iana-time-zone-haiku@0.1.2		X									X							
+icu_collections@2.2.0														X				
+icu_locale_core@2.2.0														X				
+icu_normalizer@2.2.0														X				
+icu_normalizer_data@2.2.0														X				
+icu_properties@2.2.0														X				
+icu_properties_data@2.2.0														X				
+icu_provider@2.2.0														X				
+ident_case@1.0.1		X									X							
+idna@1.1.0		X									X							
+idna_adapter@1.2.2		X									X							
+indexmap@2.14.0		X									X							
+inout@0.1.4		X									X							
+instant@0.1.13					X													
+integer-encoding@3.0.4											X							
+ipnet@2.12.0		X									X							
+itertools@0.12.1		X									X							
+itertools@0.14.0		X									X							
+itoa@1.0.18		X									X							
+jiff@0.2.24											X				X			
+jiff-tzdb@0.1.6											X				X			
+jiff-tzdb-platform@0.1.3											X				X			
+jobserver@0.1.34		X									X							
+js-sys@0.3.98		X									X							
+levenshtein_automata@0.2.1											X							
+lexical-core@1.0.6		X									X							
+lexical-parse-float@1.0.6		X									X							
+lexical-parse-integer@1.0.6		X									X							
+lexical-util@1.0.7		X									X							
+lexical-write-float@1.0.6		X									X							
+lexical-write-integer@1.0.6		X									X							
+libbz2-rs-sys@0.2.5																	X	
+libc@0.2.186		X									X							
 libloading@0.7.4									X									
+libloading@0.8.9									X									
 libloading@0.9.0									X									
-liblzma@0.4.6		X										X						
-liblzma-sys@0.4.5		X										X						
-libm@0.2.15												X						
-libredox@0.1.16												X						
-linux-raw-sys@0.12.1		X	X									X						
-litemap@0.8.0															X			
-lock_api@0.4.14		X										X						
-log@0.4.29		X										X						
-lz4_flex@0.11.6												X						
-lz4_flex@0.13.0												X						
-lzokay-native@0.1.0												X						
-md-5@0.10.6		X										X						
-memchr@2.8.0												X				X		
-mime@0.3.17		X										X						
-miniz_oxide@0.8.9		X										X					X	
-mio@1.0.4												X						
-native-tls@0.2.18		X										X						
-num@0.4.3		X										X						
-num-bigint@0.4.6		X										X						
-num-complex@0.4.6		X										X						
-num-integer@0.1.46		X										X						
-num-iter@0.1.45		X										X						
-num-rational@0.4.2		X										X						
-num-traits@0.2.19		X										X						
-object@0.37.3		X										X						
-object_store@0.13.2		X										X						
-once_cell@1.21.3		X										X						
+liblzma@0.4.6		X									X							
+liblzma-sys@0.4.6		X									X							
+libm@0.2.16											X							
+libredox@0.1.16											X							
+linux-raw-sys@0.12.1		X	X								X							
+linux-raw-sys@0.4.15		X	X								X							
+litemap@0.8.2														X				
+lock_api@0.4.14		X									X							
+log@0.4.29		X									X							
+lru@0.12.5											X							
+lz4_flex@0.11.6											X							
+lz4_flex@0.13.1											X							
+lzokay-native@0.1.0											X							
+md-5@0.10.6		X									X							
+measure_time@0.8.3											X							
+memchr@2.8.0											X				X			
+memmap2@0.9.10		X									X							
+mime@0.3.17		X									X							
+minimal-lexical@0.2.1		X									X							
+miniz_oxide@0.8.9		X									X					X		
+mio@1.2.0											X							
+murmurhash32@0.3.1											X							
+native-tls@0.2.18		X									X							
+nom@7.1.3											X							
+num@0.4.3		X									X							
+num-bigint@0.4.6		X									X							
+num-complex@0.4.6		X									X							
+num-conv@0.2.2		X									X							
+num-integer@0.1.46		X									X							
+num-iter@0.1.45		X									X							
+num-rational@0.4.2		X									X							
+num-traits@0.2.19		X									X							
+num_cpus@1.17.0		X									X							
+object@0.37.3		X									X							
+object_store@0.13.2		X									X							
+once_cell@1.21.4		X									X							
+oneshot@0.1.13		X									X							
 opendal@0.55.0		X																
-openssl@0.10.76		X																
-openssl-macros@0.1.1		X										X						
-openssl-probe@0.2.1		X										X						
-openssl-sys@0.9.112												X						
+openssl@0.10.80		X																
+openssl-macros@0.1.1		X									X							
+openssl-probe@0.2.1		X									X							
+openssl-sys@0.9.116											X							
 orc-rust@0.8.0		X																
-ordered-float@2.10.1												X						
-paimon@0.1.0		X																
-paimon-c@0.1.0		X																
-paimon-datafusion@0.1.0		X																
-paimon-integration-tests@0.1.0		X																
-parking_lot@0.12.5		X										X						
-parking_lot_core@0.9.12		X										X						
-parquet@58.1.0		X																
-paste@1.0.15		X										X						
-percent-encoding@2.3.2		X										X						
-petgraph@0.8.3		X										X						
-phf@0.12.1												X						
-phf_shared@0.12.1												X						
-pin-project-lite@0.2.16		X										X						
-pin-utils@0.1.0		X										X						
-pkg-config@0.3.32		X										X						
-plain@0.2.3		X										X						
-portable-atomic@1.13.1		X										X						
-portable-atomic-util@0.2.6		X										X						
-potential_utf@0.1.2															X			
-ppv-lite86@0.2.21		X										X						
-pretty_assertions@1.4.1		X										X						
-proc-macro2@1.0.95		X										X						
+ordered-float@2.10.1											X							
+ordered-multimap@0.7.3											X							
+ownedbytes@0.7.0											X							
+paimon@0.2.0		X																
+paimon-c@0.2.0		X																
+paimon-datafusion@0.2.0		X																
+paimon-integration-tests@0.2.0		X																
+parking_lot@0.12.5		X									X							
+parking_lot_core@0.9.12		X									X							
+parquet@58.3.0		X																
+paste@1.0.15		X									X							
+percent-encoding@2.3.2		X									X							
+petgraph@0.8.3		X									X							
+phf@0.12.1											X							
+phf_shared@0.12.1											X							
+pin-project-lite@0.2.17		X									X							
+pkg-config@0.3.33		X									X							
+plain@0.2.3		X									X							
+portable-atomic@1.13.1		X									X							
+portable-atomic-util@0.2.7		X									X							
+potential_utf@0.1.5														X				
+powerfmt@0.2.0		X									X							
+ppv-lite86@0.2.21		X									X							
+pretty_assertions@1.4.1		X									X							
+prettyplease@0.2.37		X									X							
+proc-macro2@1.0.106		X									X							
 prost@0.13.5		X																
 prost@0.14.3		X																
 prost-derive@0.13.5		X																
 prost-derive@0.14.3		X																
 prost-types@0.14.3		X																
-psm@0.1.30		X										X						
-pyo3@0.28.3		X										X						
-pyo3-build-config@0.28.3		X										X						
-pyo3-ffi@0.28.3		X										X						
-pyo3-macros@0.28.3		X										X						
-pyo3-macros-backend@0.28.3		X										X						
-pypaimon_rust@0.1.0		X																
-quick-xml@0.37.5												X						
-quick-xml@0.38.4												X						
-quote@1.0.44		X										X						
-r-efi@5.3.0		X								X		X						
-rand@0.10.0		X										X						
-rand@0.8.5		X										X						
-rand@0.9.2		X										X						
-rand_chacha@0.3.1		X										X						
-rand_chacha@0.9.0		X										X						
-rand_core@0.10.0		X										X						
-rand_core@0.6.4		X										X						
-rand_core@0.9.3		X										X						
-recursive@0.1.1												X						
-recursive-proc-macro-impl@0.1.1												X						
-redox_syscall@0.5.18												X						
-regex@1.12.3		X										X						
-regex-automata@0.4.14		X										X						
-regex-syntax@0.8.10		X										X						
-repr_offset@0.2.2																	X	
+psm@0.1.31		X									X							
+pyo3@0.28.3		X									X							
+pyo3-build-config@0.28.3		X									X							
+pyo3-ffi@0.28.3		X									X							
+pyo3-macros@0.28.3		X									X							
+pyo3-macros-backend@0.28.3		X									X							
+pypaimon_rust@0.2.0		X																
+quad-rand@0.2.3											X							
+quick-xml@0.37.5											X							
+quick-xml@0.38.4											X							
+quote@1.0.45		X									X							
+r-efi@5.3.0		X								X	X							
+r-efi@6.0.0		X								X	X							
+rand@0.8.6		X									X							
+rand@0.9.4		X									X							
+rand_chacha@0.3.1		X									X							
+rand_chacha@0.9.0		X									X							
+rand_core@0.6.4		X									X							
+rand_core@0.9.5		X									X							
+rand_distr@0.4.3		X									X							
+rayon@1.12.0		X									X							
+rayon-core@1.13.0		X									X							
+recursive@0.1.1											X							
+recursive-proc-macro-impl@0.1.1											X							
+redox_syscall@0.5.18											X							
+redox_syscall@0.7.5											X							
+regex@1.12.3		X									X							
+regex-automata@0.4.14		X									X							
+regex-lite@0.1.9		X									X							
+regex-syntax@0.8.10		X									X							
+repr_offset@0.2.2																X		
 reqsign@0.16.5		X																
-reqwest@0.12.28		X										X						
+reqwest@0.12.28		X									X							
 ring@0.17.14		X							X									
-roaring@0.11.3		X										X						
-roxmltree@0.21.1		X										X						
-rust_decimal@1.41.0												X						
-rustc_version@0.4.1		X										X						
-rustix@1.1.4		X	X									X						
-rustls@0.23.29		X							X			X						
-rustls-pki-types@1.12.0		X										X						
-rustls-webpki@0.103.4									X									
-rustversion@1.0.21		X										X						
-ryu@1.0.20		X				X												
-same-file@1.0.6												X				X		
-schannel@0.1.29												X						
-scopeguard@1.2.0		X										X						
-security-framework@3.6.0		X										X						
-security-framework-sys@2.17.0		X										X						
-semver@1.0.27		X										X						
-seq-macro@0.3.6		X										X						
-serde@1.0.228		X										X						
-serde-transcode@1.1.1		X										X						
-serde_avro_fast@2.0.2											X							
-serde_bytes@0.11.19		X										X						
-serde_core@1.0.228		X										X						
-serde_derive@1.0.228		X										X						
-serde_json@1.0.149		X										X						
-serde_repr@0.1.20		X										X						
-serde_serializer_quick_unsupported@1.0.0											X							
-serde_urlencoded@0.7.1		X										X						
-serde_with@3.14.0		X										X						
-serde_with_macros@3.14.0		X										X						
-sha1@0.10.6		X										X						
-sha2@0.10.9		X										X						
-shlex@1.3.0		X										X						
-simd-adler32@0.3.8												X						
-simdutf8@0.1.5		X										X						
-siphasher@1.0.2		X										X						
-slab@0.4.10												X						
-smallvec@1.15.1		X										X						
-snafu@0.8.9		X										X						
-snafu@0.9.0		X										X						
-snafu-derive@0.8.9		X										X						
-snafu-derive@0.9.0		X										X						
+roaring@0.11.4		X									X							
+roxmltree@0.21.1		X									X							
+rust-ini@0.21.3											X							
+rust-stemmers@1.2.0					X						X							
+rustc-hash@1.1.0		X									X							
+rustc_version@0.4.1		X									X							
+rustix@0.38.44		X	X								X							
+rustix@1.1.4		X	X								X							
+rustls@0.23.40		X							X		X							
+rustls-pki-types@1.14.1		X									X							
+rustls-webpki@0.103.13									X									
+rustversion@1.0.22		X									X							
+ryu@1.0.23		X				X												
+same-file@1.0.6											X				X			
+schannel@0.1.29											X							
+scopeguard@1.2.0		X									X							
+security-framework@3.7.0		X									X							
+security-framework-sys@2.17.0		X									X							
+semver@1.0.28		X									X							
+seq-macro@0.3.6		X									X							
+serde@1.0.228		X									X							
+serde_bytes@0.11.19		X									X							
+serde_core@1.0.228		X									X							
+serde_derive@1.0.228		X									X							
+serde_json@1.0.149		X									X							
+serde_repr@0.1.20		X									X							
+serde_urlencoded@0.7.1		X									X							
+serde_with@3.20.0		X									X							
+serde_with_macros@3.20.0		X									X							
+sha1@0.10.6		X									X							
+sha2@0.10.9		X									X							
+shlex@1.3.0		X									X							
+simd-adler32@0.3.9											X							
+simdutf8@0.1.5		X									X							
+siphasher@1.0.3		X									X							
+sketches-ddsketch@0.2.2		X																
+slab@0.4.12											X							
+smallvec@1.15.1		X									X							
+snafu@0.8.9		X									X							
+snafu@0.9.0		X									X							
+snafu-derive@0.8.9		X									X							
+snafu-derive@0.9.0		X									X							
 snap@1.1.1					X													
-socket2@0.5.10		X										X						
-socket2@0.6.2		X										X						
+socket2@0.6.3		X									X							
 sqlparser@0.61.0		X																
 sqlparser_derive@0.5.0		X																
-stable_deref_trait@1.2.0		X										X						
-stacker@0.1.23		X										X						
-strsim@0.11.1												X						
+stable_deref_trait@1.2.1		X									X							
+stacker@0.1.24		X									X							
+strsim@0.11.1											X							
+strum@0.27.2											X							
+strum_macros@0.27.2											X							
 subtle@2.6.1					X													
-syn@1.0.109		X										X						
-syn@2.0.117		X										X						
+syn@1.0.109		X									X							
+syn@2.0.117		X									X							
 sync_wrapper@1.0.2		X																
-synstructure@0.13.2												X						
-system-configuration@0.6.1		X										X						
-system-configuration-sys@0.6.0		X										X						
+synstructure@0.13.2											X							
+system-configuration@0.7.0		X									X							
+system-configuration-sys@0.6.0		X									X							
+tantivy@0.22.1											X							
+tantivy-bitpacker@0.6.0											X							
+tantivy-columnar@0.3.0											X							
+tantivy-common@0.7.0											X							
+tantivy-fst@0.5.0											X				X			
+tantivy-query-grammar@0.22.0											X							
+tantivy-sstable@0.3.0											X							
+tantivy-stacker@0.3.0											X							
+tantivy-tokenizer-api@0.3.0											X							
 target-lexicon@0.13.5			X															
-tempfile@3.26.0		X										X						
-thiserror@1.0.69		X										X						
-thiserror@2.0.18		X										X						
-thiserror-impl@1.0.69		X										X						
-thiserror-impl@2.0.18		X										X						
+tempfile@3.27.0		X									X							
+thiserror@1.0.69		X									X							
+thiserror@2.0.18		X									X							
+thiserror-impl@1.0.69		X									X							
+thiserror-impl@2.0.18		X									X							
 thrift@0.17.0		X																
+time@0.3.47		X									X							
+time-core@0.1.8		X									X							
 tiny-keccak@2.0.2							X											
-tinystr@0.8.1															X			
-tokio@1.49.0												X						
-tokio-macros@2.6.0												X						
-tokio-native-tls@0.3.1												X						
-tokio-rustls@0.26.2		X										X						
-tokio-stream@0.1.18												X						
-tokio-util@0.7.18												X						
-tower@0.5.2												X						
-tower-http@0.6.8												X						
-tower-layer@0.3.3												X						
-tower-service@0.3.3												X						
-tracing@0.1.41												X						
-tracing-attributes@0.1.31												X						
-tracing-core@0.1.36												X						
-try-lock@0.2.5												X						
-tstr@0.2.4																	X	
-tstr_proc_macros@0.2.2																	X	
-twox-hash@2.1.2												X						
-typed-arena@2.0.2												X						
-typed-builder@0.19.1		X										X						
-typed-builder-macro@0.19.1		X										X						
-typenum@1.18.0		X										X						
-typewit@1.15.1																	X	
-unicode-ident@1.0.18		X										X			X			
-unicode-segmentation@1.13.2		X										X						
-unicode-width@0.2.2		X										X						
+tinystr@0.8.3														X				
+tokio@1.52.3											X							
+tokio-macros@2.7.0											X							
+tokio-native-tls@0.3.1											X							
+tokio-rustls@0.26.4		X									X							
+tokio-stream@0.1.18											X							
+tokio-util@0.7.18											X							
+tower@0.5.3											X							
+tower-http@0.6.11											X							
+tower-layer@0.3.3											X							
+tower-service@0.3.3											X							
+tracing@0.1.44											X							
+tracing-attributes@0.1.31											X							
+tracing-core@0.1.36											X							
+try-lock@0.2.5											X							
+tstr@0.2.4																X		
+tstr_proc_macros@0.2.2																X		
+twox-hash@2.1.2											X							
+typed-arena@2.0.2											X							
+typed-builder@0.19.1		X									X							
+typed-builder-macro@0.19.1		X									X							
+typenum@1.20.0		X									X							
+typewit@1.15.2																X		
+unicode-ident@1.0.24		X									X			X				
+unicode-segmentation@1.13.2		X									X							
+unicode-width@0.2.2		X									X							
 untrusted@0.9.0									X									
-url@2.5.8		X										X						
-urlencoding@2.1.3												X						
-utf8_iter@1.0.4		X										X						
-uuid@1.21.0		X										X						
-vcpkg@0.2.15		X										X						
-version_check@0.9.5		X										X						
-walkdir@2.5.0												X				X		
-want@0.3.1												X						
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X						
-wasi@0.14.2+wasi-0.2.4		X	X									X						
-wasip2@1.0.2+wasi-0.2.9		X	X									X						
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X						
-wasite@0.1.0		X				X						X						
-wasm-bindgen@0.2.100		X										X						
-wasm-bindgen-backend@0.2.100		X										X						
-wasm-bindgen-futures@0.4.50		X										X						
-wasm-bindgen-macro@0.2.100		X										X						
-wasm-bindgen-macro-support@0.2.100		X										X						
-wasm-bindgen-shared@0.2.100		X										X						
-wasm-streams@0.4.2		X										X						
-web-sys@0.3.77		X										X						
-web-time@1.1.0		X										X						
-webpki-roots@1.0.2								X										
-whoami@1.6.1		X				X						X						
-winapi@0.3.9		X										X						
-winapi-i686-pc-windows-gnu@0.4.0		X										X						
-winapi-util@0.1.11												X				X		
-winapi-x86_64-pc-windows-gnu@0.4.0		X										X						
-windows-core@0.61.2		X										X						
-windows-implement@0.60.0		X										X						
-windows-interface@0.59.1		X										X						
-windows-link@0.1.3		X										X						
-windows-link@0.2.1		X										X						
-windows-registry@0.5.3		X										X						
-windows-result@0.3.4		X										X						
-windows-strings@0.4.2		X										X						
-windows-sys@0.52.0		X										X						
-windows-sys@0.59.0		X										X						
-windows-sys@0.60.2		X										X						
-windows-sys@0.61.2		X										X						
-windows-targets@0.52.6		X										X						
-windows-targets@0.53.5		X										X						
-windows_aarch64_gnullvm@0.52.6		X										X						
-windows_aarch64_gnullvm@0.53.1		X										X						
-windows_aarch64_msvc@0.52.6		X										X						
-windows_aarch64_msvc@0.53.1		X										X						
-windows_i686_gnu@0.52.6		X										X						
-windows_i686_gnu@0.53.1		X										X						
-windows_i686_gnullvm@0.52.6		X										X						
-windows_i686_gnullvm@0.53.1		X										X						
-windows_i686_msvc@0.52.6		X										X						
-windows_i686_msvc@0.53.1		X										X						
-windows_x86_64_gnu@0.52.6		X										X						
-windows_x86_64_gnu@0.53.1		X										X						
-windows_x86_64_gnullvm@0.52.6		X										X						
-windows_x86_64_gnullvm@0.53.1		X										X						
-windows_x86_64_msvc@0.52.6		X										X						
-windows_x86_64_msvc@0.53.1		X										X						
-wit-bindgen@0.51.0		X	X									X						
-wit-bindgen-rt@0.39.0		X	X									X						
-writeable@0.6.1															X			
-yansi@1.0.1		X										X						
-yoke@0.8.0															X			
-yoke-derive@0.8.0															X			
-zerocopy@0.8.26		X		X								X						
-zerocopy-derive@0.8.26		X		X								X						
-zerofrom@0.1.6															X			
-zerofrom-derive@0.1.6															X			
-zeroize@1.8.1		X										X						
-zerotrie@0.2.2															X			
-zerovec@0.11.2															X			
-zerovec-derive@0.11.1															X			
-zlib-rs@0.6.3																	X	
-zmij@1.0.21												X						
-zstd@0.13.3												X						
-zstd-safe@7.2.4		X										X						
-zstd-sys@2.0.16+zstd.1.5.7		X										X						
+url@2.5.8		X									X							
+urlencoding@2.1.3											X							
+utf8-ranges@1.0.5											X				X			
+utf8_iter@1.0.4		X									X							
+uuid@1.23.1		X									X							
+vcpkg@0.2.15		X									X							
+version_check@0.9.5		X									X							
+walkdir@2.5.0											X				X			
+want@0.3.1											X							
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X							
+wasip2@1.0.3+wasi-0.2.9		X	X								X							
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X							
+wasite@0.1.0		X				X					X							
+wasm-bindgen@0.2.121		X									X							
+wasm-bindgen-futures@0.4.71		X									X							
+wasm-bindgen-macro@0.2.121		X									X							
+wasm-bindgen-macro-support@0.2.121		X									X							
+wasm-bindgen-shared@0.2.121		X									X							
+wasm-streams@0.4.2		X									X							
+web-sys@0.3.98		X									X							
+web-time@1.1.0		X									X							
+webpki-roots@1.0.7								X										
+whoami@1.6.1		X				X					X							
+winapi@0.3.9		X									X							
+winapi-i686-pc-windows-gnu@0.4.0		X									X							
+winapi-util@0.1.11											X				X			
+winapi-x86_64-pc-windows-gnu@0.4.0		X									X							
+windows-core@0.62.2		X									X							
+windows-implement@0.60.2		X									X							
+windows-interface@0.59.3		X									X							
+windows-link@0.2.1		X									X							
+windows-registry@0.6.1		X									X							
+windows-result@0.4.1		X									X							
+windows-strings@0.5.1		X									X							
+windows-sys@0.52.0		X									X							
+windows-sys@0.59.0		X									X							
+windows-sys@0.60.2		X									X							
+windows-sys@0.61.2		X									X							
+windows-targets@0.52.6		X									X							
+windows-targets@0.53.5		X									X							
+windows_aarch64_gnullvm@0.52.6		X									X							
+windows_aarch64_gnullvm@0.53.1		X									X							
+windows_aarch64_msvc@0.52.6		X									X							
+windows_aarch64_msvc@0.53.1		X									X							
+windows_i686_gnu@0.52.6		X									X							
+windows_i686_gnu@0.53.1		X									X							
+windows_i686_gnullvm@0.52.6		X									X							
+windows_i686_gnullvm@0.53.1		X									X							
+windows_i686_msvc@0.52.6		X									X							
+windows_i686_msvc@0.53.1		X									X							
+windows_x86_64_gnu@0.52.6		X									X							
+windows_x86_64_gnu@0.53.1		X									X							
+windows_x86_64_gnullvm@0.52.6		X									X							
+windows_x86_64_gnullvm@0.53.1		X									X							
+windows_x86_64_msvc@0.52.6		X									X							
+windows_x86_64_msvc@0.53.1		X									X							
+wit-bindgen@0.51.0		X	X								X							
+wit-bindgen@0.57.1		X	X								X							
+writeable@0.6.3														X				
+yansi@1.0.1		X									X							
+yoke@0.8.2														X				
+yoke-derive@0.8.2														X				
+zerocopy@0.8.48		X		X							X							
+zerocopy-derive@0.8.48		X		X							X							
+zerofrom@0.1.8														X				
+zerofrom-derive@0.1.7														X				
+zeroize@1.8.2		X									X							
+zerotrie@0.2.4														X				
+zerovec@0.11.6														X				
+zerovec-derive@0.11.3														X				
+zlib-rs@0.6.3																X		
+zmij@1.0.21											X							
+zstd@0.13.3											X							
+zstd-safe@7.2.4		X									X							
+zstd-sys@2.0.16+zstd.1.5.7		X									X							

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -1,344 +1,331 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X										X			
-ahash@0.8.12		X										X			
-aho-corasick@1.1.4												X		X	
-alloc-no-stdlib@2.0.4					X										
-alloc-stdlib@0.2.2					X										
-android_system_properties@0.1.5		X										X			
-anyhow@1.0.102		X										X			
-arrayvec@0.7.6		X										X			
-arrow@58.1.0		X													
-arrow-arith@58.1.0		X													
-arrow-array@58.1.0		X													
-arrow-buffer@58.1.0		X													
-arrow-cast@58.1.0		X													
-arrow-csv@58.1.0		X													
-arrow-data@58.1.0		X													
-arrow-ipc@58.1.0		X													
-arrow-json@58.1.0		X													
-arrow-ord@58.1.0		X													
-arrow-row@58.1.0		X													
-arrow-schema@58.1.0		X													
-arrow-select@58.1.0		X													
-arrow-string@58.1.0		X													
-async-stream@0.3.6												X			
-async-stream-impl@0.3.6												X			
-async-trait@0.1.89		X										X			
-atoi@2.0.0												X			
-atomic-waker@1.1.2		X										X			
-autocfg@1.5.0		X										X			
-backon@1.6.0		X													
-base64@0.22.1		X										X			
-bitflags@2.9.1		X										X			
-block-buffer@0.10.4		X										X			
-brotli@8.0.2					X							X			
-brotli-decompressor@5.0.0					X							X			
-bumpalo@3.19.0		X										X			
-bytemuck@1.25.0		X										X			X
-byteorder@1.5.0												X		X	
-bytes@1.11.1												X			
-cc@1.2.56		X										X			
-cfg-if@1.0.1		X										X			
-chacha20@0.10.0		X										X			
-chrono@0.4.44		X										X			
-chrono-tz@0.10.4		X										X			
-comfy-table@7.2.2												X			
-const-oid@0.9.6		X										X			
-const-random@0.1.18		X										X			
-const-random-macro@0.1.16		X										X			
-core-foundation@0.10.1		X										X			
-core-foundation@0.9.4		X										X			
-core-foundation-sys@0.8.7		X										X			
-cpufeatures@0.2.17		X										X			
-cpufeatures@0.3.0		X										X			
-crc32fast@1.5.0		X										X			
-crunchy@0.2.4												X			
-crypto-common@0.1.6		X										X			
-csv@1.4.0												X		X	
-csv-core@0.1.13												X		X	
-darling@0.20.11												X			
-darling_core@0.20.11												X			
-darling_macro@0.20.11												X			
-diff@0.1.13		X										X			
-digest@0.10.7		X										X			
-displaydoc@0.2.5		X										X			
-either@1.15.0		X										X			
-encoding_rs@0.8.35		X			X							X			
-equivalent@1.0.2		X										X			
-errno@0.3.14		X										X			
-fallible-streaming-iterator@0.1.9		X										X			
-fastrand@2.3.0		X										X			
-find-msvc-tools@0.1.9		X										X			
-flatbuffers@25.12.19		X													
-flate2@1.1.9		X										X			
-fnv@1.0.7		X										X			
-foreign-types@0.3.2		X										X			
-foreign-types-shared@0.1.1		X										X			
-form_urlencoded@1.2.2		X										X			
-futures@0.3.31		X										X			
-futures-channel@0.3.31		X										X			
-futures-core@0.3.31		X										X			
-futures-executor@0.3.31		X										X			
-futures-io@0.3.31		X										X			
-futures-macro@0.3.31		X										X			
-futures-sink@0.3.31		X										X			
-futures-task@0.3.31		X										X			
-futures-util@0.3.31		X										X			
-generic-array@0.14.7												X			
-getrandom@0.2.16		X										X			
-getrandom@0.3.3		X										X			
-getrandom@0.4.1		X										X			
-gloo-timers@0.3.0		X										X			
-h2@0.4.13												X			
-half@2.7.1		X										X			
-hashbrown@0.16.1		X										X			
-heck@0.5.0		X										X			
-hex@0.4.3		X										X			
-hmac@0.12.1		X										X			
-home@0.5.12		X										X			
-http@1.3.1		X										X			
-http-body@1.0.1												X			
-http-body-util@0.1.3												X			
-httparse@1.10.1		X										X			
-httpdate@1.0.3		X										X			
-hyper@1.6.0												X			
-hyper-rustls@0.27.7		X							X			X			
-hyper-tls@0.6.0		X										X			
-hyper-util@0.1.15												X			
-iana-time-zone@0.1.63		X										X			
-iana-time-zone-haiku@0.1.2		X										X			
-icu_collections@2.0.0													X		
-icu_locale_core@2.0.0													X		
-icu_normalizer@2.0.0													X		
-icu_normalizer_data@2.0.0													X		
-icu_properties@2.0.1													X		
-icu_properties_data@2.0.1													X		
-icu_provider@2.0.0													X		
-ident_case@1.0.1		X										X			
-idna@1.1.0		X										X			
-idna_adapter@1.2.1		X										X			
-indexmap@2.13.0		X										X			
-integer-encoding@3.0.4												X			
-integer-encoding@4.1.0												X			
-ipnet@2.11.0		X										X			
-iri-string@0.7.8		X										X			
-itertools@0.14.0		X										X			
-itoa@1.0.15		X										X			
-jiff@0.2.23												X		X	
-jiff-tzdb@0.1.6												X		X	
-jiff-tzdb-platform@0.1.3												X		X	
-jobserver@0.1.34		X										X			
-js-sys@0.3.77		X										X			
-lexical-core@1.0.6		X										X			
-lexical-parse-float@1.0.6		X										X			
-lexical-parse-integer@1.0.6		X										X			
-lexical-util@1.0.7		X										X			
-lexical-write-float@1.0.6		X										X			
-lexical-write-integer@1.0.6		X										X			
-libc@0.2.182		X										X			
-libm@0.2.15												X			
-linux-raw-sys@0.12.1		X	X									X			
-litemap@0.8.0													X		
-log@0.4.29		X										X			
-lz4_flex@0.11.6												X			
-lz4_flex@0.13.0												X			
-lzokay-native@0.1.0												X			
-md-5@0.10.6		X										X			
-memchr@2.8.0												X		X	
-mime@0.3.17		X										X			
-miniz_oxide@0.8.9		X										X			X
-mio@1.0.4												X			
-native-tls@0.2.18		X										X			
-num@0.4.3		X										X			
-num-bigint@0.4.6		X										X			
-num-complex@0.4.6		X										X			
-num-integer@0.1.46		X										X			
-num-iter@0.1.45		X										X			
-num-rational@0.4.2		X										X			
-num-traits@0.2.19		X										X			
-once_cell@1.21.3		X										X			
-opendal@0.55.0		X													
-openssl@0.10.76		X													
-openssl-macros@0.1.1		X										X			
-openssl-probe@0.2.1		X										X			
-openssl-sys@0.9.112												X			
-orc-rust@0.8.0		X													
-ordered-float@2.10.1												X			
-paimon@0.1.0		X													
-paimon-c@0.1.0		X													
-parquet@58.1.0		X													
-paste@1.0.15		X										X			
-percent-encoding@2.3.2		X										X			
-phf@0.12.1												X			
-phf_shared@0.12.1												X			
-pin-project-lite@0.2.16		X										X			
-pin-utils@0.1.0		X										X			
-pkg-config@0.3.32		X										X			
-portable-atomic@1.13.1		X										X			
-portable-atomic-util@0.2.6		X										X			
-potential_utf@0.1.2													X		
-ppv-lite86@0.2.21		X										X			
-pretty_assertions@1.4.1		X										X			
-proc-macro2@1.0.95		X										X			
-prost@0.13.5		X													
-prost-derive@0.13.5		X													
-quick-xml@0.38.4												X			
-quote@1.0.44		X										X			
-r-efi@5.3.0		X								X		X			
-rand@0.10.0		X										X			
-rand@0.8.5		X										X			
-rand_chacha@0.3.1		X										X			
-rand_core@0.10.0		X										X			
-rand_core@0.6.4		X										X			
-regex@1.12.3		X										X			
-regex-automata@0.4.14		X										X			
-regex-syntax@0.8.10		X										X			
-reqsign@0.16.5		X													
-reqwest@0.12.28		X										X			
-ring@0.17.14		X							X						
-roaring@0.11.3		X										X			
-rust_decimal@1.41.0												X			
-rustc_version@0.4.1		X										X			
-rustix@1.1.4		X	X									X			
-rustls@0.23.29		X							X			X			
-rustls-pki-types@1.12.0		X										X			
-rustls-webpki@0.103.4									X						
-rustversion@1.0.21		X										X			
-ryu@1.0.20		X				X									
-schannel@0.1.29												X			
-security-framework@3.6.0		X										X			
-security-framework-sys@2.17.0		X										X			
-semver@1.0.27		X										X			
-seq-macro@0.3.6		X										X			
-serde@1.0.228		X										X			
-serde-transcode@1.1.1		X										X			
-serde_avro_fast@2.0.2											X				
-serde_bytes@0.11.19		X										X			
-serde_core@1.0.228		X										X			
-serde_derive@1.0.228		X										X			
-serde_json@1.0.149		X										X			
-serde_repr@0.1.20		X										X			
-serde_serializer_quick_unsupported@1.0.0											X				
-serde_urlencoded@0.7.1		X										X			
-serde_with@3.14.0		X										X			
-serde_with_macros@3.14.0		X										X			
-sha1@0.10.6		X										X			
-sha2@0.10.9		X										X			
-shlex@1.3.0		X										X			
-simd-adler32@0.3.8												X			
-simdutf8@0.1.5		X										X			
-siphasher@1.0.2		X										X			
-slab@0.4.10												X			
-smallvec@1.15.1		X										X			
-snafu@0.8.9		X										X			
-snafu@0.9.0		X										X			
-snafu-derive@0.8.9		X										X			
-snafu-derive@0.9.0		X										X			
-snap@1.1.1					X										
-socket2@0.5.10		X										X			
-socket2@0.6.2		X										X			
-stable_deref_trait@1.2.0		X										X			
-strsim@0.11.1												X			
-subtle@2.6.1					X										
-syn@2.0.117		X										X			
-sync_wrapper@1.0.2		X													
-synstructure@0.13.2												X			
-system-configuration@0.6.1		X										X			
-system-configuration-sys@0.6.0		X										X			
-tempfile@3.26.0		X										X			
-thiserror@1.0.69		X										X			
-thiserror@2.0.18		X										X			
-thiserror-impl@1.0.69		X										X			
-thiserror-impl@2.0.18		X										X			
-thrift@0.17.0		X													
-tiny-keccak@2.0.2							X								
-tinystr@0.8.1													X		
-tokio@1.49.0												X			
-tokio-macros@2.6.0												X			
-tokio-native-tls@0.3.1												X			
-tokio-rustls@0.26.2		X										X			
-tokio-util@0.7.18												X			
-tower@0.5.2												X			
-tower-http@0.6.8												X			
-tower-layer@0.3.3												X			
-tower-service@0.3.3												X			
-tracing@0.1.41												X			
-tracing-core@0.1.36												X			
-try-lock@0.2.5												X			
-twox-hash@2.1.2												X			
-typed-builder@0.19.1		X										X			
-typed-builder-macro@0.19.1		X										X			
-typenum@1.18.0		X										X			
-unicode-ident@1.0.18		X										X	X		
-unicode-segmentation@1.13.2		X										X			
-unicode-width@0.2.2		X										X			
-untrusted@0.9.0									X						
-url@2.5.8		X										X			
-urlencoding@2.1.3												X			
-utf8_iter@1.0.4		X										X			
-uuid@1.21.0		X										X			
-vcpkg@0.2.15		X										X			
-version_check@0.9.5		X										X			
-want@0.3.1												X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X			
-wasi@0.14.2+wasi-0.2.4		X	X									X			
-wasip2@1.0.2+wasi-0.2.9		X	X									X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X			
-wasm-bindgen@0.2.100		X										X			
-wasm-bindgen-backend@0.2.100		X										X			
-wasm-bindgen-futures@0.4.50		X										X			
-wasm-bindgen-macro@0.2.100		X										X			
-wasm-bindgen-macro-support@0.2.100		X										X			
-wasm-bindgen-shared@0.2.100		X										X			
-wasm-streams@0.4.2		X										X			
-web-sys@0.3.77		X										X			
-webpki-roots@1.0.2								X							
-windows-core@0.61.2		X										X			
-windows-implement@0.60.0		X										X			
-windows-interface@0.59.1		X										X			
-windows-link@0.1.3		X										X			
-windows-link@0.2.1		X										X			
-windows-registry@0.5.3		X										X			
-windows-result@0.3.4		X										X			
-windows-strings@0.4.2		X										X			
-windows-sys@0.52.0		X										X			
-windows-sys@0.59.0		X										X			
-windows-sys@0.60.2		X										X			
-windows-sys@0.61.2		X										X			
-windows-targets@0.52.6		X										X			
-windows-targets@0.53.5		X										X			
-windows_aarch64_gnullvm@0.52.6		X										X			
-windows_aarch64_gnullvm@0.53.1		X										X			
-windows_aarch64_msvc@0.52.6		X										X			
-windows_aarch64_msvc@0.53.1		X										X			
-windows_i686_gnu@0.52.6		X										X			
-windows_i686_gnu@0.53.1		X										X			
-windows_i686_gnullvm@0.52.6		X										X			
-windows_i686_gnullvm@0.53.1		X										X			
-windows_i686_msvc@0.52.6		X										X			
-windows_i686_msvc@0.53.1		X										X			
-windows_x86_64_gnu@0.52.6		X										X			
-windows_x86_64_gnu@0.53.1		X										X			
-windows_x86_64_gnullvm@0.52.6		X										X			
-windows_x86_64_gnullvm@0.53.1		X										X			
-windows_x86_64_msvc@0.52.6		X										X			
-windows_x86_64_msvc@0.53.1		X										X			
-wit-bindgen@0.51.0		X	X									X			
-wit-bindgen-rt@0.39.0		X	X									X			
-writeable@0.6.1													X		
-yansi@1.0.1		X										X			
-yoke@0.8.0													X		
-yoke-derive@0.8.0													X		
-zerocopy@0.8.26		X		X								X			
-zerocopy-derive@0.8.26		X		X								X			
-zerofrom@0.1.6													X		
-zerofrom-derive@0.1.6													X		
-zeroize@1.8.1		X										X			
-zerotrie@0.2.2													X		
-zerovec@0.11.2													X		
-zerovec-derive@0.11.1													X		
-zlib-rs@0.6.3															X
-zmij@1.0.21												X			
-zstd@0.13.3												X			
-zstd-safe@7.2.4		X										X			
-zstd-sys@2.0.16+zstd.1.5.7		X										X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X			
+ahash@0.8.12		X									X			
+aho-corasick@1.1.4											X		X	
+alloc-no-stdlib@2.0.4					X									
+alloc-stdlib@0.2.2					X									
+android_system_properties@0.1.5		X									X			
+anyhow@1.0.102		X									X			
+apache-avro@0.21.0		X												
+arrow@58.3.0		X												
+arrow-arith@58.3.0		X												
+arrow-array@58.3.0		X									X			
+arrow-buffer@58.3.0		X												
+arrow-cast@58.3.0		X												
+arrow-csv@58.3.0		X												
+arrow-data@58.3.0		X												
+arrow-ipc@58.3.0		X												
+arrow-json@58.3.0		X												
+arrow-ord@58.3.0		X												
+arrow-row@58.3.0		X												
+arrow-schema@58.3.0		X												
+arrow-select@58.3.0		X												
+arrow-string@58.3.0		X												
+async-stream@0.3.6											X			
+async-stream-impl@0.3.6											X			
+async-trait@0.1.89		X									X			
+atoi@2.0.0											X			
+atomic-waker@1.1.2		X									X			
+autocfg@1.5.0		X									X			
+backon@1.6.0		X												
+base64@0.22.1		X									X			
+bigdecimal@0.4.10		X									X			
+bitflags@2.11.1		X									X			
+block-buffer@0.10.4		X									X			
+bon@3.9.1		X									X			
+bon-macros@3.9.1		X									X			
+brotli@8.0.2					X						X			
+brotli-decompressor@5.0.0					X						X			
+bumpalo@3.20.2		X									X			
+bytemuck@1.25.0		X									X			X
+byteorder@1.5.0											X		X	
+bytes@1.11.1											X			
+cc@1.2.62		X									X			
+cfg-if@1.0.4		X									X			
+chrono@0.4.44		X									X			
+chrono-tz@0.10.4		X									X			
+comfy-table@7.2.2											X			
+const-oid@0.9.6		X									X			
+const-random@0.1.18		X									X			
+const-random-macro@0.1.16		X									X			
+core-foundation@0.10.1		X									X			
+core-foundation@0.9.4		X									X			
+core-foundation-sys@0.8.7		X									X			
+cpufeatures@0.2.17		X									X			
+crc32fast@1.5.0		X									X			
+crunchy@0.2.4											X			
+crypto-common@0.1.7		X									X			
+csv@1.4.0											X		X	
+csv-core@0.1.13											X		X	
+darling@0.23.0											X			
+darling_core@0.23.0											X			
+darling_macro@0.23.0											X			
+diff@0.1.13		X									X			
+digest@0.10.7		X									X			
+displaydoc@0.2.5		X									X			
+either@1.15.0		X									X			
+encoding_rs@0.8.35		X			X						X			
+equivalent@1.0.2		X									X			
+errno@0.3.14		X									X			
+fallible-streaming-iterator@0.1.9		X									X			
+fastrand@2.4.1		X									X			
+find-msvc-tools@0.1.9		X									X			
+flatbuffers@25.12.19		X												
+flate2@1.1.9		X									X			
+fnv@1.0.7		X									X			
+foreign-types@0.3.2		X									X			
+foreign-types-shared@0.1.1		X									X			
+form_urlencoded@1.2.2		X									X			
+futures@0.3.32		X									X			
+futures-channel@0.3.32		X									X			
+futures-core@0.3.32		X									X			
+futures-executor@0.3.32		X									X			
+futures-io@0.3.32		X									X			
+futures-macro@0.3.32		X									X			
+futures-sink@0.3.32		X									X			
+futures-task@0.3.32		X									X			
+futures-util@0.3.32		X									X			
+generic-array@0.14.7											X			
+getrandom@0.2.17		X									X			
+getrandom@0.3.4		X									X			
+getrandom@0.4.2		X									X			
+gloo-timers@0.3.0		X									X			
+h2@0.4.14											X			
+half@2.7.1		X									X			
+hashbrown@0.17.1		X									X			
+heck@0.5.0		X									X			
+hex@0.4.3		X									X			
+hmac@0.12.1		X									X			
+home@0.5.12		X									X			
+http@1.4.0		X									X			
+http-body@1.0.1											X			
+http-body-util@0.1.3											X			
+httparse@1.10.1		X									X			
+httpdate@1.0.3		X									X			
+hyper@1.9.0											X			
+hyper-rustls@0.27.9		X							X		X			
+hyper-tls@0.6.0		X									X			
+hyper-util@0.1.20											X			
+iana-time-zone@0.1.65		X									X			
+iana-time-zone-haiku@0.1.2		X									X			
+icu_collections@2.2.0												X		
+icu_locale_core@2.2.0												X		
+icu_normalizer@2.2.0												X		
+icu_normalizer_data@2.2.0												X		
+icu_properties@2.2.0												X		
+icu_properties_data@2.2.0												X		
+icu_provider@2.2.0												X		
+ident_case@1.0.1		X									X			
+idna@1.1.0		X									X			
+idna_adapter@1.2.2		X									X			
+indexmap@2.14.0		X									X			
+integer-encoding@3.0.4											X			
+ipnet@2.12.0		X									X			
+itertools@0.14.0		X									X			
+itoa@1.0.18		X									X			
+jiff@0.2.24											X		X	
+jiff-tzdb@0.1.6											X		X	
+jiff-tzdb-platform@0.1.3											X		X	
+jobserver@0.1.34		X									X			
+js-sys@0.3.98		X									X			
+lexical-core@1.0.6		X									X			
+lexical-parse-float@1.0.6		X									X			
+lexical-parse-integer@1.0.6		X									X			
+lexical-util@1.0.7		X									X			
+lexical-write-float@1.0.6		X									X			
+lexical-write-integer@1.0.6		X									X			
+libc@0.2.186		X									X			
+libloading@0.8.9									X					
+libm@0.2.16											X			
+linux-raw-sys@0.12.1		X	X								X			
+litemap@0.8.2												X		
+log@0.4.29		X									X			
+lz4_flex@0.11.6											X			
+lz4_flex@0.13.1											X			
+lzokay-native@0.1.0											X			
+md-5@0.10.6		X									X			
+memchr@2.8.0											X		X	
+mime@0.3.17		X									X			
+miniz_oxide@0.8.9		X									X			X
+mio@1.2.0											X			
+native-tls@0.2.18		X									X			
+num@0.4.3		X									X			
+num-bigint@0.4.6		X									X			
+num-complex@0.4.6		X									X			
+num-integer@0.1.46		X									X			
+num-iter@0.1.45		X									X			
+num-rational@0.4.2		X									X			
+num-traits@0.2.19		X									X			
+once_cell@1.21.4		X									X			
+opendal@0.55.0		X												
+openssl@0.10.80		X												
+openssl-macros@0.1.1		X									X			
+openssl-probe@0.2.1		X									X			
+openssl-sys@0.9.116											X			
+orc-rust@0.8.0		X												
+ordered-float@2.10.1											X			
+paimon@0.2.0		X												
+paimon-c@0.2.0		X												
+parquet@58.3.0		X												
+paste@1.0.15		X									X			
+percent-encoding@2.3.2		X									X			
+phf@0.12.1											X			
+phf_shared@0.12.1											X			
+pin-project-lite@0.2.17		X									X			
+pkg-config@0.3.33		X									X			
+portable-atomic@1.13.1		X									X			
+portable-atomic-util@0.2.7		X									X			
+potential_utf@0.1.5												X		
+ppv-lite86@0.2.21		X									X			
+pretty_assertions@1.4.1		X									X			
+prettyplease@0.2.37		X									X			
+proc-macro2@1.0.106		X									X			
+prost@0.13.5		X												
+prost-derive@0.13.5		X												
+quad-rand@0.2.3											X			
+quick-xml@0.38.4											X			
+quote@1.0.45		X									X			
+r-efi@5.3.0		X								X	X			
+r-efi@6.0.0		X								X	X			
+rand@0.8.6		X									X			
+rand@0.9.4		X									X			
+rand_chacha@0.3.1		X									X			
+rand_chacha@0.9.0		X									X			
+rand_core@0.6.4		X									X			
+rand_core@0.9.5		X									X			
+regex@1.12.3		X									X			
+regex-automata@0.4.14		X									X			
+regex-lite@0.1.9		X									X			
+regex-syntax@0.8.10		X									X			
+reqsign@0.16.5		X												
+reqwest@0.12.28		X									X			
+ring@0.17.14		X							X					
+roaring@0.11.4		X									X			
+rustc_version@0.4.1		X									X			
+rustix@1.1.4		X	X								X			
+rustls@0.23.40		X							X		X			
+rustls-pki-types@1.14.1		X									X			
+rustls-webpki@0.103.13									X					
+rustversion@1.0.22		X									X			
+ryu@1.0.23		X				X								
+schannel@0.1.29											X			
+security-framework@3.7.0		X									X			
+security-framework-sys@2.17.0		X									X			
+semver@1.0.28		X									X			
+seq-macro@0.3.6		X									X			
+serde@1.0.228		X									X			
+serde_bytes@0.11.19		X									X			
+serde_core@1.0.228		X									X			
+serde_derive@1.0.228		X									X			
+serde_json@1.0.149		X									X			
+serde_repr@0.1.20		X									X			
+serde_urlencoded@0.7.1		X									X			
+serde_with@3.20.0		X									X			
+serde_with_macros@3.20.0		X									X			
+sha1@0.10.6		X									X			
+sha2@0.10.9		X									X			
+shlex@1.3.0		X									X			
+simd-adler32@0.3.9											X			
+simdutf8@0.1.5		X									X			
+siphasher@1.0.3		X									X			
+slab@0.4.12											X			
+smallvec@1.15.1		X									X			
+snafu@0.8.9		X									X			
+snafu@0.9.0		X									X			
+snafu-derive@0.8.9		X									X			
+snafu-derive@0.9.0		X									X			
+snap@1.1.1					X									
+socket2@0.6.3		X									X			
+stable_deref_trait@1.2.1		X									X			
+strsim@0.11.1											X			
+strum@0.27.2											X			
+strum_macros@0.27.2											X			
+subtle@2.6.1					X									
+syn@2.0.117		X									X			
+sync_wrapper@1.0.2		X												
+synstructure@0.13.2											X			
+system-configuration@0.7.0		X									X			
+system-configuration-sys@0.6.0		X									X			
+tempfile@3.27.0		X									X			
+thiserror@1.0.69		X									X			
+thiserror@2.0.18		X									X			
+thiserror-impl@1.0.69		X									X			
+thiserror-impl@2.0.18		X									X			
+thrift@0.17.0		X												
+tiny-keccak@2.0.2							X							
+tinystr@0.8.3												X		
+tokio@1.52.3											X			
+tokio-macros@2.7.0											X			
+tokio-native-tls@0.3.1											X			
+tokio-rustls@0.26.4		X									X			
+tokio-util@0.7.18											X			
+tower@0.5.3											X			
+tower-http@0.6.11											X			
+tower-layer@0.3.3											X			
+tower-service@0.3.3											X			
+tracing@0.1.44											X			
+tracing-core@0.1.36											X			
+try-lock@0.2.5											X			
+twox-hash@2.1.2											X			
+typed-builder@0.19.1		X									X			
+typed-builder-macro@0.19.1		X									X			
+typenum@1.20.0		X									X			
+unicode-ident@1.0.24		X									X	X		
+unicode-segmentation@1.13.2		X									X			
+unicode-width@0.2.2		X									X			
+untrusted@0.9.0									X					
+url@2.5.8		X									X			
+urlencoding@2.1.3											X			
+utf8_iter@1.0.4		X									X			
+uuid@1.23.1		X									X			
+vcpkg@0.2.15		X									X			
+version_check@0.9.5		X									X			
+want@0.3.1											X			
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
+wasip2@1.0.3+wasi-0.2.9		X	X								X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X			
+wasm-bindgen@0.2.121		X									X			
+wasm-bindgen-futures@0.4.71		X									X			
+wasm-bindgen-macro@0.2.121		X									X			
+wasm-bindgen-macro-support@0.2.121		X									X			
+wasm-bindgen-shared@0.2.121		X									X			
+wasm-streams@0.4.2		X									X			
+web-sys@0.3.98		X									X			
+webpki-roots@1.0.7								X						
+windows-core@0.62.2		X									X			
+windows-implement@0.60.2		X									X			
+windows-interface@0.59.3		X									X			
+windows-link@0.2.1		X									X			
+windows-registry@0.6.1		X									X			
+windows-result@0.4.1		X									X			
+windows-strings@0.5.1		X									X			
+windows-sys@0.52.0		X									X			
+windows-sys@0.61.2		X									X			
+windows-targets@0.52.6		X									X			
+windows_aarch64_gnullvm@0.52.6		X									X			
+windows_aarch64_msvc@0.52.6		X									X			
+windows_i686_gnu@0.52.6		X									X			
+windows_i686_gnullvm@0.52.6		X									X			
+windows_i686_msvc@0.52.6		X									X			
+windows_x86_64_gnu@0.52.6		X									X			
+windows_x86_64_gnullvm@0.52.6		X									X			
+windows_x86_64_msvc@0.52.6		X									X			
+wit-bindgen@0.51.0		X	X								X			
+wit-bindgen@0.57.1		X	X								X			
+writeable@0.6.3												X		
+yansi@1.0.1		X									X			
+yoke@0.8.2												X		
+yoke-derive@0.8.2												X		
+zerocopy@0.8.48		X		X							X			
+zerocopy-derive@0.8.48		X		X							X			
+zerofrom@0.1.8												X		
+zerofrom-derive@0.1.7												X		
+zeroize@1.8.2		X									X			
+zerotrie@0.2.4												X		
+zerovec@0.11.6												X		
+zerovec-derive@0.11.3												X		
+zlib-rs@0.6.3														X
+zmij@1.0.21											X			
+zstd@0.13.3											X			
+zstd-safe@7.2.4		X									X			
+zstd-sys@2.0.16+zstd.1.5.7		X									X			

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -1,477 +1,523 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
-abi_stable@0.11.3		X										X						
-abi_stable_derive@0.11.3		X										X						
-abi_stable_shared@0.11.0		X										X						
-adler2@2.0.1	X	X										X						
-aes@0.8.4		X										X						
-ahash@0.8.12		X										X						
-aho-corasick@1.1.4												X				X		
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6	zlib-acknowledgement
+abi_stable@0.11.3		X									X							
+abi_stable_derive@0.11.3		X									X							
+abi_stable_shared@0.11.0		X									X							
+adler2@2.0.1	X	X									X							
+aes@0.8.4		X									X							
+ahash@0.8.12		X									X							
+aho-corasick@1.1.4											X				X			
 alloc-no-stdlib@2.0.4					X													
 alloc-stdlib@0.2.2					X													
-allocator-api2@0.2.21		X										X						
-android_system_properties@0.1.5		X										X						
-anyhow@1.0.102		X										X						
+allocator-api2@0.2.21		X									X							
+android_system_properties@0.1.5		X									X							
+anyhow@1.0.102		X									X							
+apache-avro@0.21.0		X																
 ar_archive_writer@0.5.1			X															
+arc-swap@1.9.1		X									X							
 arrayref@0.3.9				X														
-arrayvec@0.7.6		X										X						
-arrow@58.1.0		X																
-arrow-arith@58.1.0		X																
-arrow-array@58.1.0		X																
-arrow-buffer@58.1.0		X																
-arrow-cast@58.1.0		X																
-arrow-csv@58.1.0		X																
-arrow-data@58.1.0		X																
-arrow-ipc@58.1.0		X																
-arrow-json@58.1.0		X																
-arrow-ord@58.1.0		X																
-arrow-pyarrow@58.1.0		X																
-arrow-row@58.1.0		X																
-arrow-schema@58.1.0		X																
-arrow-select@58.1.0		X																
-arrow-string@58.1.0		X																
-as_derive_utils@0.11.0		X										X						
-async-compression@0.4.41		X										X						
-async-ffi@0.5.0												X						
-async-stream@0.3.6												X						
-async-stream-impl@0.3.6												X						
-async-trait@0.1.89		X										X						
-atoi@2.0.0												X						
-atomic-waker@1.1.2		X										X						
-autocfg@1.5.0		X										X						
+arrayvec@0.7.6		X									X							
+arrow@58.3.0		X																
+arrow-arith@58.3.0		X																
+arrow-array@58.3.0		X									X							
+arrow-buffer@58.3.0		X																
+arrow-cast@58.3.0		X																
+arrow-csv@58.3.0		X																
+arrow-data@58.3.0		X																
+arrow-ipc@58.3.0		X																
+arrow-json@58.3.0		X																
+arrow-ord@58.3.0		X																
+arrow-pyarrow@58.3.0		X																
+arrow-row@58.3.0		X																
+arrow-schema@58.3.0		X																
+arrow-select@58.3.0		X																
+arrow-string@58.3.0		X																
+as_derive_utils@0.11.0		X									X							
+async-compression@0.4.42		X									X							
+async-ffi@0.5.0											X							
+async-stream@0.3.6											X							
+async-stream-impl@0.3.6											X							
+async-trait@0.1.89		X									X							
+atoi@2.0.0											X							
+atomic-waker@1.1.2		X									X							
+autocfg@1.5.0		X									X							
 backon@1.6.0		X																
-base64@0.22.1		X										X						
-bigdecimal@0.4.10		X										X						
-bitflags@2.9.1		X										X						
-blake2@0.10.6		X										X						
-blake3@1.8.3		X	X				X											
-block-buffer@0.10.4		X										X						
-block-padding@0.3.3		X										X						
-brotli@8.0.2					X							X						
-brotli-decompressor@5.0.0					X							X						
-bumpalo@3.19.0		X										X						
-bytemuck@1.25.0		X										X					X	
-byteorder@1.5.0												X				X		
-bytes@1.11.1												X						
-bzip2@0.6.1		X										X						
-cbc@0.1.2		X										X						
-cc@1.2.56		X										X						
-cfg-if@1.0.1		X										X						
-chacha20@0.10.0		X										X						
-chrono@0.4.44		X										X						
-chrono-tz@0.10.4		X										X						
-cipher@0.4.4		X										X						
-comfy-table@7.2.2												X						
-compression-codecs@0.4.37		X										X						
-compression-core@0.4.31		X										X						
-const-oid@0.9.6		X										X						
-const-random@0.1.18		X										X						
-const-random-macro@0.1.16		X										X						
-const_panic@0.2.15																	X	
-constant_time_eq@0.4.2		X					X						X					
-core-foundation@0.10.1		X										X						
-core-foundation@0.9.4		X										X						
-core-foundation-sys@0.8.7		X										X						
-core_extensions@1.5.4		X										X						
-core_extensions_proc_macros@1.5.4		X										X						
-cpufeatures@0.2.17		X										X						
-cpufeatures@0.3.0		X										X						
-crc@3.4.0		X										X						
-crc-catalog@2.4.0		X										X						
-crc32c@0.6.8		X										X						
-crc32fast@1.5.0		X										X						
-crossbeam-channel@0.5.15		X										X						
-crossbeam-utils@0.8.21		X										X						
-crunchy@0.2.4												X						
-crypto-common@0.1.6		X										X						
-csv@1.4.0												X				X		
-csv-core@0.1.13												X				X		
-ctr@0.9.2		X										X						
-darling@0.20.11												X						
-darling_core@0.20.11												X						
-darling_macro@0.20.11												X						
-dashmap@6.1.0												X						
-datafusion@53.0.0		X																
-datafusion-catalog@53.0.0		X																
-datafusion-catalog-listing@53.0.0		X																
-datafusion-common@53.0.0		X																
-datafusion-common-runtime@53.0.0		X																
-datafusion-datasource@53.0.0		X																
-datafusion-datasource-arrow@53.0.0		X																
-datafusion-datasource-csv@53.0.0		X																
-datafusion-datasource-json@53.0.0		X																
-datafusion-datasource-parquet@53.0.0		X																
-datafusion-doc@53.0.0		X																
-datafusion-execution@53.0.0		X																
-datafusion-expr@53.0.0		X																
-datafusion-expr-common@53.0.0		X																
-datafusion-ffi@53.0.0		X																
-datafusion-functions@53.0.0		X																
-datafusion-functions-aggregate@53.0.0		X																
-datafusion-functions-aggregate-common@53.0.0		X																
-datafusion-functions-nested@53.0.0		X																
-datafusion-functions-table@53.0.0		X																
-datafusion-functions-window@53.0.0		X																
-datafusion-functions-window-common@53.0.0		X																
-datafusion-macros@53.0.0		X																
-datafusion-optimizer@53.0.0		X																
-datafusion-physical-expr@53.0.0		X																
-datafusion-physical-expr-adapter@53.0.0		X																
-datafusion-physical-expr-common@53.0.0		X																
-datafusion-physical-optimizer@53.0.0		X																
-datafusion-physical-plan@53.0.0		X																
-datafusion-proto@53.0.0		X																
-datafusion-proto-common@53.0.0		X																
-datafusion-pruning@53.0.0		X																
-datafusion-session@53.0.0		X																
-datafusion-sql@53.0.0		X																
-des@0.8.1		X										X						
-diff@0.1.13		X										X						
-digest@0.10.7		X										X						
-displaydoc@0.2.5		X										X						
-dns-lookup@3.0.1		X										X						
-either@1.15.0		X										X						
-encoding_rs@0.8.35		X			X							X						
-equivalent@1.0.2		X										X						
-errno@0.3.14		X										X						
-fallible-streaming-iterator@0.1.9		X										X						
-fastrand@2.3.0		X										X						
-find-msvc-tools@0.1.9		X										X						
-fixedbitset@0.5.7		X										X						
+base64@0.22.1		X									X							
+bigdecimal@0.4.10		X									X							
+bitflags@2.11.1		X									X							
+bitpacking@0.9.3											X							
+blake2@0.10.6		X									X							
+blake3@1.8.5		X	X				X											
+block-buffer@0.10.4		X									X							
+block-padding@0.3.3		X									X							
+bon@3.9.1		X									X							
+bon-macros@3.9.1		X									X							
+brotli@8.0.2					X						X							
+brotli-decompressor@5.0.0					X						X							
+bumpalo@3.20.2		X									X							
+bytemuck@1.25.0		X									X					X		
+byteorder@1.5.0											X				X			
+bytes@1.11.1											X							
+bzip2@0.6.1		X									X							
+cbc@0.1.2		X									X							
+cc@1.2.62		X									X							
+census@0.4.2											X							
+cfg-if@1.0.4		X									X							
+chrono@0.4.44		X									X							
+chrono-tz@0.10.4		X									X							
+cipher@0.4.4		X									X							
+comfy-table@7.2.2											X							
+compression-codecs@0.4.38		X									X							
+compression-core@0.4.32		X									X							
+const-oid@0.9.6		X									X							
+const-random@0.1.18		X									X							
+const-random-macro@0.1.16		X									X							
+const_panic@0.2.15																X		
+constant_time_eq@0.4.2		X					X					X						
+core-foundation@0.10.1		X									X							
+core-foundation@0.9.4		X									X							
+core-foundation-sys@0.8.7		X									X							
+core_extensions@1.5.4		X									X							
+core_extensions_proc_macros@1.5.4		X									X							
+cpufeatures@0.2.17		X									X							
+cpufeatures@0.3.0		X									X							
+crc@3.4.0		X									X							
+crc-catalog@2.5.0		X									X							
+crc32c@0.6.8		X									X							
+crc32fast@1.5.0		X									X							
+crossbeam-channel@0.5.15		X									X							
+crossbeam-deque@0.8.6		X									X							
+crossbeam-epoch@0.9.18		X									X							
+crossbeam-utils@0.8.21		X									X							
+crunchy@0.2.4											X							
+crypto-common@0.1.7		X									X							
+csv@1.4.0											X				X			
+csv-core@0.1.13											X				X			
+ctr@0.9.2		X									X							
+darling@0.23.0											X							
+darling_core@0.23.0											X							
+darling_macro@0.23.0											X							
+dashmap@6.2.1											X							
+datafusion@53.1.0		X																
+datafusion-catalog@53.1.0		X																
+datafusion-catalog-listing@53.1.0		X																
+datafusion-common@53.1.0		X																
+datafusion-common-runtime@53.1.0		X																
+datafusion-datasource@53.1.0		X																
+datafusion-datasource-arrow@53.1.0		X																
+datafusion-datasource-csv@53.1.0		X																
+datafusion-datasource-json@53.1.0		X																
+datafusion-datasource-parquet@53.1.0		X																
+datafusion-doc@53.1.0		X																
+datafusion-execution@53.1.0		X																
+datafusion-expr@53.1.0		X																
+datafusion-expr-common@53.1.0		X																
+datafusion-ffi@53.1.0		X																
+datafusion-functions@53.1.0		X																
+datafusion-functions-aggregate@53.1.0		X																
+datafusion-functions-aggregate-common@53.1.0		X																
+datafusion-functions-nested@53.1.0		X																
+datafusion-functions-table@53.1.0		X																
+datafusion-functions-window@53.1.0		X																
+datafusion-functions-window-common@53.1.0		X																
+datafusion-macros@53.1.0		X																
+datafusion-optimizer@53.1.0		X																
+datafusion-physical-expr@53.1.0		X																
+datafusion-physical-expr-adapter@53.1.0		X																
+datafusion-physical-expr-common@53.1.0		X																
+datafusion-physical-optimizer@53.1.0		X																
+datafusion-physical-plan@53.1.0		X																
+datafusion-proto@53.1.0		X																
+datafusion-proto-common@53.1.0		X																
+datafusion-pruning@53.1.0		X																
+datafusion-session@53.1.0		X																
+datafusion-sql@53.1.0		X																
+deranged@0.5.8		X									X							
+des@0.8.1		X									X							
+diff@0.1.13		X									X							
+digest@0.10.7		X									X							
+displaydoc@0.2.5		X									X							
+dlv-list@0.5.2		X									X							
+dns-lookup@3.0.1		X									X							
+downcast-rs@1.2.1		X									X							
+either@1.15.0		X									X							
+encoding_rs@0.8.35		X			X						X							
+equivalent@1.0.2		X									X							
+errno@0.3.14		X									X							
+fallible-streaming-iterator@0.1.9		X									X							
+fastdivide@0.4.2											X							X
+fastrand@2.4.1		X									X							
+find-msvc-tools@0.1.9		X									X							
+fixedbitset@0.5.7		X									X							
 flatbuffers@25.12.19		X																
-flate2@1.1.9		X										X						
-fnv@1.0.7		X										X						
-foldhash@0.1.5																	X	
-foldhash@0.2.0																	X	
-foreign-types@0.3.2		X										X						
-foreign-types-shared@0.1.1		X										X						
-form_urlencoded@1.2.2		X										X						
-futures@0.3.31		X										X						
-futures-channel@0.3.31		X										X						
-futures-core@0.3.31		X										X						
-futures-executor@0.3.31		X										X						
-futures-io@0.3.31		X										X						
-futures-macro@0.3.31		X										X						
-futures-sink@0.3.31		X										X						
-futures-task@0.3.31		X										X						
-futures-util@0.3.31		X										X						
-g2gen@1.2.2		X										X						
-g2p@1.2.2		X										X						
-g2poly@1.2.2		X										X						
-generational-arena@0.2.9														X				
-generic-array@0.14.7												X						
-getrandom@0.2.16		X										X						
-getrandom@0.3.3		X										X						
-getrandom@0.4.1		X										X						
-glob@0.3.3		X										X						
-gloo-timers@0.3.0		X										X						
-h2@0.4.13												X						
-half@2.7.1		X										X						
-hashbrown@0.14.5		X										X						
-hashbrown@0.15.4		X										X						
-hashbrown@0.16.1		X										X						
+flate2@1.1.9		X									X							
+fnv@1.0.7		X									X							
+foldhash@0.1.5																X		
+foldhash@0.2.0																X		
+foreign-types@0.3.2		X									X							
+foreign-types-shared@0.1.1		X									X							
+form_urlencoded@1.2.2		X									X							
+fs4@0.8.4		X									X							
+futures@0.3.32		X									X							
+futures-channel@0.3.32		X									X							
+futures-core@0.3.32		X									X							
+futures-executor@0.3.32		X									X							
+futures-io@0.3.32		X									X							
+futures-macro@0.3.32		X									X							
+futures-sink@0.3.32		X									X							
+futures-task@0.3.32		X									X							
+futures-util@0.3.32		X									X							
+g2gen@1.2.2		X									X							
+g2p@1.2.2		X									X							
+g2poly@1.2.2		X									X							
+generational-arena@0.2.9													X					
+generic-array@0.14.7											X							
+getrandom@0.2.17		X									X							
+getrandom@0.3.4		X									X							
+getrandom@0.4.2		X									X							
+glob@0.3.3		X									X							
+gloo-timers@0.3.0		X									X							
+h2@0.4.14											X							
+half@2.7.1		X									X							
+hashbrown@0.14.5		X									X							
+hashbrown@0.15.5		X									X							
+hashbrown@0.16.1		X									X							
+hashbrown@0.17.1		X									X							
 hdfs-native@0.13.5		X																
-heck@0.5.0		X										X						
-hex@0.4.3		X										X						
-hmac@0.12.1		X										X						
-home@0.5.12		X										X						
-http@1.3.1		X										X						
-http-body@1.0.1												X						
-http-body-util@0.1.3												X						
-httparse@1.10.1		X										X						
-httpdate@1.0.3		X										X						
-humantime@2.3.0		X										X						
-hyper@1.6.0												X						
-hyper-rustls@0.27.7		X							X			X						
-hyper-tls@0.6.0		X										X						
-hyper-util@0.1.15												X						
-iana-time-zone@0.1.63		X										X						
-iana-time-zone-haiku@0.1.2		X										X						
-icu_collections@2.0.0															X			
-icu_locale_core@2.0.0															X			
-icu_normalizer@2.0.0															X			
-icu_normalizer_data@2.0.0															X			
-icu_properties@2.0.1															X			
-icu_properties_data@2.0.1															X			
-icu_provider@2.0.0															X			
-ident_case@1.0.1		X										X						
-idna@1.1.0		X										X						
-idna_adapter@1.2.1		X										X						
-indexmap@2.13.0		X										X						
-inout@0.1.4		X										X						
-integer-encoding@3.0.4												X						
-integer-encoding@4.1.0												X						
-ipnet@2.11.0		X										X						
-iri-string@0.7.8		X										X						
-itertools@0.14.0		X										X						
-itoa@1.0.15		X										X						
-jiff@0.2.23												X				X		
-jiff-tzdb@0.1.6												X				X		
-jiff-tzdb-platform@0.1.3												X				X		
-jobserver@0.1.34		X										X						
-js-sys@0.3.77		X										X						
-lexical-core@1.0.6		X										X						
-lexical-parse-float@1.0.6		X										X						
-lexical-parse-integer@1.0.6		X										X						
-lexical-util@1.0.7		X										X						
-lexical-write-float@1.0.6		X										X						
-lexical-write-integer@1.0.6		X										X						
-libbz2-rs-sys@0.2.2																		X
-libc@0.2.182		X										X						
+heck@0.5.0		X									X							
+hermit-abi@0.5.2		X									X							
+hex@0.4.3		X									X							
+hmac@0.12.1		X									X							
+home@0.5.12		X									X							
+htmlescape@0.3.1		X									X		X					
+http@1.4.0		X									X							
+http-body@1.0.1											X							
+http-body-util@0.1.3											X							
+httparse@1.10.1		X									X							
+httpdate@1.0.3		X									X							
+humantime@2.3.0		X									X							
+hyper@1.9.0											X							
+hyper-rustls@0.27.9		X							X		X							
+hyper-tls@0.6.0		X									X							
+hyper-util@0.1.20											X							
+iana-time-zone@0.1.65		X									X							
+iana-time-zone-haiku@0.1.2		X									X							
+icu_collections@2.2.0														X				
+icu_locale_core@2.2.0														X				
+icu_normalizer@2.2.0														X				
+icu_normalizer_data@2.2.0														X				
+icu_properties@2.2.0														X				
+icu_properties_data@2.2.0														X				
+icu_provider@2.2.0														X				
+ident_case@1.0.1		X									X							
+idna@1.1.0		X									X							
+idna_adapter@1.2.2		X									X							
+indexmap@2.14.0		X									X							
+inout@0.1.4		X									X							
+instant@0.1.13					X													
+integer-encoding@3.0.4											X							
+ipnet@2.12.0		X									X							
+itertools@0.12.1		X									X							
+itertools@0.14.0		X									X							
+itoa@1.0.18		X									X							
+jiff@0.2.24											X				X			
+jiff-tzdb@0.1.6											X				X			
+jiff-tzdb-platform@0.1.3											X				X			
+jobserver@0.1.34		X									X							
+js-sys@0.3.98		X									X							
+levenshtein_automata@0.2.1											X							
+lexical-core@1.0.6		X									X							
+lexical-parse-float@1.0.6		X									X							
+lexical-parse-integer@1.0.6		X									X							
+lexical-util@1.0.7		X									X							
+lexical-write-float@1.0.6		X									X							
+lexical-write-integer@1.0.6		X									X							
+libbz2-rs-sys@0.2.5																	X	
+libc@0.2.186		X									X							
 libloading@0.7.4									X									
+libloading@0.8.9									X									
 libloading@0.9.0									X									
-liblzma@0.4.6		X										X						
-liblzma-sys@0.4.5		X										X						
-libm@0.2.15												X						
-libredox@0.1.16												X						
-linux-raw-sys@0.12.1		X	X									X						
-litemap@0.8.0															X			
-lock_api@0.4.14		X										X						
-log@0.4.29		X										X						
-lz4_flex@0.11.6												X						
-lz4_flex@0.13.0												X						
-lzokay-native@0.1.0												X						
-md-5@0.10.6		X										X						
-memchr@2.8.0												X				X		
-mime@0.3.17		X										X						
-miniz_oxide@0.8.9		X										X					X	
-mio@1.0.4												X						
-native-tls@0.2.18		X										X						
-num@0.4.3		X										X						
-num-bigint@0.4.6		X										X						
-num-complex@0.4.6		X										X						
-num-integer@0.1.46		X										X						
-num-iter@0.1.45		X										X						
-num-rational@0.4.2		X										X						
-num-traits@0.2.19		X										X						
-object@0.37.3		X										X						
-object_store@0.13.2		X										X						
-once_cell@1.21.3		X										X						
+liblzma@0.4.6		X									X							
+liblzma-sys@0.4.6		X									X							
+libm@0.2.16											X							
+libredox@0.1.16											X							
+linux-raw-sys@0.12.1		X	X								X							
+linux-raw-sys@0.4.15		X	X								X							
+litemap@0.8.2														X				
+lock_api@0.4.14		X									X							
+log@0.4.29		X									X							
+lru@0.12.5											X							
+lz4_flex@0.11.6											X							
+lz4_flex@0.13.1											X							
+lzokay-native@0.1.0											X							
+md-5@0.10.6		X									X							
+measure_time@0.8.3											X							
+memchr@2.8.0											X				X			
+memmap2@0.9.10		X									X							
+mime@0.3.17		X									X							
+minimal-lexical@0.2.1		X									X							
+miniz_oxide@0.8.9		X									X					X		
+mio@1.2.0											X							
+murmurhash32@0.3.1											X							
+native-tls@0.2.18		X									X							
+nom@7.1.3											X							
+num@0.4.3		X									X							
+num-bigint@0.4.6		X									X							
+num-complex@0.4.6		X									X							
+num-conv@0.2.2		X									X							
+num-integer@0.1.46		X									X							
+num-iter@0.1.45		X									X							
+num-rational@0.4.2		X									X							
+num-traits@0.2.19		X									X							
+num_cpus@1.17.0		X									X							
+object@0.37.3		X									X							
+object_store@0.13.2		X									X							
+once_cell@1.21.4		X									X							
+oneshot@0.1.13		X									X							
 opendal@0.55.0		X																
-openssl@0.10.76		X																
-openssl-macros@0.1.1		X										X						
-openssl-probe@0.2.1		X										X						
-openssl-sys@0.9.112												X						
+openssl@0.10.80		X																
+openssl-macros@0.1.1		X									X							
+openssl-probe@0.2.1		X									X							
+openssl-sys@0.9.116											X							
 orc-rust@0.8.0		X																
-ordered-float@2.10.1												X						
-paimon@0.1.0		X																
-paimon-datafusion@0.1.0		X																
-parking_lot@0.12.5		X										X						
-parking_lot_core@0.9.12		X										X						
-parquet@58.1.0		X																
-paste@1.0.15		X										X						
-percent-encoding@2.3.2		X										X						
-petgraph@0.8.3		X										X						
-phf@0.12.1												X						
-phf_shared@0.12.1												X						
-pin-project-lite@0.2.16		X										X						
-pin-utils@0.1.0		X										X						
-pkg-config@0.3.32		X										X						
-plain@0.2.3		X										X						
-portable-atomic@1.13.1		X										X						
-portable-atomic-util@0.2.6		X										X						
-potential_utf@0.1.2															X			
-ppv-lite86@0.2.21		X										X						
-pretty_assertions@1.4.1		X										X						
-proc-macro2@1.0.95		X										X						
+ordered-float@2.10.1											X							
+ordered-multimap@0.7.3											X							
+ownedbytes@0.7.0											X							
+paimon@0.2.0		X																
+paimon-datafusion@0.2.0		X																
+parking_lot@0.12.5		X									X							
+parking_lot_core@0.9.12		X									X							
+parquet@58.3.0		X																
+paste@1.0.15		X									X							
+percent-encoding@2.3.2		X									X							
+petgraph@0.8.3		X									X							
+phf@0.12.1											X							
+phf_shared@0.12.1											X							
+pin-project-lite@0.2.17		X									X							
+pkg-config@0.3.33		X									X							
+plain@0.2.3		X									X							
+portable-atomic@1.13.1		X									X							
+portable-atomic-util@0.2.7		X									X							
+potential_utf@0.1.5														X				
+powerfmt@0.2.0		X									X							
+ppv-lite86@0.2.21		X									X							
+pretty_assertions@1.4.1		X									X							
+prettyplease@0.2.37		X									X							
+proc-macro2@1.0.106		X									X							
 prost@0.13.5		X																
 prost@0.14.3		X																
 prost-derive@0.13.5		X																
 prost-derive@0.14.3		X																
 prost-types@0.14.3		X																
-psm@0.1.30		X										X						
-pyo3@0.28.3		X										X						
-pyo3-build-config@0.28.3		X										X						
-pyo3-ffi@0.28.3		X										X						
-pyo3-macros@0.28.3		X										X						
-pyo3-macros-backend@0.28.3		X										X						
-pypaimon_rust@0.1.0		X																
-quick-xml@0.37.5												X						
-quick-xml@0.38.4												X						
-quote@1.0.44		X										X						
-r-efi@5.3.0		X								X		X						
-rand@0.10.0		X										X						
-rand@0.8.5		X										X						
-rand@0.9.2		X										X						
-rand_chacha@0.3.1		X										X						
-rand_chacha@0.9.0		X										X						
-rand_core@0.10.0		X										X						
-rand_core@0.6.4		X										X						
-rand_core@0.9.3		X										X						
-recursive@0.1.1												X						
-recursive-proc-macro-impl@0.1.1												X						
-redox_syscall@0.5.18												X						
-regex@1.12.3		X										X						
-regex-automata@0.4.14		X										X						
-regex-syntax@0.8.10		X										X						
-repr_offset@0.2.2																	X	
+psm@0.1.31		X									X							
+pyo3@0.28.3		X									X							
+pyo3-build-config@0.28.3		X									X							
+pyo3-ffi@0.28.3		X									X							
+pyo3-macros@0.28.3		X									X							
+pyo3-macros-backend@0.28.3		X									X							
+pypaimon_rust@0.2.0		X																
+quad-rand@0.2.3											X							
+quick-xml@0.37.5											X							
+quick-xml@0.38.4											X							
+quote@1.0.45		X									X							
+r-efi@5.3.0		X								X	X							
+r-efi@6.0.0		X								X	X							
+rand@0.8.6		X									X							
+rand@0.9.4		X									X							
+rand_chacha@0.3.1		X									X							
+rand_chacha@0.9.0		X									X							
+rand_core@0.6.4		X									X							
+rand_core@0.9.5		X									X							
+rand_distr@0.4.3		X									X							
+rayon@1.12.0		X									X							
+rayon-core@1.13.0		X									X							
+recursive@0.1.1											X							
+recursive-proc-macro-impl@0.1.1											X							
+redox_syscall@0.5.18											X							
+redox_syscall@0.7.5											X							
+regex@1.12.3		X									X							
+regex-automata@0.4.14		X									X							
+regex-lite@0.1.9		X									X							
+regex-syntax@0.8.10		X									X							
+repr_offset@0.2.2																X		
 reqsign@0.16.5		X																
-reqwest@0.12.28		X										X						
+reqwest@0.12.28		X									X							
 ring@0.17.14		X							X									
-roaring@0.11.3		X										X						
-roxmltree@0.21.1		X										X						
-rust_decimal@1.41.0												X						
-rustc_version@0.4.1		X										X						
-rustix@1.1.4		X	X									X						
-rustls@0.23.29		X							X			X						
-rustls-pki-types@1.12.0		X										X						
-rustls-webpki@0.103.4									X									
-rustversion@1.0.21		X										X						
-ryu@1.0.20		X				X												
-same-file@1.0.6												X				X		
-schannel@0.1.29												X						
-scopeguard@1.2.0		X										X						
-security-framework@3.6.0		X										X						
-security-framework-sys@2.17.0		X										X						
-semver@1.0.27		X										X						
-seq-macro@0.3.6		X										X						
-serde@1.0.228		X										X						
-serde-transcode@1.1.1		X										X						
-serde_avro_fast@2.0.2											X							
-serde_bytes@0.11.19		X										X						
-serde_core@1.0.228		X										X						
-serde_derive@1.0.228		X										X						
-serde_json@1.0.149		X										X						
-serde_repr@0.1.20		X										X						
-serde_serializer_quick_unsupported@1.0.0											X							
-serde_urlencoded@0.7.1		X										X						
-serde_with@3.14.0		X										X						
-serde_with_macros@3.14.0		X										X						
-sha1@0.10.6		X										X						
-sha2@0.10.9		X										X						
-shlex@1.3.0		X										X						
-simd-adler32@0.3.8												X						
-simdutf8@0.1.5		X										X						
-siphasher@1.0.2		X										X						
-slab@0.4.10												X						
-smallvec@1.15.1		X										X						
-snafu@0.8.9		X										X						
-snafu@0.9.0		X										X						
-snafu-derive@0.8.9		X										X						
-snafu-derive@0.9.0		X										X						
+roaring@0.11.4		X									X							
+roxmltree@0.21.1		X									X							
+rust-ini@0.21.3											X							
+rust-stemmers@1.2.0					X						X							
+rustc-hash@1.1.0		X									X							
+rustc_version@0.4.1		X									X							
+rustix@0.38.44		X	X								X							
+rustix@1.1.4		X	X								X							
+rustls@0.23.40		X							X		X							
+rustls-pki-types@1.14.1		X									X							
+rustls-webpki@0.103.13									X									
+rustversion@1.0.22		X									X							
+ryu@1.0.23		X				X												
+same-file@1.0.6											X				X			
+schannel@0.1.29											X							
+scopeguard@1.2.0		X									X							
+security-framework@3.7.0		X									X							
+security-framework-sys@2.17.0		X									X							
+semver@1.0.28		X									X							
+seq-macro@0.3.6		X									X							
+serde@1.0.228		X									X							
+serde_bytes@0.11.19		X									X							
+serde_core@1.0.228		X									X							
+serde_derive@1.0.228		X									X							
+serde_json@1.0.149		X									X							
+serde_repr@0.1.20		X									X							
+serde_urlencoded@0.7.1		X									X							
+serde_with@3.20.0		X									X							
+serde_with_macros@3.20.0		X									X							
+sha1@0.10.6		X									X							
+sha2@0.10.9		X									X							
+shlex@1.3.0		X									X							
+simd-adler32@0.3.9											X							
+simdutf8@0.1.5		X									X							
+siphasher@1.0.3		X									X							
+sketches-ddsketch@0.2.2		X																
+slab@0.4.12											X							
+smallvec@1.15.1		X									X							
+snafu@0.8.9		X									X							
+snafu@0.9.0		X									X							
+snafu-derive@0.8.9		X									X							
+snafu-derive@0.9.0		X									X							
 snap@1.1.1					X													
-socket2@0.5.10		X										X						
-socket2@0.6.2		X										X						
+socket2@0.6.3		X									X							
 sqlparser@0.61.0		X																
 sqlparser_derive@0.5.0		X																
-stable_deref_trait@1.2.0		X										X						
-stacker@0.1.23		X										X						
-strsim@0.11.1												X						
+stable_deref_trait@1.2.1		X									X							
+stacker@0.1.24		X									X							
+strsim@0.11.1											X							
+strum@0.27.2											X							
+strum_macros@0.27.2											X							
 subtle@2.6.1					X													
-syn@1.0.109		X										X						
-syn@2.0.117		X										X						
+syn@1.0.109		X									X							
+syn@2.0.117		X									X							
 sync_wrapper@1.0.2		X																
-synstructure@0.13.2												X						
-system-configuration@0.6.1		X										X						
-system-configuration-sys@0.6.0		X										X						
+synstructure@0.13.2											X							
+system-configuration@0.7.0		X									X							
+system-configuration-sys@0.6.0		X									X							
+tantivy@0.22.1											X							
+tantivy-bitpacker@0.6.0											X							
+tantivy-columnar@0.3.0											X							
+tantivy-common@0.7.0											X							
+tantivy-fst@0.5.0											X				X			
+tantivy-query-grammar@0.22.0											X							
+tantivy-sstable@0.3.0											X							
+tantivy-stacker@0.3.0											X							
+tantivy-tokenizer-api@0.3.0											X							
 target-lexicon@0.13.5			X															
-tempfile@3.26.0		X										X						
-thiserror@1.0.69		X										X						
-thiserror@2.0.18		X										X						
-thiserror-impl@1.0.69		X										X						
-thiserror-impl@2.0.18		X										X						
+tempfile@3.27.0		X									X							
+thiserror@1.0.69		X									X							
+thiserror@2.0.18		X									X							
+thiserror-impl@1.0.69		X									X							
+thiserror-impl@2.0.18		X									X							
 thrift@0.17.0		X																
+time@0.3.47		X									X							
+time-core@0.1.8		X									X							
 tiny-keccak@2.0.2							X											
-tinystr@0.8.1															X			
-tokio@1.49.0												X						
-tokio-macros@2.6.0												X						
-tokio-native-tls@0.3.1												X						
-tokio-rustls@0.26.2		X										X						
-tokio-stream@0.1.18												X						
-tokio-util@0.7.18												X						
-tower@0.5.2												X						
-tower-http@0.6.8												X						
-tower-layer@0.3.3												X						
-tower-service@0.3.3												X						
-tracing@0.1.41												X						
-tracing-attributes@0.1.31												X						
-tracing-core@0.1.36												X						
-try-lock@0.2.5												X						
-tstr@0.2.4																	X	
-tstr_proc_macros@0.2.2																	X	
-twox-hash@2.1.2												X						
-typed-arena@2.0.2												X						
-typed-builder@0.19.1		X										X						
-typed-builder-macro@0.19.1		X										X						
-typenum@1.18.0		X										X						
-typewit@1.15.1																	X	
-unicode-ident@1.0.18		X										X			X			
-unicode-segmentation@1.13.2		X										X						
-unicode-width@0.2.2		X										X						
+tinystr@0.8.3														X				
+tokio@1.52.3											X							
+tokio-macros@2.7.0											X							
+tokio-native-tls@0.3.1											X							
+tokio-rustls@0.26.4		X									X							
+tokio-stream@0.1.18											X							
+tokio-util@0.7.18											X							
+tower@0.5.3											X							
+tower-http@0.6.11											X							
+tower-layer@0.3.3											X							
+tower-service@0.3.3											X							
+tracing@0.1.44											X							
+tracing-attributes@0.1.31											X							
+tracing-core@0.1.36											X							
+try-lock@0.2.5											X							
+tstr@0.2.4																X		
+tstr_proc_macros@0.2.2																X		
+twox-hash@2.1.2											X							
+typed-arena@2.0.2											X							
+typed-builder@0.19.1		X									X							
+typed-builder-macro@0.19.1		X									X							
+typenum@1.20.0		X									X							
+typewit@1.15.2																X		
+unicode-ident@1.0.24		X									X			X				
+unicode-segmentation@1.13.2		X									X							
+unicode-width@0.2.2		X									X							
 untrusted@0.9.0									X									
-url@2.5.8		X										X						
-urlencoding@2.1.3												X						
-utf8_iter@1.0.4		X										X						
-uuid@1.21.0		X										X						
-vcpkg@0.2.15		X										X						
-version_check@0.9.5		X										X						
-walkdir@2.5.0												X				X		
-want@0.3.1												X						
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X						
-wasi@0.14.2+wasi-0.2.4		X	X									X						
-wasip2@1.0.2+wasi-0.2.9		X	X									X						
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X						
-wasite@0.1.0		X				X						X						
-wasm-bindgen@0.2.100		X										X						
-wasm-bindgen-backend@0.2.100		X										X						
-wasm-bindgen-futures@0.4.50		X										X						
-wasm-bindgen-macro@0.2.100		X										X						
-wasm-bindgen-macro-support@0.2.100		X										X						
-wasm-bindgen-shared@0.2.100		X										X						
-wasm-streams@0.4.2		X										X						
-web-sys@0.3.77		X										X						
-web-time@1.1.0		X										X						
-webpki-roots@1.0.2								X										
-whoami@1.6.1		X				X						X						
-winapi@0.3.9		X										X						
-winapi-i686-pc-windows-gnu@0.4.0		X										X						
-winapi-util@0.1.11												X				X		
-winapi-x86_64-pc-windows-gnu@0.4.0		X										X						
-windows-core@0.61.2		X										X						
-windows-implement@0.60.0		X										X						
-windows-interface@0.59.1		X										X						
-windows-link@0.1.3		X										X						
-windows-link@0.2.1		X										X						
-windows-registry@0.5.3		X										X						
-windows-result@0.3.4		X										X						
-windows-strings@0.4.2		X										X						
-windows-sys@0.52.0		X										X						
-windows-sys@0.59.0		X										X						
-windows-sys@0.60.2		X										X						
-windows-sys@0.61.2		X										X						
-windows-targets@0.52.6		X										X						
-windows-targets@0.53.5		X										X						
-windows_aarch64_gnullvm@0.52.6		X										X						
-windows_aarch64_gnullvm@0.53.1		X										X						
-windows_aarch64_msvc@0.52.6		X										X						
-windows_aarch64_msvc@0.53.1		X										X						
-windows_i686_gnu@0.52.6		X										X						
-windows_i686_gnu@0.53.1		X										X						
-windows_i686_gnullvm@0.52.6		X										X						
-windows_i686_gnullvm@0.53.1		X										X						
-windows_i686_msvc@0.52.6		X										X						
-windows_i686_msvc@0.53.1		X										X						
-windows_x86_64_gnu@0.52.6		X										X						
-windows_x86_64_gnu@0.53.1		X										X						
-windows_x86_64_gnullvm@0.52.6		X										X						
-windows_x86_64_gnullvm@0.53.1		X										X						
-windows_x86_64_msvc@0.52.6		X										X						
-windows_x86_64_msvc@0.53.1		X										X						
-wit-bindgen@0.51.0		X	X									X						
-wit-bindgen-rt@0.39.0		X	X									X						
-writeable@0.6.1															X			
-yansi@1.0.1		X										X						
-yoke@0.8.0															X			
-yoke-derive@0.8.0															X			
-zerocopy@0.8.26		X		X								X						
-zerocopy-derive@0.8.26		X		X								X						
-zerofrom@0.1.6															X			
-zerofrom-derive@0.1.6															X			
-zeroize@1.8.1		X										X						
-zerotrie@0.2.2															X			
-zerovec@0.11.2															X			
-zerovec-derive@0.11.1															X			
-zlib-rs@0.6.3																	X	
-zmij@1.0.21												X						
-zstd@0.13.3												X						
-zstd-safe@7.2.4		X										X						
-zstd-sys@2.0.16+zstd.1.5.7		X										X						
+url@2.5.8		X									X							
+urlencoding@2.1.3											X							
+utf8-ranges@1.0.5											X				X			
+utf8_iter@1.0.4		X									X							
+uuid@1.23.1		X									X							
+vcpkg@0.2.15		X									X							
+version_check@0.9.5		X									X							
+walkdir@2.5.0											X				X			
+want@0.3.1											X							
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X							
+wasip2@1.0.3+wasi-0.2.9		X	X								X							
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X							
+wasite@0.1.0		X				X					X							
+wasm-bindgen@0.2.121		X									X							
+wasm-bindgen-futures@0.4.71		X									X							
+wasm-bindgen-macro@0.2.121		X									X							
+wasm-bindgen-macro-support@0.2.121		X									X							
+wasm-bindgen-shared@0.2.121		X									X							
+wasm-streams@0.4.2		X									X							
+web-sys@0.3.98		X									X							
+web-time@1.1.0		X									X							
+webpki-roots@1.0.7								X										
+whoami@1.6.1		X				X					X							
+winapi@0.3.9		X									X							
+winapi-i686-pc-windows-gnu@0.4.0		X									X							
+winapi-util@0.1.11											X				X			
+winapi-x86_64-pc-windows-gnu@0.4.0		X									X							
+windows-core@0.62.2		X									X							
+windows-implement@0.60.2		X									X							
+windows-interface@0.59.3		X									X							
+windows-link@0.2.1		X									X							
+windows-registry@0.6.1		X									X							
+windows-result@0.4.1		X									X							
+windows-strings@0.5.1		X									X							
+windows-sys@0.52.0		X									X							
+windows-sys@0.59.0		X									X							
+windows-sys@0.60.2		X									X							
+windows-sys@0.61.2		X									X							
+windows-targets@0.52.6		X									X							
+windows-targets@0.53.5		X									X							
+windows_aarch64_gnullvm@0.52.6		X									X							
+windows_aarch64_gnullvm@0.53.1		X									X							
+windows_aarch64_msvc@0.52.6		X									X							
+windows_aarch64_msvc@0.53.1		X									X							
+windows_i686_gnu@0.52.6		X									X							
+windows_i686_gnu@0.53.1		X									X							
+windows_i686_gnullvm@0.52.6		X									X							
+windows_i686_gnullvm@0.53.1		X									X							
+windows_i686_msvc@0.52.6		X									X							
+windows_i686_msvc@0.53.1		X									X							
+windows_x86_64_gnu@0.52.6		X									X							
+windows_x86_64_gnu@0.53.1		X									X							
+windows_x86_64_gnullvm@0.52.6		X									X							
+windows_x86_64_gnullvm@0.53.1		X									X							
+windows_x86_64_msvc@0.52.6		X									X							
+windows_x86_64_msvc@0.53.1		X									X							
+wit-bindgen@0.51.0		X	X								X							
+wit-bindgen@0.57.1		X	X								X							
+writeable@0.6.3														X				
+yansi@1.0.1		X									X							
+yoke@0.8.2														X				
+yoke-derive@0.8.2														X				
+zerocopy@0.8.48		X		X							X							
+zerocopy-derive@0.8.48		X		X							X							
+zerofrom@0.1.8														X				
+zerofrom-derive@0.1.7														X				
+zeroize@1.8.2		X									X							
+zerotrie@0.2.4														X				
+zerovec@0.11.6														X				
+zerovec-derive@0.11.3														X				
+zlib-rs@0.6.3																X		
+zmij@1.0.21											X							
+zstd@0.13.3											X							
+zstd-safe@7.2.4		X									X							
+zstd-sys@2.0.16+zstd.1.5.7		X									X							

--- a/crates/integration_tests/DEPENDENCIES.rust.tsv
+++ b/crates/integration_tests/DEPENDENCIES.rust.tsv
@@ -1,344 +1,331 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X										X			
-ahash@0.8.12		X										X			
-aho-corasick@1.1.4												X		X	
-alloc-no-stdlib@2.0.4					X										
-alloc-stdlib@0.2.2					X										
-android_system_properties@0.1.5		X										X			
-anyhow@1.0.102		X										X			
-arrayvec@0.7.6		X										X			
-arrow@58.1.0		X													
-arrow-arith@58.1.0		X													
-arrow-array@58.1.0		X													
-arrow-buffer@58.1.0		X													
-arrow-cast@58.1.0		X													
-arrow-csv@58.1.0		X													
-arrow-data@58.1.0		X													
-arrow-ipc@58.1.0		X													
-arrow-json@58.1.0		X													
-arrow-ord@58.1.0		X													
-arrow-row@58.1.0		X													
-arrow-schema@58.1.0		X													
-arrow-select@58.1.0		X													
-arrow-string@58.1.0		X													
-async-stream@0.3.6												X			
-async-stream-impl@0.3.6												X			
-async-trait@0.1.89		X										X			
-atoi@2.0.0												X			
-atomic-waker@1.1.2		X										X			
-autocfg@1.5.0		X										X			
-backon@1.6.0		X													
-base64@0.22.1		X										X			
-bitflags@2.9.1		X										X			
-block-buffer@0.10.4		X										X			
-brotli@8.0.2					X							X			
-brotli-decompressor@5.0.0					X							X			
-bumpalo@3.19.0		X										X			
-bytemuck@1.25.0		X										X			X
-byteorder@1.5.0												X		X	
-bytes@1.11.1												X			
-cc@1.2.56		X										X			
-cfg-if@1.0.1		X										X			
-chacha20@0.10.0		X										X			
-chrono@0.4.44		X										X			
-chrono-tz@0.10.4		X										X			
-comfy-table@7.2.2												X			
-const-oid@0.9.6		X										X			
-const-random@0.1.18		X										X			
-const-random-macro@0.1.16		X										X			
-core-foundation@0.10.1		X										X			
-core-foundation@0.9.4		X										X			
-core-foundation-sys@0.8.7		X										X			
-cpufeatures@0.2.17		X										X			
-cpufeatures@0.3.0		X										X			
-crc32fast@1.5.0		X										X			
-crunchy@0.2.4												X			
-crypto-common@0.1.6		X										X			
-csv@1.4.0												X		X	
-csv-core@0.1.13												X		X	
-darling@0.20.11												X			
-darling_core@0.20.11												X			
-darling_macro@0.20.11												X			
-diff@0.1.13		X										X			
-digest@0.10.7		X										X			
-displaydoc@0.2.5		X										X			
-either@1.15.0		X										X			
-encoding_rs@0.8.35		X			X							X			
-equivalent@1.0.2		X										X			
-errno@0.3.14		X										X			
-fallible-streaming-iterator@0.1.9		X										X			
-fastrand@2.3.0		X										X			
-find-msvc-tools@0.1.9		X										X			
-flatbuffers@25.12.19		X													
-flate2@1.1.9		X										X			
-fnv@1.0.7		X										X			
-foreign-types@0.3.2		X										X			
-foreign-types-shared@0.1.1		X										X			
-form_urlencoded@1.2.2		X										X			
-futures@0.3.31		X										X			
-futures-channel@0.3.31		X										X			
-futures-core@0.3.31		X										X			
-futures-executor@0.3.31		X										X			
-futures-io@0.3.31		X										X			
-futures-macro@0.3.31		X										X			
-futures-sink@0.3.31		X										X			
-futures-task@0.3.31		X										X			
-futures-util@0.3.31		X										X			
-generic-array@0.14.7												X			
-getrandom@0.2.16		X										X			
-getrandom@0.3.3		X										X			
-getrandom@0.4.1		X										X			
-gloo-timers@0.3.0		X										X			
-h2@0.4.13												X			
-half@2.7.1		X										X			
-hashbrown@0.16.1		X										X			
-heck@0.5.0		X										X			
-hex@0.4.3		X										X			
-hmac@0.12.1		X										X			
-home@0.5.12		X										X			
-http@1.3.1		X										X			
-http-body@1.0.1												X			
-http-body-util@0.1.3												X			
-httparse@1.10.1		X										X			
-httpdate@1.0.3		X										X			
-hyper@1.6.0												X			
-hyper-rustls@0.27.7		X							X			X			
-hyper-tls@0.6.0		X										X			
-hyper-util@0.1.15												X			
-iana-time-zone@0.1.63		X										X			
-iana-time-zone-haiku@0.1.2		X										X			
-icu_collections@2.0.0													X		
-icu_locale_core@2.0.0													X		
-icu_normalizer@2.0.0													X		
-icu_normalizer_data@2.0.0													X		
-icu_properties@2.0.1													X		
-icu_properties_data@2.0.1													X		
-icu_provider@2.0.0													X		
-ident_case@1.0.1		X										X			
-idna@1.1.0		X										X			
-idna_adapter@1.2.1		X										X			
-indexmap@2.13.0		X										X			
-integer-encoding@3.0.4												X			
-integer-encoding@4.1.0												X			
-ipnet@2.11.0		X										X			
-iri-string@0.7.8		X										X			
-itertools@0.14.0		X										X			
-itoa@1.0.15		X										X			
-jiff@0.2.23												X		X	
-jiff-tzdb@0.1.6												X		X	
-jiff-tzdb-platform@0.1.3												X		X	
-jobserver@0.1.34		X										X			
-js-sys@0.3.77		X										X			
-lexical-core@1.0.6		X										X			
-lexical-parse-float@1.0.6		X										X			
-lexical-parse-integer@1.0.6		X										X			
-lexical-util@1.0.7		X										X			
-lexical-write-float@1.0.6		X										X			
-lexical-write-integer@1.0.6		X										X			
-libc@0.2.182		X										X			
-libm@0.2.15												X			
-linux-raw-sys@0.12.1		X	X									X			
-litemap@0.8.0													X		
-log@0.4.29		X										X			
-lz4_flex@0.11.6												X			
-lz4_flex@0.13.0												X			
-lzokay-native@0.1.0												X			
-md-5@0.10.6		X										X			
-memchr@2.8.0												X		X	
-mime@0.3.17		X										X			
-miniz_oxide@0.8.9		X										X			X
-mio@1.0.4												X			
-native-tls@0.2.18		X										X			
-num@0.4.3		X										X			
-num-bigint@0.4.6		X										X			
-num-complex@0.4.6		X										X			
-num-integer@0.1.46		X										X			
-num-iter@0.1.45		X										X			
-num-rational@0.4.2		X										X			
-num-traits@0.2.19		X										X			
-once_cell@1.21.3		X										X			
-opendal@0.55.0		X													
-openssl@0.10.76		X													
-openssl-macros@0.1.1		X										X			
-openssl-probe@0.2.1		X										X			
-openssl-sys@0.9.112												X			
-orc-rust@0.8.0		X													
-ordered-float@2.10.1												X			
-paimon@0.1.0		X													
-paimon-integration-tests@0.1.0		X													
-parquet@58.1.0		X													
-paste@1.0.15		X										X			
-percent-encoding@2.3.2		X										X			
-phf@0.12.1												X			
-phf_shared@0.12.1												X			
-pin-project-lite@0.2.16		X										X			
-pin-utils@0.1.0		X										X			
-pkg-config@0.3.32		X										X			
-portable-atomic@1.13.1		X										X			
-portable-atomic-util@0.2.6		X										X			
-potential_utf@0.1.2													X		
-ppv-lite86@0.2.21		X										X			
-pretty_assertions@1.4.1		X										X			
-proc-macro2@1.0.95		X										X			
-prost@0.13.5		X													
-prost-derive@0.13.5		X													
-quick-xml@0.38.4												X			
-quote@1.0.44		X										X			
-r-efi@5.3.0		X								X		X			
-rand@0.10.0		X										X			
-rand@0.8.5		X										X			
-rand_chacha@0.3.1		X										X			
-rand_core@0.10.0		X										X			
-rand_core@0.6.4		X										X			
-regex@1.12.3		X										X			
-regex-automata@0.4.14		X										X			
-regex-syntax@0.8.10		X										X			
-reqsign@0.16.5		X													
-reqwest@0.12.28		X										X			
-ring@0.17.14		X							X						
-roaring@0.11.3		X										X			
-rust_decimal@1.41.0												X			
-rustc_version@0.4.1		X										X			
-rustix@1.1.4		X	X									X			
-rustls@0.23.29		X							X			X			
-rustls-pki-types@1.12.0		X										X			
-rustls-webpki@0.103.4									X						
-rustversion@1.0.21		X										X			
-ryu@1.0.20		X				X									
-schannel@0.1.29												X			
-security-framework@3.6.0		X										X			
-security-framework-sys@2.17.0		X										X			
-semver@1.0.27		X										X			
-seq-macro@0.3.6		X										X			
-serde@1.0.228		X										X			
-serde-transcode@1.1.1		X										X			
-serde_avro_fast@2.0.2											X				
-serde_bytes@0.11.19		X										X			
-serde_core@1.0.228		X										X			
-serde_derive@1.0.228		X										X			
-serde_json@1.0.149		X										X			
-serde_repr@0.1.20		X										X			
-serde_serializer_quick_unsupported@1.0.0											X				
-serde_urlencoded@0.7.1		X										X			
-serde_with@3.14.0		X										X			
-serde_with_macros@3.14.0		X										X			
-sha1@0.10.6		X										X			
-sha2@0.10.9		X										X			
-shlex@1.3.0		X										X			
-simd-adler32@0.3.8												X			
-simdutf8@0.1.5		X										X			
-siphasher@1.0.2		X										X			
-slab@0.4.10												X			
-smallvec@1.15.1		X										X			
-snafu@0.8.9		X										X			
-snafu@0.9.0		X										X			
-snafu-derive@0.8.9		X										X			
-snafu-derive@0.9.0		X										X			
-snap@1.1.1					X										
-socket2@0.5.10		X										X			
-socket2@0.6.2		X										X			
-stable_deref_trait@1.2.0		X										X			
-strsim@0.11.1												X			
-subtle@2.6.1					X										
-syn@2.0.117		X										X			
-sync_wrapper@1.0.2		X													
-synstructure@0.13.2												X			
-system-configuration@0.6.1		X										X			
-system-configuration-sys@0.6.0		X										X			
-tempfile@3.26.0		X										X			
-thiserror@1.0.69		X										X			
-thiserror@2.0.18		X										X			
-thiserror-impl@1.0.69		X										X			
-thiserror-impl@2.0.18		X										X			
-thrift@0.17.0		X													
-tiny-keccak@2.0.2							X								
-tinystr@0.8.1													X		
-tokio@1.49.0												X			
-tokio-macros@2.6.0												X			
-tokio-native-tls@0.3.1												X			
-tokio-rustls@0.26.2		X										X			
-tokio-util@0.7.18												X			
-tower@0.5.2												X			
-tower-http@0.6.8												X			
-tower-layer@0.3.3												X			
-tower-service@0.3.3												X			
-tracing@0.1.41												X			
-tracing-core@0.1.36												X			
-try-lock@0.2.5												X			
-twox-hash@2.1.2												X			
-typed-builder@0.19.1		X										X			
-typed-builder-macro@0.19.1		X										X			
-typenum@1.18.0		X										X			
-unicode-ident@1.0.18		X										X	X		
-unicode-segmentation@1.13.2		X										X			
-unicode-width@0.2.2		X										X			
-untrusted@0.9.0									X						
-url@2.5.8		X										X			
-urlencoding@2.1.3												X			
-utf8_iter@1.0.4		X										X			
-uuid@1.21.0		X										X			
-vcpkg@0.2.15		X										X			
-version_check@0.9.5		X										X			
-want@0.3.1												X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X			
-wasi@0.14.2+wasi-0.2.4		X	X									X			
-wasip2@1.0.2+wasi-0.2.9		X	X									X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X			
-wasm-bindgen@0.2.100		X										X			
-wasm-bindgen-backend@0.2.100		X										X			
-wasm-bindgen-futures@0.4.50		X										X			
-wasm-bindgen-macro@0.2.100		X										X			
-wasm-bindgen-macro-support@0.2.100		X										X			
-wasm-bindgen-shared@0.2.100		X										X			
-wasm-streams@0.4.2		X										X			
-web-sys@0.3.77		X										X			
-webpki-roots@1.0.2								X							
-windows-core@0.61.2		X										X			
-windows-implement@0.60.0		X										X			
-windows-interface@0.59.1		X										X			
-windows-link@0.1.3		X										X			
-windows-link@0.2.1		X										X			
-windows-registry@0.5.3		X										X			
-windows-result@0.3.4		X										X			
-windows-strings@0.4.2		X										X			
-windows-sys@0.52.0		X										X			
-windows-sys@0.59.0		X										X			
-windows-sys@0.60.2		X										X			
-windows-sys@0.61.2		X										X			
-windows-targets@0.52.6		X										X			
-windows-targets@0.53.5		X										X			
-windows_aarch64_gnullvm@0.52.6		X										X			
-windows_aarch64_gnullvm@0.53.1		X										X			
-windows_aarch64_msvc@0.52.6		X										X			
-windows_aarch64_msvc@0.53.1		X										X			
-windows_i686_gnu@0.52.6		X										X			
-windows_i686_gnu@0.53.1		X										X			
-windows_i686_gnullvm@0.52.6		X										X			
-windows_i686_gnullvm@0.53.1		X										X			
-windows_i686_msvc@0.52.6		X										X			
-windows_i686_msvc@0.53.1		X										X			
-windows_x86_64_gnu@0.52.6		X										X			
-windows_x86_64_gnu@0.53.1		X										X			
-windows_x86_64_gnullvm@0.52.6		X										X			
-windows_x86_64_gnullvm@0.53.1		X										X			
-windows_x86_64_msvc@0.52.6		X										X			
-windows_x86_64_msvc@0.53.1		X										X			
-wit-bindgen@0.51.0		X	X									X			
-wit-bindgen-rt@0.39.0		X	X									X			
-writeable@0.6.1													X		
-yansi@1.0.1		X										X			
-yoke@0.8.0													X		
-yoke-derive@0.8.0													X		
-zerocopy@0.8.26		X		X								X			
-zerocopy-derive@0.8.26		X		X								X			
-zerofrom@0.1.6													X		
-zerofrom-derive@0.1.6													X		
-zeroize@1.8.1		X										X			
-zerotrie@0.2.2													X		
-zerovec@0.11.2													X		
-zerovec-derive@0.11.1													X		
-zlib-rs@0.6.3															X
-zmij@1.0.21												X			
-zstd@0.13.3												X			
-zstd-safe@7.2.4		X										X			
-zstd-sys@2.0.16+zstd.1.5.7		X										X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X			
+ahash@0.8.12		X									X			
+aho-corasick@1.1.4											X		X	
+alloc-no-stdlib@2.0.4					X									
+alloc-stdlib@0.2.2					X									
+android_system_properties@0.1.5		X									X			
+anyhow@1.0.102		X									X			
+apache-avro@0.21.0		X												
+arrow@58.3.0		X												
+arrow-arith@58.3.0		X												
+arrow-array@58.3.0		X									X			
+arrow-buffer@58.3.0		X												
+arrow-cast@58.3.0		X												
+arrow-csv@58.3.0		X												
+arrow-data@58.3.0		X												
+arrow-ipc@58.3.0		X												
+arrow-json@58.3.0		X												
+arrow-ord@58.3.0		X												
+arrow-row@58.3.0		X												
+arrow-schema@58.3.0		X												
+arrow-select@58.3.0		X												
+arrow-string@58.3.0		X												
+async-stream@0.3.6											X			
+async-stream-impl@0.3.6											X			
+async-trait@0.1.89		X									X			
+atoi@2.0.0											X			
+atomic-waker@1.1.2		X									X			
+autocfg@1.5.0		X									X			
+backon@1.6.0		X												
+base64@0.22.1		X									X			
+bigdecimal@0.4.10		X									X			
+bitflags@2.11.1		X									X			
+block-buffer@0.10.4		X									X			
+bon@3.9.1		X									X			
+bon-macros@3.9.1		X									X			
+brotli@8.0.2					X						X			
+brotli-decompressor@5.0.0					X						X			
+bumpalo@3.20.2		X									X			
+bytemuck@1.25.0		X									X			X
+byteorder@1.5.0											X		X	
+bytes@1.11.1											X			
+cc@1.2.62		X									X			
+cfg-if@1.0.4		X									X			
+chrono@0.4.44		X									X			
+chrono-tz@0.10.4		X									X			
+comfy-table@7.2.2											X			
+const-oid@0.9.6		X									X			
+const-random@0.1.18		X									X			
+const-random-macro@0.1.16		X									X			
+core-foundation@0.10.1		X									X			
+core-foundation@0.9.4		X									X			
+core-foundation-sys@0.8.7		X									X			
+cpufeatures@0.2.17		X									X			
+crc32fast@1.5.0		X									X			
+crunchy@0.2.4											X			
+crypto-common@0.1.7		X									X			
+csv@1.4.0											X		X	
+csv-core@0.1.13											X		X	
+darling@0.23.0											X			
+darling_core@0.23.0											X			
+darling_macro@0.23.0											X			
+diff@0.1.13		X									X			
+digest@0.10.7		X									X			
+displaydoc@0.2.5		X									X			
+either@1.15.0		X									X			
+encoding_rs@0.8.35		X			X						X			
+equivalent@1.0.2		X									X			
+errno@0.3.14		X									X			
+fallible-streaming-iterator@0.1.9		X									X			
+fastrand@2.4.1		X									X			
+find-msvc-tools@0.1.9		X									X			
+flatbuffers@25.12.19		X												
+flate2@1.1.9		X									X			
+fnv@1.0.7		X									X			
+foreign-types@0.3.2		X									X			
+foreign-types-shared@0.1.1		X									X			
+form_urlencoded@1.2.2		X									X			
+futures@0.3.32		X									X			
+futures-channel@0.3.32		X									X			
+futures-core@0.3.32		X									X			
+futures-executor@0.3.32		X									X			
+futures-io@0.3.32		X									X			
+futures-macro@0.3.32		X									X			
+futures-sink@0.3.32		X									X			
+futures-task@0.3.32		X									X			
+futures-util@0.3.32		X									X			
+generic-array@0.14.7											X			
+getrandom@0.2.17		X									X			
+getrandom@0.3.4		X									X			
+getrandom@0.4.2		X									X			
+gloo-timers@0.3.0		X									X			
+h2@0.4.14											X			
+half@2.7.1		X									X			
+hashbrown@0.17.1		X									X			
+heck@0.5.0		X									X			
+hex@0.4.3		X									X			
+hmac@0.12.1		X									X			
+home@0.5.12		X									X			
+http@1.4.0		X									X			
+http-body@1.0.1											X			
+http-body-util@0.1.3											X			
+httparse@1.10.1		X									X			
+httpdate@1.0.3		X									X			
+hyper@1.9.0											X			
+hyper-rustls@0.27.9		X							X		X			
+hyper-tls@0.6.0		X									X			
+hyper-util@0.1.20											X			
+iana-time-zone@0.1.65		X									X			
+iana-time-zone-haiku@0.1.2		X									X			
+icu_collections@2.2.0												X		
+icu_locale_core@2.2.0												X		
+icu_normalizer@2.2.0												X		
+icu_normalizer_data@2.2.0												X		
+icu_properties@2.2.0												X		
+icu_properties_data@2.2.0												X		
+icu_provider@2.2.0												X		
+ident_case@1.0.1		X									X			
+idna@1.1.0		X									X			
+idna_adapter@1.2.2		X									X			
+indexmap@2.14.0		X									X			
+integer-encoding@3.0.4											X			
+ipnet@2.12.0		X									X			
+itertools@0.14.0		X									X			
+itoa@1.0.18		X									X			
+jiff@0.2.24											X		X	
+jiff-tzdb@0.1.6											X		X	
+jiff-tzdb-platform@0.1.3											X		X	
+jobserver@0.1.34		X									X			
+js-sys@0.3.98		X									X			
+lexical-core@1.0.6		X									X			
+lexical-parse-float@1.0.6		X									X			
+lexical-parse-integer@1.0.6		X									X			
+lexical-util@1.0.7		X									X			
+lexical-write-float@1.0.6		X									X			
+lexical-write-integer@1.0.6		X									X			
+libc@0.2.186		X									X			
+libloading@0.8.9									X					
+libm@0.2.16											X			
+linux-raw-sys@0.12.1		X	X								X			
+litemap@0.8.2												X		
+log@0.4.29		X									X			
+lz4_flex@0.11.6											X			
+lz4_flex@0.13.1											X			
+lzokay-native@0.1.0											X			
+md-5@0.10.6		X									X			
+memchr@2.8.0											X		X	
+mime@0.3.17		X									X			
+miniz_oxide@0.8.9		X									X			X
+mio@1.2.0											X			
+native-tls@0.2.18		X									X			
+num@0.4.3		X									X			
+num-bigint@0.4.6		X									X			
+num-complex@0.4.6		X									X			
+num-integer@0.1.46		X									X			
+num-iter@0.1.45		X									X			
+num-rational@0.4.2		X									X			
+num-traits@0.2.19		X									X			
+once_cell@1.21.4		X									X			
+opendal@0.55.0		X												
+openssl@0.10.80		X												
+openssl-macros@0.1.1		X									X			
+openssl-probe@0.2.1		X									X			
+openssl-sys@0.9.116											X			
+orc-rust@0.8.0		X												
+ordered-float@2.10.1											X			
+paimon@0.2.0		X												
+paimon-integration-tests@0.2.0		X												
+parquet@58.3.0		X												
+paste@1.0.15		X									X			
+percent-encoding@2.3.2		X									X			
+phf@0.12.1											X			
+phf_shared@0.12.1											X			
+pin-project-lite@0.2.17		X									X			
+pkg-config@0.3.33		X									X			
+portable-atomic@1.13.1		X									X			
+portable-atomic-util@0.2.7		X									X			
+potential_utf@0.1.5												X		
+ppv-lite86@0.2.21		X									X			
+pretty_assertions@1.4.1		X									X			
+prettyplease@0.2.37		X									X			
+proc-macro2@1.0.106		X									X			
+prost@0.13.5		X												
+prost-derive@0.13.5		X												
+quad-rand@0.2.3											X			
+quick-xml@0.38.4											X			
+quote@1.0.45		X									X			
+r-efi@5.3.0		X								X	X			
+r-efi@6.0.0		X								X	X			
+rand@0.8.6		X									X			
+rand@0.9.4		X									X			
+rand_chacha@0.3.1		X									X			
+rand_chacha@0.9.0		X									X			
+rand_core@0.6.4		X									X			
+rand_core@0.9.5		X									X			
+regex@1.12.3		X									X			
+regex-automata@0.4.14		X									X			
+regex-lite@0.1.9		X									X			
+regex-syntax@0.8.10		X									X			
+reqsign@0.16.5		X												
+reqwest@0.12.28		X									X			
+ring@0.17.14		X							X					
+roaring@0.11.4		X									X			
+rustc_version@0.4.1		X									X			
+rustix@1.1.4		X	X								X			
+rustls@0.23.40		X							X		X			
+rustls-pki-types@1.14.1		X									X			
+rustls-webpki@0.103.13									X					
+rustversion@1.0.22		X									X			
+ryu@1.0.23		X				X								
+schannel@0.1.29											X			
+security-framework@3.7.0		X									X			
+security-framework-sys@2.17.0		X									X			
+semver@1.0.28		X									X			
+seq-macro@0.3.6		X									X			
+serde@1.0.228		X									X			
+serde_bytes@0.11.19		X									X			
+serde_core@1.0.228		X									X			
+serde_derive@1.0.228		X									X			
+serde_json@1.0.149		X									X			
+serde_repr@0.1.20		X									X			
+serde_urlencoded@0.7.1		X									X			
+serde_with@3.20.0		X									X			
+serde_with_macros@3.20.0		X									X			
+sha1@0.10.6		X									X			
+sha2@0.10.9		X									X			
+shlex@1.3.0		X									X			
+simd-adler32@0.3.9											X			
+simdutf8@0.1.5		X									X			
+siphasher@1.0.3		X									X			
+slab@0.4.12											X			
+smallvec@1.15.1		X									X			
+snafu@0.8.9		X									X			
+snafu@0.9.0		X									X			
+snafu-derive@0.8.9		X									X			
+snafu-derive@0.9.0		X									X			
+snap@1.1.1					X									
+socket2@0.6.3		X									X			
+stable_deref_trait@1.2.1		X									X			
+strsim@0.11.1											X			
+strum@0.27.2											X			
+strum_macros@0.27.2											X			
+subtle@2.6.1					X									
+syn@2.0.117		X									X			
+sync_wrapper@1.0.2		X												
+synstructure@0.13.2											X			
+system-configuration@0.7.0		X									X			
+system-configuration-sys@0.6.0		X									X			
+tempfile@3.27.0		X									X			
+thiserror@1.0.69		X									X			
+thiserror@2.0.18		X									X			
+thiserror-impl@1.0.69		X									X			
+thiserror-impl@2.0.18		X									X			
+thrift@0.17.0		X												
+tiny-keccak@2.0.2							X							
+tinystr@0.8.3												X		
+tokio@1.52.3											X			
+tokio-macros@2.7.0											X			
+tokio-native-tls@0.3.1											X			
+tokio-rustls@0.26.4		X									X			
+tokio-util@0.7.18											X			
+tower@0.5.3											X			
+tower-http@0.6.11											X			
+tower-layer@0.3.3											X			
+tower-service@0.3.3											X			
+tracing@0.1.44											X			
+tracing-core@0.1.36											X			
+try-lock@0.2.5											X			
+twox-hash@2.1.2											X			
+typed-builder@0.19.1		X									X			
+typed-builder-macro@0.19.1		X									X			
+typenum@1.20.0		X									X			
+unicode-ident@1.0.24		X									X	X		
+unicode-segmentation@1.13.2		X									X			
+unicode-width@0.2.2		X									X			
+untrusted@0.9.0									X					
+url@2.5.8		X									X			
+urlencoding@2.1.3											X			
+utf8_iter@1.0.4		X									X			
+uuid@1.23.1		X									X			
+vcpkg@0.2.15		X									X			
+version_check@0.9.5		X									X			
+want@0.3.1											X			
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
+wasip2@1.0.3+wasi-0.2.9		X	X								X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X			
+wasm-bindgen@0.2.121		X									X			
+wasm-bindgen-futures@0.4.71		X									X			
+wasm-bindgen-macro@0.2.121		X									X			
+wasm-bindgen-macro-support@0.2.121		X									X			
+wasm-bindgen-shared@0.2.121		X									X			
+wasm-streams@0.4.2		X									X			
+web-sys@0.3.98		X									X			
+webpki-roots@1.0.7								X						
+windows-core@0.62.2		X									X			
+windows-implement@0.60.2		X									X			
+windows-interface@0.59.3		X									X			
+windows-link@0.2.1		X									X			
+windows-registry@0.6.1		X									X			
+windows-result@0.4.1		X									X			
+windows-strings@0.5.1		X									X			
+windows-sys@0.52.0		X									X			
+windows-sys@0.61.2		X									X			
+windows-targets@0.52.6		X									X			
+windows_aarch64_gnullvm@0.52.6		X									X			
+windows_aarch64_msvc@0.52.6		X									X			
+windows_i686_gnu@0.52.6		X									X			
+windows_i686_gnullvm@0.52.6		X									X			
+windows_i686_msvc@0.52.6		X									X			
+windows_x86_64_gnu@0.52.6		X									X			
+windows_x86_64_gnullvm@0.52.6		X									X			
+windows_x86_64_msvc@0.52.6		X									X			
+wit-bindgen@0.51.0		X	X								X			
+wit-bindgen@0.57.1		X	X								X			
+writeable@0.6.3												X		
+yansi@1.0.1		X									X			
+yoke@0.8.2												X		
+yoke-derive@0.8.2												X		
+zerocopy@0.8.48		X		X							X			
+zerocopy-derive@0.8.48		X		X							X			
+zerofrom@0.1.8												X		
+zerofrom-derive@0.1.7												X		
+zeroize@1.8.2		X									X			
+zerotrie@0.2.4												X		
+zerovec@0.11.6												X		
+zerovec-derive@0.11.3												X		
+zlib-rs@0.6.3														X
+zmij@1.0.21											X			
+zstd@0.13.3											X			
+zstd-safe@7.2.4		X									X			
+zstd-sys@2.0.16+zstd.1.5.7		X									X			

--- a/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
@@ -1,421 +1,457 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
-adler2@2.0.1	X	X										X					
-ahash@0.8.12		X										X					
-aho-corasick@1.1.4												X			X		
-alloc-no-stdlib@2.0.4					X												
-alloc-stdlib@0.2.2					X												
-allocator-api2@0.2.21		X										X					
-android_system_properties@0.1.5		X										X					
-anyhow@1.0.102		X										X					
-ar_archive_writer@0.5.1			X														
-arrayref@0.3.9				X													
-arrayvec@0.7.6		X										X					
-arrow@58.1.0		X															
-arrow-arith@58.1.0		X															
-arrow-array@58.1.0		X															
-arrow-buffer@58.1.0		X															
-arrow-cast@58.1.0		X															
-arrow-csv@58.1.0		X															
-arrow-data@58.1.0		X															
-arrow-ipc@58.1.0		X															
-arrow-json@58.1.0		X															
-arrow-ord@58.1.0		X															
-arrow-row@58.1.0		X															
-arrow-schema@58.1.0		X															
-arrow-select@58.1.0		X															
-arrow-string@58.1.0		X															
-async-compression@0.4.41		X										X					
-async-stream@0.3.6												X					
-async-stream-impl@0.3.6												X					
-async-trait@0.1.89		X										X					
-atoi@2.0.0												X					
-atomic-waker@1.1.2		X										X					
-autocfg@1.5.0		X										X					
-backon@1.6.0		X															
-base64@0.22.1		X										X					
-bigdecimal@0.4.10		X										X					
-bitflags@2.9.1		X										X					
-blake2@0.10.6		X										X					
-blake3@1.8.3		X	X				X										
-block-buffer@0.10.4		X										X					
-brotli@8.0.2					X							X					
-brotli-decompressor@5.0.0					X							X					
-bumpalo@3.19.0		X										X					
-bytemuck@1.25.0		X										X				X	
-byteorder@1.5.0												X			X		
-bytes@1.11.1												X					
-bzip2@0.6.1		X										X					
-cc@1.2.56		X										X					
-cfg-if@1.0.1		X										X					
-chacha20@0.10.0		X										X					
-chrono@0.4.44		X										X					
-chrono-tz@0.10.4		X										X					
-comfy-table@7.2.2												X					
-compression-codecs@0.4.37		X										X					
-compression-core@0.4.31		X										X					
-const-oid@0.9.6		X										X					
-const-random@0.1.18		X										X					
-const-random-macro@0.1.16		X										X					
-constant_time_eq@0.4.2		X					X						X				
-core-foundation@0.10.1		X										X					
-core-foundation@0.9.4		X										X					
-core-foundation-sys@0.8.7		X										X					
-cpufeatures@0.2.17		X										X					
-cpufeatures@0.3.0		X										X					
-crc32fast@1.5.0		X										X					
-crossbeam-utils@0.8.21		X										X					
-crunchy@0.2.4												X					
-crypto-common@0.1.6		X										X					
-csv@1.4.0												X			X		
-csv-core@0.1.13												X			X		
-darling@0.20.11												X					
-darling_core@0.20.11												X					
-darling_macro@0.20.11												X					
-dashmap@6.1.0												X					
-datafusion@53.0.0		X															
-datafusion-catalog@53.0.0		X															
-datafusion-catalog-listing@53.0.0		X															
-datafusion-common@53.0.0		X															
-datafusion-common-runtime@53.0.0		X															
-datafusion-datasource@53.0.0		X															
-datafusion-datasource-arrow@53.0.0		X															
-datafusion-datasource-csv@53.0.0		X															
-datafusion-datasource-json@53.0.0		X															
-datafusion-datasource-parquet@53.0.0		X															
-datafusion-doc@53.0.0		X															
-datafusion-execution@53.0.0		X															
-datafusion-expr@53.0.0		X															
-datafusion-expr-common@53.0.0		X															
-datafusion-functions@53.0.0		X															
-datafusion-functions-aggregate@53.0.0		X															
-datafusion-functions-aggregate-common@53.0.0		X															
-datafusion-functions-nested@53.0.0		X															
-datafusion-functions-table@53.0.0		X															
-datafusion-functions-window@53.0.0		X															
-datafusion-functions-window-common@53.0.0		X															
-datafusion-macros@53.0.0		X															
-datafusion-optimizer@53.0.0		X															
-datafusion-physical-expr@53.0.0		X															
-datafusion-physical-expr-adapter@53.0.0		X															
-datafusion-physical-expr-common@53.0.0		X															
-datafusion-physical-optimizer@53.0.0		X															
-datafusion-physical-plan@53.0.0		X															
-datafusion-pruning@53.0.0		X															
-datafusion-session@53.0.0		X															
-datafusion-sql@53.0.0		X															
-diff@0.1.13		X										X					
-digest@0.10.7		X										X					
-displaydoc@0.2.5		X										X					
-either@1.15.0		X										X					
-encoding_rs@0.8.35		X			X							X					
-equivalent@1.0.2		X										X					
-errno@0.3.14		X										X					
-fallible-streaming-iterator@0.1.9		X										X					
-fastrand@2.3.0		X										X					
-find-msvc-tools@0.1.9		X										X					
-fixedbitset@0.5.7		X										X					
-flatbuffers@25.12.19		X															
-flate2@1.1.9		X										X					
-fnv@1.0.7		X										X					
-foldhash@0.1.5																X	
-foldhash@0.2.0																X	
-foreign-types@0.3.2		X										X					
-foreign-types-shared@0.1.1		X										X					
-form_urlencoded@1.2.2		X										X					
-futures@0.3.31		X										X					
-futures-channel@0.3.31		X										X					
-futures-core@0.3.31		X										X					
-futures-executor@0.3.31		X										X					
-futures-io@0.3.31		X										X					
-futures-macro@0.3.31		X										X					
-futures-sink@0.3.31		X										X					
-futures-task@0.3.31		X										X					
-futures-util@0.3.31		X										X					
-generic-array@0.14.7												X					
-getrandom@0.2.16		X										X					
-getrandom@0.3.3		X										X					
-getrandom@0.4.1		X										X					
-glob@0.3.3		X										X					
-gloo-timers@0.3.0		X										X					
-h2@0.4.13												X					
-half@2.7.1		X										X					
-hashbrown@0.14.5		X										X					
-hashbrown@0.15.4		X										X					
-hashbrown@0.16.1		X										X					
-heck@0.5.0		X										X					
-hex@0.4.3		X										X					
-hmac@0.12.1		X										X					
-home@0.5.12		X										X					
-http@1.3.1		X										X					
-http-body@1.0.1												X					
-http-body-util@0.1.3												X					
-httparse@1.10.1		X										X					
-httpdate@1.0.3		X										X					
-humantime@2.3.0		X										X					
-hyper@1.6.0												X					
-hyper-rustls@0.27.7		X							X			X					
-hyper-tls@0.6.0		X										X					
-hyper-util@0.1.15												X					
-iana-time-zone@0.1.63		X										X					
-iana-time-zone-haiku@0.1.2		X										X					
-icu_collections@2.0.0														X			
-icu_locale_core@2.0.0														X			
-icu_normalizer@2.0.0														X			
-icu_normalizer_data@2.0.0														X			
-icu_properties@2.0.1														X			
-icu_properties_data@2.0.1														X			
-icu_provider@2.0.0														X			
-ident_case@1.0.1		X										X					
-idna@1.1.0		X										X					
-idna_adapter@1.2.1		X										X					
-indexmap@2.13.0		X										X					
-integer-encoding@3.0.4												X					
-integer-encoding@4.1.0												X					
-ipnet@2.11.0		X										X					
-iri-string@0.7.8		X										X					
-itertools@0.14.0		X										X					
-itoa@1.0.15		X										X					
-jiff@0.2.23												X			X		
-jiff-tzdb@0.1.6												X			X		
-jiff-tzdb-platform@0.1.3												X			X		
-jobserver@0.1.34		X										X					
-js-sys@0.3.77		X										X					
-lexical-core@1.0.6		X										X					
-lexical-parse-float@1.0.6		X										X					
-lexical-parse-integer@1.0.6		X										X					
-lexical-util@1.0.7		X										X					
-lexical-write-float@1.0.6		X										X					
-lexical-write-integer@1.0.6		X										X					
-libbz2-rs-sys@0.2.2																	X
-libc@0.2.182		X										X					
-liblzma@0.4.6		X										X					
-liblzma-sys@0.4.5		X										X					
-libm@0.2.15												X					
-linux-raw-sys@0.12.1		X	X									X					
-litemap@0.8.0														X			
-lock_api@0.4.14		X										X					
-log@0.4.29		X										X					
-lz4_flex@0.11.6												X					
-lz4_flex@0.13.0												X					
-lzokay-native@0.1.0												X					
-md-5@0.10.6		X										X					
-memchr@2.8.0												X			X		
-mime@0.3.17		X										X					
-miniz_oxide@0.8.9		X										X				X	
-mio@1.0.4												X					
-native-tls@0.2.18		X										X					
-num@0.4.3		X										X					
-num-bigint@0.4.6		X										X					
-num-complex@0.4.6		X										X					
-num-integer@0.1.46		X										X					
-num-iter@0.1.45		X										X					
-num-rational@0.4.2		X										X					
-num-traits@0.2.19		X										X					
-object@0.37.3		X										X					
-object_store@0.13.2		X										X					
-once_cell@1.21.3		X										X					
-opendal@0.55.0		X															
-openssl@0.10.76		X															
-openssl-macros@0.1.1		X										X					
-openssl-probe@0.2.1		X										X					
-openssl-sys@0.9.112												X					
-orc-rust@0.8.0		X															
-ordered-float@2.10.1												X					
-paimon@0.1.0		X															
-paimon-datafusion@0.1.0		X															
-parking_lot@0.12.5		X										X					
-parking_lot_core@0.9.12		X										X					
-parquet@58.1.0		X															
-paste@1.0.15		X										X					
-percent-encoding@2.3.2		X										X					
-petgraph@0.8.3		X										X					
-phf@0.12.1												X					
-phf_shared@0.12.1												X					
-pin-project-lite@0.2.16		X										X					
-pin-utils@0.1.0		X										X					
-pkg-config@0.3.32		X										X					
-portable-atomic@1.13.1		X										X					
-portable-atomic-util@0.2.6		X										X					
-potential_utf@0.1.2														X			
-ppv-lite86@0.2.21		X										X					
-pretty_assertions@1.4.1		X										X					
-proc-macro2@1.0.95		X										X					
-prost@0.13.5		X															
-prost-derive@0.13.5		X															
-psm@0.1.30		X										X					
-quick-xml@0.38.4												X					
-quote@1.0.44		X										X					
-r-efi@5.3.0		X								X		X					
-rand@0.10.0		X										X					
-rand@0.8.5		X										X					
-rand@0.9.2		X										X					
-rand_chacha@0.3.1		X										X					
-rand_chacha@0.9.0		X										X					
-rand_core@0.10.0		X										X					
-rand_core@0.6.4		X										X					
-rand_core@0.9.3		X										X					
-recursive@0.1.1												X					
-recursive-proc-macro-impl@0.1.1												X					
-redox_syscall@0.5.18												X					
-regex@1.12.3		X										X					
-regex-automata@0.4.14		X										X					
-regex-syntax@0.8.10		X										X					
-reqsign@0.16.5		X															
-reqwest@0.12.28		X										X					
-ring@0.17.14		X							X								
-roaring@0.11.3		X										X					
-rust_decimal@1.41.0												X					
-rustc_version@0.4.1		X										X					
-rustix@1.1.4		X	X									X					
-rustls@0.23.29		X							X			X					
-rustls-pki-types@1.12.0		X										X					
-rustls-webpki@0.103.4									X								
-rustversion@1.0.21		X										X					
-ryu@1.0.20		X				X											
-same-file@1.0.6												X			X		
-schannel@0.1.29												X					
-scopeguard@1.2.0		X										X					
-security-framework@3.6.0		X										X					
-security-framework-sys@2.17.0		X										X					
-semver@1.0.27		X										X					
-seq-macro@0.3.6		X										X					
-serde@1.0.228		X										X					
-serde-transcode@1.1.1		X										X					
-serde_avro_fast@2.0.2											X						
-serde_bytes@0.11.19		X										X					
-serde_core@1.0.228		X										X					
-serde_derive@1.0.228		X										X					
-serde_json@1.0.149		X										X					
-serde_repr@0.1.20		X										X					
-serde_serializer_quick_unsupported@1.0.0											X						
-serde_urlencoded@0.7.1		X										X					
-serde_with@3.14.0		X										X					
-serde_with_macros@3.14.0		X										X					
-sha1@0.10.6		X										X					
-sha2@0.10.9		X										X					
-shlex@1.3.0		X										X					
-simd-adler32@0.3.8												X					
-simdutf8@0.1.5		X										X					
-siphasher@1.0.2		X										X					
-slab@0.4.10												X					
-smallvec@1.15.1		X										X					
-snafu@0.8.9		X										X					
-snafu@0.9.0		X										X					
-snafu-derive@0.8.9		X										X					
-snafu-derive@0.9.0		X										X					
-snap@1.1.1					X												
-socket2@0.5.10		X										X					
-socket2@0.6.2		X										X					
-sqlparser@0.61.0		X															
-sqlparser_derive@0.5.0		X															
-stable_deref_trait@1.2.0		X										X					
-stacker@0.1.23		X										X					
-strsim@0.11.1												X					
-subtle@2.6.1					X												
-syn@2.0.117		X										X					
-sync_wrapper@1.0.2		X															
-synstructure@0.13.2												X					
-system-configuration@0.6.1		X										X					
-system-configuration-sys@0.6.0		X										X					
-tempfile@3.26.0		X										X					
-thiserror@1.0.69		X										X					
-thiserror@2.0.18		X										X					
-thiserror-impl@1.0.69		X										X					
-thiserror-impl@2.0.18		X										X					
-thrift@0.17.0		X															
-tiny-keccak@2.0.2							X										
-tinystr@0.8.1														X			
-tokio@1.49.0												X					
-tokio-macros@2.6.0												X					
-tokio-native-tls@0.3.1												X					
-tokio-rustls@0.26.2		X										X					
-tokio-stream@0.1.18												X					
-tokio-util@0.7.18												X					
-tower@0.5.2												X					
-tower-http@0.6.8												X					
-tower-layer@0.3.3												X					
-tower-service@0.3.3												X					
-tracing@0.1.41												X					
-tracing-attributes@0.1.31												X					
-tracing-core@0.1.36												X					
-try-lock@0.2.5												X					
-twox-hash@2.1.2												X					
-typed-builder@0.19.1		X										X					
-typed-builder-macro@0.19.1		X										X					
-typenum@1.18.0		X										X					
-unicode-ident@1.0.18		X										X		X			
-unicode-segmentation@1.13.2		X										X					
-unicode-width@0.2.2		X										X					
-untrusted@0.9.0									X								
-url@2.5.8		X										X					
-urlencoding@2.1.3												X					
-utf8_iter@1.0.4		X										X					
-uuid@1.21.0		X										X					
-vcpkg@0.2.15		X										X					
-version_check@0.9.5		X										X					
-walkdir@2.5.0												X			X		
-want@0.3.1												X					
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X					
-wasi@0.14.2+wasi-0.2.4		X	X									X					
-wasip2@1.0.2+wasi-0.2.9		X	X									X					
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X					
-wasm-bindgen@0.2.100		X										X					
-wasm-bindgen-backend@0.2.100		X										X					
-wasm-bindgen-futures@0.4.50		X										X					
-wasm-bindgen-macro@0.2.100		X										X					
-wasm-bindgen-macro-support@0.2.100		X										X					
-wasm-bindgen-shared@0.2.100		X										X					
-wasm-streams@0.4.2		X										X					
-web-sys@0.3.77		X										X					
-web-time@1.1.0		X										X					
-webpki-roots@1.0.2								X									
-winapi-util@0.1.11												X			X		
-windows-core@0.61.2		X										X					
-windows-implement@0.60.0		X										X					
-windows-interface@0.59.1		X										X					
-windows-link@0.1.3		X										X					
-windows-link@0.2.1		X										X					
-windows-registry@0.5.3		X										X					
-windows-result@0.3.4		X										X					
-windows-strings@0.4.2		X										X					
-windows-sys@0.52.0		X										X					
-windows-sys@0.59.0		X										X					
-windows-sys@0.60.2		X										X					
-windows-sys@0.61.2		X										X					
-windows-targets@0.52.6		X										X					
-windows-targets@0.53.5		X										X					
-windows_aarch64_gnullvm@0.52.6		X										X					
-windows_aarch64_gnullvm@0.53.1		X										X					
-windows_aarch64_msvc@0.52.6		X										X					
-windows_aarch64_msvc@0.53.1		X										X					
-windows_i686_gnu@0.52.6		X										X					
-windows_i686_gnu@0.53.1		X										X					
-windows_i686_gnullvm@0.52.6		X										X					
-windows_i686_gnullvm@0.53.1		X										X					
-windows_i686_msvc@0.52.6		X										X					
-windows_i686_msvc@0.53.1		X										X					
-windows_x86_64_gnu@0.52.6		X										X					
-windows_x86_64_gnu@0.53.1		X										X					
-windows_x86_64_gnullvm@0.52.6		X										X					
-windows_x86_64_gnullvm@0.53.1		X										X					
-windows_x86_64_msvc@0.52.6		X										X					
-windows_x86_64_msvc@0.53.1		X										X					
-wit-bindgen@0.51.0		X	X									X					
-wit-bindgen-rt@0.39.0		X	X									X					
-writeable@0.6.1														X			
-yansi@1.0.1		X										X					
-yoke@0.8.0														X			
-yoke-derive@0.8.0														X			
-zerocopy@0.8.26		X		X								X					
-zerocopy-derive@0.8.26		X		X								X					
-zerofrom@0.1.6														X			
-zerofrom-derive@0.1.6														X			
-zeroize@1.8.1		X										X					
-zerotrie@0.2.2														X			
-zerovec@0.11.2														X			
-zerovec-derive@0.11.1														X			
-zlib-rs@0.6.3																X	
-zmij@1.0.21												X					
-zstd@0.13.3												X					
-zstd-safe@7.2.4		X										X					
-zstd-sys@2.0.16+zstd.1.5.7		X										X					
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6	zlib-acknowledgement
+adler2@2.0.1	X	X									X							
+ahash@0.8.12		X									X							
+aho-corasick@1.1.4											X				X			
+alloc-no-stdlib@2.0.4					X													
+alloc-stdlib@0.2.2					X													
+allocator-api2@0.2.21		X									X							
+android_system_properties@0.1.5		X									X							
+anyhow@1.0.102		X									X							
+apache-avro@0.21.0		X																
+ar_archive_writer@0.5.1			X															
+arc-swap@1.9.1		X									X							
+arrayref@0.3.9				X														
+arrayvec@0.7.6		X									X							
+arrow@58.3.0		X																
+arrow-arith@58.3.0		X																
+arrow-array@58.3.0		X									X							
+arrow-buffer@58.3.0		X																
+arrow-cast@58.3.0		X																
+arrow-csv@58.3.0		X																
+arrow-data@58.3.0		X																
+arrow-ipc@58.3.0		X																
+arrow-json@58.3.0		X																
+arrow-ord@58.3.0		X																
+arrow-row@58.3.0		X																
+arrow-schema@58.3.0		X																
+arrow-select@58.3.0		X																
+arrow-string@58.3.0		X																
+async-compression@0.4.42		X									X							
+async-stream@0.3.6											X							
+async-stream-impl@0.3.6											X							
+async-trait@0.1.89		X									X							
+atoi@2.0.0											X							
+atomic-waker@1.1.2		X									X							
+autocfg@1.5.0		X									X							
+backon@1.6.0		X																
+base64@0.22.1		X									X							
+bigdecimal@0.4.10		X									X							
+bitflags@2.11.1		X									X							
+bitpacking@0.9.3											X							
+blake2@0.10.6		X									X							
+blake3@1.8.5		X	X				X											
+block-buffer@0.10.4		X									X							
+bon@3.9.1		X									X							
+bon-macros@3.9.1		X									X							
+brotli@8.0.2					X						X							
+brotli-decompressor@5.0.0					X						X							
+bumpalo@3.20.2		X									X							
+bytemuck@1.25.0		X									X					X		
+byteorder@1.5.0											X				X			
+bytes@1.11.1											X							
+bzip2@0.6.1		X									X							
+cc@1.2.62		X									X							
+census@0.4.2											X							
+cfg-if@1.0.4		X									X							
+chrono@0.4.44		X									X							
+chrono-tz@0.10.4		X									X							
+comfy-table@7.2.2											X							
+compression-codecs@0.4.38		X									X							
+compression-core@0.4.32		X									X							
+const-oid@0.9.6		X									X							
+const-random@0.1.18		X									X							
+const-random-macro@0.1.16		X									X							
+constant_time_eq@0.4.2		X					X					X						
+core-foundation@0.10.1		X									X							
+core-foundation@0.9.4		X									X							
+core-foundation-sys@0.8.7		X									X							
+cpufeatures@0.2.17		X									X							
+cpufeatures@0.3.0		X									X							
+crc32fast@1.5.0		X									X							
+crossbeam-channel@0.5.15		X									X							
+crossbeam-deque@0.8.6		X									X							
+crossbeam-epoch@0.9.18		X									X							
+crossbeam-utils@0.8.21		X									X							
+crunchy@0.2.4											X							
+crypto-common@0.1.7		X									X							
+csv@1.4.0											X				X			
+csv-core@0.1.13											X				X			
+darling@0.23.0											X							
+darling_core@0.23.0											X							
+darling_macro@0.23.0											X							
+dashmap@6.2.1											X							
+datafusion@53.1.0		X																
+datafusion-catalog@53.1.0		X																
+datafusion-catalog-listing@53.1.0		X																
+datafusion-common@53.1.0		X																
+datafusion-common-runtime@53.1.0		X																
+datafusion-datasource@53.1.0		X																
+datafusion-datasource-arrow@53.1.0		X																
+datafusion-datasource-csv@53.1.0		X																
+datafusion-datasource-json@53.1.0		X																
+datafusion-datasource-parquet@53.1.0		X																
+datafusion-doc@53.1.0		X																
+datafusion-execution@53.1.0		X																
+datafusion-expr@53.1.0		X																
+datafusion-expr-common@53.1.0		X																
+datafusion-functions@53.1.0		X																
+datafusion-functions-aggregate@53.1.0		X																
+datafusion-functions-aggregate-common@53.1.0		X																
+datafusion-functions-nested@53.1.0		X																
+datafusion-functions-table@53.1.0		X																
+datafusion-functions-window@53.1.0		X																
+datafusion-functions-window-common@53.1.0		X																
+datafusion-macros@53.1.0		X																
+datafusion-optimizer@53.1.0		X																
+datafusion-physical-expr@53.1.0		X																
+datafusion-physical-expr-adapter@53.1.0		X																
+datafusion-physical-expr-common@53.1.0		X																
+datafusion-physical-optimizer@53.1.0		X																
+datafusion-physical-plan@53.1.0		X																
+datafusion-pruning@53.1.0		X																
+datafusion-session@53.1.0		X																
+datafusion-sql@53.1.0		X																
+deranged@0.5.8		X									X							
+diff@0.1.13		X									X							
+digest@0.10.7		X									X							
+displaydoc@0.2.5		X									X							
+downcast-rs@1.2.1		X									X							
+either@1.15.0		X									X							
+encoding_rs@0.8.35		X			X						X							
+equivalent@1.0.2		X									X							
+errno@0.3.14		X									X							
+fallible-streaming-iterator@0.1.9		X									X							
+fastdivide@0.4.2											X							X
+fastrand@2.4.1		X									X							
+find-msvc-tools@0.1.9		X									X							
+fixedbitset@0.5.7		X									X							
+flatbuffers@25.12.19		X																
+flate2@1.1.9		X									X							
+fnv@1.0.7		X									X							
+foldhash@0.1.5																X		
+foldhash@0.2.0																X		
+foreign-types@0.3.2		X									X							
+foreign-types-shared@0.1.1		X									X							
+form_urlencoded@1.2.2		X									X							
+fs4@0.8.4		X									X							
+futures@0.3.32		X									X							
+futures-channel@0.3.32		X									X							
+futures-core@0.3.32		X									X							
+futures-executor@0.3.32		X									X							
+futures-io@0.3.32		X									X							
+futures-macro@0.3.32		X									X							
+futures-sink@0.3.32		X									X							
+futures-task@0.3.32		X									X							
+futures-util@0.3.32		X									X							
+generic-array@0.14.7											X							
+getrandom@0.2.17		X									X							
+getrandom@0.3.4		X									X							
+getrandom@0.4.2		X									X							
+glob@0.3.3		X									X							
+gloo-timers@0.3.0		X									X							
+h2@0.4.14											X							
+half@2.7.1		X									X							
+hashbrown@0.14.5		X									X							
+hashbrown@0.15.5		X									X							
+hashbrown@0.16.1		X									X							
+hashbrown@0.17.1		X									X							
+heck@0.5.0		X									X							
+hermit-abi@0.5.2		X									X							
+hex@0.4.3		X									X							
+hmac@0.12.1		X									X							
+home@0.5.12		X									X							
+htmlescape@0.3.1		X									X		X					
+http@1.4.0		X									X							
+http-body@1.0.1											X							
+http-body-util@0.1.3											X							
+httparse@1.10.1		X									X							
+httpdate@1.0.3		X									X							
+humantime@2.3.0		X									X							
+hyper@1.9.0											X							
+hyper-rustls@0.27.9		X							X		X							
+hyper-tls@0.6.0		X									X							
+hyper-util@0.1.20											X							
+iana-time-zone@0.1.65		X									X							
+iana-time-zone-haiku@0.1.2		X									X							
+icu_collections@2.2.0														X				
+icu_locale_core@2.2.0														X				
+icu_normalizer@2.2.0														X				
+icu_normalizer_data@2.2.0														X				
+icu_properties@2.2.0														X				
+icu_properties_data@2.2.0														X				
+icu_provider@2.2.0														X				
+ident_case@1.0.1		X									X							
+idna@1.1.0		X									X							
+idna_adapter@1.2.2		X									X							
+indexmap@2.14.0		X									X							
+instant@0.1.13					X													
+integer-encoding@3.0.4											X							
+ipnet@2.12.0		X									X							
+itertools@0.12.1		X									X							
+itertools@0.14.0		X									X							
+itoa@1.0.18		X									X							
+jiff@0.2.24											X				X			
+jiff-tzdb@0.1.6											X				X			
+jiff-tzdb-platform@0.1.3											X				X			
+jobserver@0.1.34		X									X							
+js-sys@0.3.98		X									X							
+levenshtein_automata@0.2.1											X							
+lexical-core@1.0.6		X									X							
+lexical-parse-float@1.0.6		X									X							
+lexical-parse-integer@1.0.6		X									X							
+lexical-util@1.0.7		X									X							
+lexical-write-float@1.0.6		X									X							
+lexical-write-integer@1.0.6		X									X							
+libbz2-rs-sys@0.2.5																	X	
+libc@0.2.186		X									X							
+libloading@0.8.9									X									
+liblzma@0.4.6		X									X							
+liblzma-sys@0.4.6		X									X							
+libm@0.2.16											X							
+linux-raw-sys@0.12.1		X	X								X							
+linux-raw-sys@0.4.15		X	X								X							
+litemap@0.8.2														X				
+lock_api@0.4.14		X									X							
+log@0.4.29		X									X							
+lru@0.12.5											X							
+lz4_flex@0.11.6											X							
+lz4_flex@0.13.1											X							
+lzokay-native@0.1.0											X							
+md-5@0.10.6		X									X							
+measure_time@0.8.3											X							
+memchr@2.8.0											X				X			
+memmap2@0.9.10		X									X							
+mime@0.3.17		X									X							
+minimal-lexical@0.2.1		X									X							
+miniz_oxide@0.8.9		X									X					X		
+mio@1.2.0											X							
+murmurhash32@0.3.1											X							
+native-tls@0.2.18		X									X							
+nom@7.1.3											X							
+num@0.4.3		X									X							
+num-bigint@0.4.6		X									X							
+num-complex@0.4.6		X									X							
+num-conv@0.2.2		X									X							
+num-integer@0.1.46		X									X							
+num-iter@0.1.45		X									X							
+num-rational@0.4.2		X									X							
+num-traits@0.2.19		X									X							
+num_cpus@1.17.0		X									X							
+object@0.37.3		X									X							
+object_store@0.13.2		X									X							
+once_cell@1.21.4		X									X							
+oneshot@0.1.13		X									X							
+opendal@0.55.0		X																
+openssl@0.10.80		X																
+openssl-macros@0.1.1		X									X							
+openssl-probe@0.2.1		X									X							
+openssl-sys@0.9.116											X							
+orc-rust@0.8.0		X																
+ordered-float@2.10.1											X							
+ownedbytes@0.7.0											X							
+paimon@0.2.0		X																
+paimon-datafusion@0.2.0		X																
+parking_lot@0.12.5		X									X							
+parking_lot_core@0.9.12		X									X							
+parquet@58.3.0		X																
+paste@1.0.15		X									X							
+percent-encoding@2.3.2		X									X							
+petgraph@0.8.3		X									X							
+phf@0.12.1											X							
+phf_shared@0.12.1											X							
+pin-project-lite@0.2.17		X									X							
+pkg-config@0.3.33		X									X							
+portable-atomic@1.13.1		X									X							
+portable-atomic-util@0.2.7		X									X							
+potential_utf@0.1.5														X				
+powerfmt@0.2.0		X									X							
+ppv-lite86@0.2.21		X									X							
+pretty_assertions@1.4.1		X									X							
+prettyplease@0.2.37		X									X							
+proc-macro2@1.0.106		X									X							
+prost@0.13.5		X																
+prost-derive@0.13.5		X																
+psm@0.1.31		X									X							
+quad-rand@0.2.3											X							
+quick-xml@0.38.4											X							
+quote@1.0.45		X									X							
+r-efi@5.3.0		X								X	X							
+r-efi@6.0.0		X								X	X							
+rand@0.8.6		X									X							
+rand@0.9.4		X									X							
+rand_chacha@0.3.1		X									X							
+rand_chacha@0.9.0		X									X							
+rand_core@0.6.4		X									X							
+rand_core@0.9.5		X									X							
+rand_distr@0.4.3		X									X							
+rayon@1.12.0		X									X							
+rayon-core@1.13.0		X									X							
+recursive@0.1.1											X							
+recursive-proc-macro-impl@0.1.1											X							
+redox_syscall@0.5.18											X							
+regex@1.12.3		X									X							
+regex-automata@0.4.14		X									X							
+regex-lite@0.1.9		X									X							
+regex-syntax@0.8.10		X									X							
+reqsign@0.16.5		X																
+reqwest@0.12.28		X									X							
+ring@0.17.14		X							X									
+roaring@0.11.4		X									X							
+rust-stemmers@1.2.0					X						X							
+rustc-hash@1.1.0		X									X							
+rustc_version@0.4.1		X									X							
+rustix@0.38.44		X	X								X							
+rustix@1.1.4		X	X								X							
+rustls@0.23.40		X							X		X							
+rustls-pki-types@1.14.1		X									X							
+rustls-webpki@0.103.13									X									
+rustversion@1.0.22		X									X							
+ryu@1.0.23		X				X												
+same-file@1.0.6											X				X			
+schannel@0.1.29											X							
+scopeguard@1.2.0		X									X							
+security-framework@3.7.0		X									X							
+security-framework-sys@2.17.0		X									X							
+semver@1.0.28		X									X							
+seq-macro@0.3.6		X									X							
+serde@1.0.228		X									X							
+serde_bytes@0.11.19		X									X							
+serde_core@1.0.228		X									X							
+serde_derive@1.0.228		X									X							
+serde_json@1.0.149		X									X							
+serde_repr@0.1.20		X									X							
+serde_urlencoded@0.7.1		X									X							
+serde_with@3.20.0		X									X							
+serde_with_macros@3.20.0		X									X							
+sha1@0.10.6		X									X							
+sha2@0.10.9		X									X							
+shlex@1.3.0		X									X							
+simd-adler32@0.3.9											X							
+simdutf8@0.1.5		X									X							
+siphasher@1.0.3		X									X							
+sketches-ddsketch@0.2.2		X																
+slab@0.4.12											X							
+smallvec@1.15.1		X									X							
+snafu@0.8.9		X									X							
+snafu@0.9.0		X									X							
+snafu-derive@0.8.9		X									X							
+snafu-derive@0.9.0		X									X							
+snap@1.1.1					X													
+socket2@0.6.3		X									X							
+sqlparser@0.61.0		X																
+sqlparser_derive@0.5.0		X																
+stable_deref_trait@1.2.1		X									X							
+stacker@0.1.24		X									X							
+strsim@0.11.1											X							
+strum@0.27.2											X							
+strum_macros@0.27.2											X							
+subtle@2.6.1					X													
+syn@2.0.117		X									X							
+sync_wrapper@1.0.2		X																
+synstructure@0.13.2											X							
+system-configuration@0.7.0		X									X							
+system-configuration-sys@0.6.0		X									X							
+tantivy@0.22.1											X							
+tantivy-bitpacker@0.6.0											X							
+tantivy-columnar@0.3.0											X							
+tantivy-common@0.7.0											X							
+tantivy-fst@0.5.0											X				X			
+tantivy-query-grammar@0.22.0											X							
+tantivy-sstable@0.3.0											X							
+tantivy-stacker@0.3.0											X							
+tantivy-tokenizer-api@0.3.0											X							
+tempfile@3.27.0		X									X							
+thiserror@1.0.69		X									X							
+thiserror@2.0.18		X									X							
+thiserror-impl@1.0.69		X									X							
+thiserror-impl@2.0.18		X									X							
+thrift@0.17.0		X																
+time@0.3.47		X									X							
+time-core@0.1.8		X									X							
+tiny-keccak@2.0.2							X											
+tinystr@0.8.3														X				
+tokio@1.52.3											X							
+tokio-macros@2.7.0											X							
+tokio-native-tls@0.3.1											X							
+tokio-rustls@0.26.4		X									X							
+tokio-stream@0.1.18											X							
+tokio-util@0.7.18											X							
+tower@0.5.3											X							
+tower-http@0.6.11											X							
+tower-layer@0.3.3											X							
+tower-service@0.3.3											X							
+tracing@0.1.44											X							
+tracing-attributes@0.1.31											X							
+tracing-core@0.1.36											X							
+try-lock@0.2.5											X							
+twox-hash@2.1.2											X							
+typed-builder@0.19.1		X									X							
+typed-builder-macro@0.19.1		X									X							
+typenum@1.20.0		X									X							
+unicode-ident@1.0.24		X									X			X				
+unicode-segmentation@1.13.2		X									X							
+unicode-width@0.2.2		X									X							
+untrusted@0.9.0									X									
+url@2.5.8		X									X							
+urlencoding@2.1.3											X							
+utf8-ranges@1.0.5											X				X			
+utf8_iter@1.0.4		X									X							
+uuid@1.23.1		X									X							
+vcpkg@0.2.15		X									X							
+version_check@0.9.5		X									X							
+walkdir@2.5.0											X				X			
+want@0.3.1											X							
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X							
+wasip2@1.0.3+wasi-0.2.9		X	X								X							
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X							
+wasm-bindgen@0.2.121		X									X							
+wasm-bindgen-futures@0.4.71		X									X							
+wasm-bindgen-macro@0.2.121		X									X							
+wasm-bindgen-macro-support@0.2.121		X									X							
+wasm-bindgen-shared@0.2.121		X									X							
+wasm-streams@0.4.2		X									X							
+web-sys@0.3.98		X									X							
+web-time@1.1.0		X									X							
+webpki-roots@1.0.7								X										
+winapi@0.3.9		X									X							
+winapi-i686-pc-windows-gnu@0.4.0		X									X							
+winapi-util@0.1.11											X				X			
+winapi-x86_64-pc-windows-gnu@0.4.0		X									X							
+windows-core@0.62.2		X									X							
+windows-implement@0.60.2		X									X							
+windows-interface@0.59.3		X									X							
+windows-link@0.2.1		X									X							
+windows-registry@0.6.1		X									X							
+windows-result@0.4.1		X									X							
+windows-strings@0.5.1		X									X							
+windows-sys@0.52.0		X									X							
+windows-sys@0.59.0		X									X							
+windows-sys@0.61.2		X									X							
+windows-targets@0.52.6		X									X							
+windows_aarch64_gnullvm@0.52.6		X									X							
+windows_aarch64_msvc@0.52.6		X									X							
+windows_i686_gnu@0.52.6		X									X							
+windows_i686_gnullvm@0.52.6		X									X							
+windows_i686_msvc@0.52.6		X									X							
+windows_x86_64_gnu@0.52.6		X									X							
+windows_x86_64_gnullvm@0.52.6		X									X							
+windows_x86_64_msvc@0.52.6		X									X							
+wit-bindgen@0.51.0		X	X								X							
+wit-bindgen@0.57.1		X	X								X							
+writeable@0.6.3														X				
+yansi@1.0.1		X									X							
+yoke@0.8.2														X				
+yoke-derive@0.8.2														X				
+zerocopy@0.8.48		X		X							X							
+zerocopy-derive@0.8.48		X		X							X							
+zerofrom@0.1.8														X				
+zerofrom-derive@0.1.7														X				
+zeroize@1.8.2		X									X							
+zerotrie@0.2.4														X				
+zerovec@0.11.6														X				
+zerovec-derive@0.11.3														X				
+zlib-rs@0.6.3																X		
+zmij@1.0.21											X							
+zstd@0.13.3											X							
+zstd-safe@7.2.4		X									X							
+zstd-sys@2.0.16+zstd.1.5.7		X									X							

--- a/crates/paimon/DEPENDENCIES.rust.tsv
+++ b/crates/paimon/DEPENDENCIES.rust.tsv
@@ -1,371 +1,424 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0-only	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X										X			
-aes@0.8.4		X										X			
-ahash@0.8.12		X										X			
-aho-corasick@1.1.4												X		X	
-alloc-no-stdlib@2.0.4					X										
-alloc-stdlib@0.2.2					X										
-android_system_properties@0.1.5		X										X			
-anyhow@1.0.102		X										X			
-arrayvec@0.7.6		X										X			
-arrow@58.1.0		X													
-arrow-arith@58.1.0		X													
-arrow-array@58.1.0		X													
-arrow-buffer@58.1.0		X													
-arrow-cast@58.1.0		X													
-arrow-csv@58.1.0		X													
-arrow-data@58.1.0		X													
-arrow-ipc@58.1.0		X													
-arrow-json@58.1.0		X													
-arrow-ord@58.1.0		X													
-arrow-row@58.1.0		X													
-arrow-schema@58.1.0		X													
-arrow-select@58.1.0		X													
-arrow-string@58.1.0		X													
-async-stream@0.3.6												X			
-async-stream-impl@0.3.6												X			
-async-trait@0.1.89		X										X			
-atoi@2.0.0												X			
-atomic-waker@1.1.2		X										X			
-autocfg@1.5.0		X										X			
-backon@1.6.0		X													
-base64@0.22.1		X										X			
-bitflags@2.9.1		X										X			
-block-buffer@0.10.4		X										X			
-block-padding@0.3.3		X										X			
-brotli@8.0.2					X							X			
-brotli-decompressor@5.0.0					X							X			
-bumpalo@3.19.0		X										X			
-bytemuck@1.25.0		X										X			X
-byteorder@1.5.0												X		X	
-bytes@1.11.1												X			
-cbc@0.1.2		X										X			
-cc@1.2.56		X										X			
-cfg-if@1.0.1		X										X			
-chacha20@0.10.0		X										X			
-chrono@0.4.44		X										X			
-chrono-tz@0.10.4		X										X			
-cipher@0.4.4		X										X			
-comfy-table@7.2.2												X			
-const-oid@0.9.6		X										X			
-const-random@0.1.18		X										X			
-const-random-macro@0.1.16		X										X			
-core-foundation@0.10.1		X										X			
-core-foundation@0.9.4		X										X			
-core-foundation-sys@0.8.7		X										X			
-cpufeatures@0.2.17		X										X			
-cpufeatures@0.3.0		X										X			
-crc@3.4.0		X										X			
-crc-catalog@2.4.0		X										X			
-crc32c@0.6.8		X										X			
-crc32fast@1.5.0		X										X			
-crunchy@0.2.4												X			
-crypto-common@0.1.6		X										X			
-csv@1.4.0												X		X	
-csv-core@0.1.13												X		X	
-ctr@0.9.2		X										X			
-darling@0.20.11												X			
-darling_core@0.20.11												X			
-darling_macro@0.20.11												X			
-des@0.8.1		X										X			
-diff@0.1.13		X										X			
-digest@0.10.7		X										X			
-displaydoc@0.2.5		X										X			
-dns-lookup@3.0.1		X										X			
-either@1.15.0		X										X			
-encoding_rs@0.8.35		X			X							X			
-equivalent@1.0.2		X										X			
-errno@0.3.14		X										X			
-fallible-streaming-iterator@0.1.9		X										X			
-fastrand@2.3.0		X										X			
-find-msvc-tools@0.1.9		X										X			
-flatbuffers@25.12.19		X													
-flate2@1.1.9		X										X			
-fnv@1.0.7		X										X			
-foreign-types@0.3.2		X										X			
-foreign-types-shared@0.1.1		X										X			
-form_urlencoded@1.2.2		X										X			
-futures@0.3.31		X										X			
-futures-channel@0.3.31		X										X			
-futures-core@0.3.31		X										X			
-futures-executor@0.3.31		X										X			
-futures-io@0.3.31		X										X			
-futures-macro@0.3.31		X										X			
-futures-sink@0.3.31		X										X			
-futures-task@0.3.31		X										X			
-futures-util@0.3.31		X										X			
-g2gen@1.2.2		X										X			
-g2p@1.2.2		X										X			
-g2poly@1.2.2		X										X			
-generic-array@0.14.7												X			
-getrandom@0.2.16		X										X			
-getrandom@0.3.3		X										X			
-getrandom@0.4.1		X										X			
-gloo-timers@0.3.0		X										X			
-h2@0.4.13												X			
-half@2.7.1		X										X			
-hashbrown@0.16.1		X										X			
-hdfs-native@0.13.5		X													
-heck@0.5.0		X										X			
-hex@0.4.3		X										X			
-hmac@0.12.1		X										X			
-home@0.5.12		X										X			
-http@1.3.1		X										X			
-http-body@1.0.1												X			
-http-body-util@0.1.3												X			
-httparse@1.10.1		X										X			
-httpdate@1.0.3		X										X			
-hyper@1.6.0												X			
-hyper-rustls@0.27.7		X							X			X			
-hyper-tls@0.6.0		X										X			
-hyper-util@0.1.15												X			
-iana-time-zone@0.1.63		X										X			
-iana-time-zone-haiku@0.1.2		X										X			
-icu_collections@2.0.0													X		
-icu_locale_core@2.0.0													X		
-icu_normalizer@2.0.0													X		
-icu_normalizer_data@2.0.0													X		
-icu_properties@2.0.1													X		
-icu_properties_data@2.0.1													X		
-icu_provider@2.0.0													X		
-ident_case@1.0.1		X										X			
-idna@1.1.0		X										X			
-idna_adapter@1.2.1		X										X			
-indexmap@2.13.0		X										X			
-inout@0.1.4		X										X			
-integer-encoding@3.0.4												X			
-integer-encoding@4.1.0												X			
-ipnet@2.11.0		X										X			
-iri-string@0.7.8		X										X			
-itertools@0.14.0		X										X			
-itoa@1.0.15		X										X			
-jiff@0.2.23												X		X	
-jiff-tzdb@0.1.6												X		X	
-jiff-tzdb-platform@0.1.3												X		X	
-jobserver@0.1.34		X										X			
-js-sys@0.3.77		X										X			
-lexical-core@1.0.6		X										X			
-lexical-parse-float@1.0.6		X										X			
-lexical-parse-integer@1.0.6		X										X			
-lexical-util@1.0.7		X										X			
-lexical-write-float@1.0.6		X										X			
-lexical-write-integer@1.0.6		X										X			
-libc@0.2.182		X										X			
-libloading@0.9.0									X						
-libm@0.2.15												X			
-libredox@0.1.16												X			
-linux-raw-sys@0.12.1		X	X									X			
-litemap@0.8.0													X		
-log@0.4.29		X										X			
-lz4_flex@0.11.6												X			
-lz4_flex@0.13.0												X			
-lzokay-native@0.1.0												X			
-md-5@0.10.6		X										X			
-memchr@2.8.0												X		X	
-mime@0.3.17		X										X			
-miniz_oxide@0.8.9		X										X			X
-mio@1.0.4												X			
-native-tls@0.2.18		X										X			
-num@0.4.3		X										X			
-num-bigint@0.4.6		X										X			
-num-complex@0.4.6		X										X			
-num-integer@0.1.46		X										X			
-num-iter@0.1.45		X										X			
-num-rational@0.4.2		X										X			
-num-traits@0.2.19		X										X			
-once_cell@1.21.3		X										X			
-opendal@0.55.0		X													
-openssl@0.10.76		X													
-openssl-macros@0.1.1		X										X			
-openssl-probe@0.2.1		X										X			
-openssl-sys@0.9.112												X			
-orc-rust@0.8.0		X													
-ordered-float@2.10.1												X			
-paimon@0.1.0		X													
-parquet@58.1.0		X													
-paste@1.0.15		X										X			
-percent-encoding@2.3.2		X										X			
-phf@0.12.1												X			
-phf_shared@0.12.1												X			
-pin-project-lite@0.2.16		X										X			
-pin-utils@0.1.0		X										X			
-pkg-config@0.3.32		X										X			
-plain@0.2.3		X										X			
-portable-atomic@1.13.1		X										X			
-portable-atomic-util@0.2.6		X										X			
-potential_utf@0.1.2													X		
-ppv-lite86@0.2.21		X										X			
-pretty_assertions@1.4.1		X										X			
-proc-macro2@1.0.95		X										X			
-prost@0.13.5		X													
-prost@0.14.3		X													
-prost-derive@0.13.5		X													
-prost-derive@0.14.3		X													
-prost-types@0.14.3		X													
-quick-xml@0.37.5												X			
-quick-xml@0.38.4												X			
-quote@1.0.44		X										X			
-r-efi@5.3.0		X								X		X			
-rand@0.10.0		X										X			
-rand@0.8.5		X										X			
-rand@0.9.2		X										X			
-rand_chacha@0.3.1		X										X			
-rand_chacha@0.9.0		X										X			
-rand_core@0.10.0		X										X			
-rand_core@0.6.4		X										X			
-rand_core@0.9.3		X										X			
-regex@1.12.3		X										X			
-regex-automata@0.4.14		X										X			
-regex-syntax@0.8.10		X										X			
-reqsign@0.16.5		X													
-reqwest@0.12.28		X										X			
-ring@0.17.14		X							X						
-roaring@0.11.3		X										X			
-roxmltree@0.21.1		X										X			
-rust_decimal@1.41.0												X			
-rustc_version@0.4.1		X										X			
-rustix@1.1.4		X	X									X			
-rustls@0.23.29		X							X			X			
-rustls-pki-types@1.12.0		X										X			
-rustls-webpki@0.103.4									X						
-rustversion@1.0.21		X										X			
-ryu@1.0.20		X				X									
-schannel@0.1.29												X			
-security-framework@3.6.0		X										X			
-security-framework-sys@2.17.0		X										X			
-semver@1.0.27		X										X			
-seq-macro@0.3.6		X										X			
-serde@1.0.228		X										X			
-serde-transcode@1.1.1		X										X			
-serde_avro_fast@2.0.2											X				
-serde_bytes@0.11.19		X										X			
-serde_core@1.0.228		X										X			
-serde_derive@1.0.228		X										X			
-serde_json@1.0.149		X										X			
-serde_repr@0.1.20		X										X			
-serde_serializer_quick_unsupported@1.0.0											X				
-serde_urlencoded@0.7.1		X										X			
-serde_with@3.14.0		X										X			
-serde_with_macros@3.14.0		X										X			
-sha1@0.10.6		X										X			
-sha2@0.10.9		X										X			
-shlex@1.3.0		X										X			
-simd-adler32@0.3.8												X			
-simdutf8@0.1.5		X										X			
-siphasher@1.0.2		X										X			
-slab@0.4.10												X			
-smallvec@1.15.1		X										X			
-snafu@0.8.9		X										X			
-snafu@0.9.0		X										X			
-snafu-derive@0.8.9		X										X			
-snafu-derive@0.9.0		X										X			
-snap@1.1.1					X										
-socket2@0.5.10		X										X			
-socket2@0.6.2		X										X			
-stable_deref_trait@1.2.0		X										X			
-strsim@0.11.1												X			
-subtle@2.6.1					X										
-syn@2.0.117		X										X			
-sync_wrapper@1.0.2		X													
-synstructure@0.13.2												X			
-system-configuration@0.6.1		X										X			
-system-configuration-sys@0.6.0		X										X			
-tempfile@3.26.0		X										X			
-thiserror@1.0.69		X										X			
-thiserror@2.0.18		X										X			
-thiserror-impl@1.0.69		X										X			
-thiserror-impl@2.0.18		X										X			
-thrift@0.17.0		X													
-tiny-keccak@2.0.2							X								
-tinystr@0.8.1													X		
-tokio@1.49.0												X			
-tokio-macros@2.6.0												X			
-tokio-native-tls@0.3.1												X			
-tokio-rustls@0.26.2		X										X			
-tokio-util@0.7.18												X			
-tower@0.5.2												X			
-tower-http@0.6.8												X			
-tower-layer@0.3.3												X			
-tower-service@0.3.3												X			
-tracing@0.1.41												X			
-tracing-core@0.1.36												X			
-try-lock@0.2.5												X			
-twox-hash@2.1.2												X			
-typed-builder@0.19.1		X										X			
-typed-builder-macro@0.19.1		X										X			
-typenum@1.18.0		X										X			
-unicode-ident@1.0.18		X										X	X		
-unicode-segmentation@1.13.2		X										X			
-unicode-width@0.2.2		X										X			
-untrusted@0.9.0									X						
-url@2.5.8		X										X			
-urlencoding@2.1.3												X			
-utf8_iter@1.0.4		X										X			
-uuid@1.21.0		X										X			
-vcpkg@0.2.15		X										X			
-version_check@0.9.5		X										X			
-want@0.3.1												X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X									X			
-wasi@0.14.2+wasi-0.2.4		X	X									X			
-wasip2@1.0.2+wasi-0.2.9		X	X									X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X									X			
-wasite@0.1.0		X				X						X			
-wasm-bindgen@0.2.100		X										X			
-wasm-bindgen-backend@0.2.100		X										X			
-wasm-bindgen-futures@0.4.50		X										X			
-wasm-bindgen-macro@0.2.100		X										X			
-wasm-bindgen-macro-support@0.2.100		X										X			
-wasm-bindgen-shared@0.2.100		X										X			
-wasm-streams@0.4.2		X										X			
-web-sys@0.3.77		X										X			
-webpki-roots@1.0.2								X							
-whoami@1.6.1		X				X						X			
-windows-core@0.61.2		X										X			
-windows-implement@0.60.0		X										X			
-windows-interface@0.59.1		X										X			
-windows-link@0.1.3		X										X			
-windows-link@0.2.1		X										X			
-windows-registry@0.5.3		X										X			
-windows-result@0.3.4		X										X			
-windows-strings@0.4.2		X										X			
-windows-sys@0.52.0		X										X			
-windows-sys@0.59.0		X										X			
-windows-sys@0.60.2		X										X			
-windows-sys@0.61.2		X										X			
-windows-targets@0.52.6		X										X			
-windows-targets@0.53.5		X										X			
-windows_aarch64_gnullvm@0.52.6		X										X			
-windows_aarch64_gnullvm@0.53.1		X										X			
-windows_aarch64_msvc@0.52.6		X										X			
-windows_aarch64_msvc@0.53.1		X										X			
-windows_i686_gnu@0.52.6		X										X			
-windows_i686_gnu@0.53.1		X										X			
-windows_i686_gnullvm@0.52.6		X										X			
-windows_i686_gnullvm@0.53.1		X										X			
-windows_i686_msvc@0.52.6		X										X			
-windows_i686_msvc@0.53.1		X										X			
-windows_x86_64_gnu@0.52.6		X										X			
-windows_x86_64_gnu@0.53.1		X										X			
-windows_x86_64_gnullvm@0.52.6		X										X			
-windows_x86_64_gnullvm@0.53.1		X										X			
-windows_x86_64_msvc@0.52.6		X										X			
-windows_x86_64_msvc@0.53.1		X										X			
-wit-bindgen@0.51.0		X	X									X			
-wit-bindgen-rt@0.39.0		X	X									X			
-writeable@0.6.1													X		
-yansi@1.0.1		X										X			
-yoke@0.8.0													X		
-yoke-derive@0.8.0													X		
-zerocopy@0.8.26		X		X								X			
-zerocopy-derive@0.8.26		X		X								X			
-zerofrom@0.1.6													X		
-zerofrom-derive@0.1.6													X		
-zeroize@1.8.1		X										X			
-zerotrie@0.2.2													X		
-zerovec@0.11.2													X		
-zerovec-derive@0.11.1													X		
-zlib-rs@0.6.3															X
-zmij@1.0.21												X			
-zstd@0.13.3												X			
-zstd-safe@7.2.4		X										X			
-zstd-sys@2.0.16+zstd.1.5.7		X										X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MPL-2.0	Unicode-3.0	Unlicense	Zlib	zlib-acknowledgement
+adler2@2.0.1	X	X									X					
+aes@0.8.4		X									X					
+ahash@0.8.12		X									X					
+aho-corasick@1.1.4											X			X		
+alloc-no-stdlib@2.0.4					X											
+alloc-stdlib@0.2.2					X											
+allocator-api2@0.2.21		X									X					
+android_system_properties@0.1.5		X									X					
+anyhow@1.0.102		X									X					
+apache-avro@0.21.0		X														
+arc-swap@1.9.1		X									X					
+arrow@58.3.0		X														
+arrow-arith@58.3.0		X														
+arrow-array@58.3.0		X									X					
+arrow-buffer@58.3.0		X														
+arrow-cast@58.3.0		X														
+arrow-csv@58.3.0		X														
+arrow-data@58.3.0		X														
+arrow-ipc@58.3.0		X														
+arrow-json@58.3.0		X														
+arrow-ord@58.3.0		X														
+arrow-row@58.3.0		X														
+arrow-schema@58.3.0		X														
+arrow-select@58.3.0		X														
+arrow-string@58.3.0		X														
+async-stream@0.3.6											X					
+async-stream-impl@0.3.6											X					
+async-trait@0.1.89		X									X					
+atoi@2.0.0											X					
+atomic-waker@1.1.2		X									X					
+autocfg@1.5.0		X									X					
+backon@1.6.0		X														
+base64@0.22.1		X									X					
+bigdecimal@0.4.10		X									X					
+bitflags@2.11.1		X									X					
+bitpacking@0.9.3											X					
+block-buffer@0.10.4		X									X					
+block-padding@0.3.3		X									X					
+bon@3.9.1		X									X					
+bon-macros@3.9.1		X									X					
+brotli@8.0.2					X						X					
+brotli-decompressor@5.0.0					X						X					
+bumpalo@3.20.2		X									X					
+bytemuck@1.25.0		X									X				X	
+byteorder@1.5.0											X			X		
+bytes@1.11.1											X					
+cbc@0.1.2		X									X					
+cc@1.2.62		X									X					
+census@0.4.2											X					
+cfg-if@1.0.4		X									X					
+chrono@0.4.44		X									X					
+chrono-tz@0.10.4		X									X					
+cipher@0.4.4		X									X					
+comfy-table@7.2.2											X					
+const-oid@0.9.6		X									X					
+const-random@0.1.18		X									X					
+const-random-macro@0.1.16		X									X					
+core-foundation@0.10.1		X									X					
+core-foundation@0.9.4		X									X					
+core-foundation-sys@0.8.7		X									X					
+cpufeatures@0.2.17		X									X					
+crc@3.4.0		X									X					
+crc-catalog@2.5.0		X									X					
+crc32c@0.6.8		X									X					
+crc32fast@1.5.0		X									X					
+crossbeam-channel@0.5.15		X									X					
+crossbeam-deque@0.8.6		X									X					
+crossbeam-epoch@0.9.18		X									X					
+crossbeam-utils@0.8.21		X									X					
+crunchy@0.2.4											X					
+crypto-common@0.1.7		X									X					
+csv@1.4.0											X			X		
+csv-core@0.1.13											X			X		
+ctr@0.9.2		X									X					
+darling@0.23.0											X					
+darling_core@0.23.0											X					
+darling_macro@0.23.0											X					
+deranged@0.5.8		X									X					
+des@0.8.1		X									X					
+diff@0.1.13		X									X					
+digest@0.10.7		X									X					
+displaydoc@0.2.5		X									X					
+dlv-list@0.5.2		X									X					
+dns-lookup@3.0.1		X									X					
+downcast-rs@1.2.1		X									X					
+either@1.15.0		X									X					
+encoding_rs@0.8.35		X			X						X					
+equivalent@1.0.2		X									X					
+errno@0.3.14		X									X					
+fallible-streaming-iterator@0.1.9		X									X					
+fastdivide@0.4.2											X					X
+fastrand@2.4.1		X									X					
+find-msvc-tools@0.1.9		X									X					
+flatbuffers@25.12.19		X														
+flate2@1.1.9		X									X					
+fnv@1.0.7		X									X					
+foldhash@0.1.5															X	
+foreign-types@0.3.2		X									X					
+foreign-types-shared@0.1.1		X									X					
+form_urlencoded@1.2.2		X									X					
+fs4@0.8.4		X									X					
+futures@0.3.32		X									X					
+futures-channel@0.3.32		X									X					
+futures-core@0.3.32		X									X					
+futures-executor@0.3.32		X									X					
+futures-io@0.3.32		X									X					
+futures-macro@0.3.32		X									X					
+futures-sink@0.3.32		X									X					
+futures-task@0.3.32		X									X					
+futures-util@0.3.32		X									X					
+g2gen@1.2.2		X									X					
+g2p@1.2.2		X									X					
+g2poly@1.2.2		X									X					
+generic-array@0.14.7											X					
+getrandom@0.2.17		X									X					
+getrandom@0.3.4		X									X					
+getrandom@0.4.2		X									X					
+gloo-timers@0.3.0		X									X					
+h2@0.4.14											X					
+half@2.7.1		X									X					
+hashbrown@0.14.5		X									X					
+hashbrown@0.15.5		X									X					
+hashbrown@0.17.1		X									X					
+hdfs-native@0.13.5		X														
+heck@0.5.0		X									X					
+hermit-abi@0.5.2		X									X					
+hex@0.4.3		X									X					
+hmac@0.12.1		X									X					
+home@0.5.12		X									X					
+htmlescape@0.3.1		X									X	X				
+http@1.4.0		X									X					
+http-body@1.0.1											X					
+http-body-util@0.1.3											X					
+httparse@1.10.1		X									X					
+httpdate@1.0.3		X									X					
+hyper@1.9.0											X					
+hyper-rustls@0.27.9		X							X		X					
+hyper-tls@0.6.0		X									X					
+hyper-util@0.1.20											X					
+iana-time-zone@0.1.65		X									X					
+iana-time-zone-haiku@0.1.2		X									X					
+icu_collections@2.2.0													X			
+icu_locale_core@2.2.0													X			
+icu_normalizer@2.2.0													X			
+icu_normalizer_data@2.2.0													X			
+icu_properties@2.2.0													X			
+icu_properties_data@2.2.0													X			
+icu_provider@2.2.0													X			
+ident_case@1.0.1		X									X					
+idna@1.1.0		X									X					
+idna_adapter@1.2.2		X									X					
+indexmap@2.14.0		X									X					
+inout@0.1.4		X									X					
+instant@0.1.13					X											
+integer-encoding@3.0.4											X					
+ipnet@2.12.0		X									X					
+itertools@0.12.1		X									X					
+itertools@0.14.0		X									X					
+itoa@1.0.18		X									X					
+jiff@0.2.24											X			X		
+jiff-tzdb@0.1.6											X			X		
+jiff-tzdb-platform@0.1.3											X			X		
+jobserver@0.1.34		X									X					
+js-sys@0.3.98		X									X					
+levenshtein_automata@0.2.1											X					
+lexical-core@1.0.6		X									X					
+lexical-parse-float@1.0.6		X									X					
+lexical-parse-integer@1.0.6		X									X					
+lexical-util@1.0.7		X									X					
+lexical-write-float@1.0.6		X									X					
+lexical-write-integer@1.0.6		X									X					
+libc@0.2.186		X									X					
+libloading@0.8.9									X							
+libloading@0.9.0									X							
+libm@0.2.16											X					
+libredox@0.1.16											X					
+linux-raw-sys@0.12.1		X	X								X					
+linux-raw-sys@0.4.15		X	X								X					
+litemap@0.8.2													X			
+log@0.4.29		X									X					
+lru@0.12.5											X					
+lz4_flex@0.11.6											X					
+lz4_flex@0.13.1											X					
+lzokay-native@0.1.0											X					
+md-5@0.10.6		X									X					
+measure_time@0.8.3											X					
+memchr@2.8.0											X			X		
+memmap2@0.9.10		X									X					
+mime@0.3.17		X									X					
+minimal-lexical@0.2.1		X									X					
+miniz_oxide@0.8.9		X									X				X	
+mio@1.2.0											X					
+murmurhash32@0.3.1											X					
+native-tls@0.2.18		X									X					
+nom@7.1.3											X					
+num@0.4.3		X									X					
+num-bigint@0.4.6		X									X					
+num-complex@0.4.6		X									X					
+num-conv@0.2.2		X									X					
+num-integer@0.1.46		X									X					
+num-iter@0.1.45		X									X					
+num-rational@0.4.2		X									X					
+num-traits@0.2.19		X									X					
+num_cpus@1.17.0		X									X					
+once_cell@1.21.4		X									X					
+oneshot@0.1.13		X									X					
+opendal@0.55.0		X														
+openssl@0.10.80		X														
+openssl-macros@0.1.1		X									X					
+openssl-probe@0.2.1		X									X					
+openssl-sys@0.9.116											X					
+orc-rust@0.8.0		X														
+ordered-float@2.10.1											X					
+ordered-multimap@0.7.3											X					
+ownedbytes@0.7.0											X					
+paimon@0.2.0		X														
+parquet@58.3.0		X														
+paste@1.0.15		X									X					
+percent-encoding@2.3.2		X									X					
+phf@0.12.1											X					
+phf_shared@0.12.1											X					
+pin-project-lite@0.2.17		X									X					
+pkg-config@0.3.33		X									X					
+plain@0.2.3		X									X					
+portable-atomic@1.13.1		X									X					
+portable-atomic-util@0.2.7		X									X					
+potential_utf@0.1.5													X			
+powerfmt@0.2.0		X									X					
+ppv-lite86@0.2.21		X									X					
+pretty_assertions@1.4.1		X									X					
+prettyplease@0.2.37		X									X					
+proc-macro2@1.0.106		X									X					
+prost@0.13.5		X														
+prost@0.14.3		X														
+prost-derive@0.13.5		X														
+prost-derive@0.14.3		X														
+prost-types@0.14.3		X														
+quad-rand@0.2.3											X					
+quick-xml@0.37.5											X					
+quick-xml@0.38.4											X					
+quote@1.0.45		X									X					
+r-efi@5.3.0		X								X	X					
+r-efi@6.0.0		X								X	X					
+rand@0.8.6		X									X					
+rand@0.9.4		X									X					
+rand_chacha@0.3.1		X									X					
+rand_chacha@0.9.0		X									X					
+rand_core@0.6.4		X									X					
+rand_core@0.9.5		X									X					
+rand_distr@0.4.3		X									X					
+rayon@1.12.0		X									X					
+rayon-core@1.13.0		X									X					
+redox_syscall@0.7.5											X					
+regex@1.12.3		X									X					
+regex-automata@0.4.14		X									X					
+regex-lite@0.1.9		X									X					
+regex-syntax@0.8.10		X									X					
+reqsign@0.16.5		X														
+reqwest@0.12.28		X									X					
+ring@0.17.14		X							X							
+roaring@0.11.4		X									X					
+roxmltree@0.21.1		X									X					
+rust-ini@0.21.3											X					
+rust-stemmers@1.2.0					X						X					
+rustc-hash@1.1.0		X									X					
+rustc_version@0.4.1		X									X					
+rustix@0.38.44		X	X								X					
+rustix@1.1.4		X	X								X					
+rustls@0.23.40		X							X		X					
+rustls-pki-types@1.14.1		X									X					
+rustls-webpki@0.103.13									X							
+rustversion@1.0.22		X									X					
+ryu@1.0.23		X				X										
+schannel@0.1.29											X					
+security-framework@3.7.0		X									X					
+security-framework-sys@2.17.0		X									X					
+semver@1.0.28		X									X					
+seq-macro@0.3.6		X									X					
+serde@1.0.228		X									X					
+serde_bytes@0.11.19		X									X					
+serde_core@1.0.228		X									X					
+serde_derive@1.0.228		X									X					
+serde_json@1.0.149		X									X					
+serde_repr@0.1.20		X									X					
+serde_urlencoded@0.7.1		X									X					
+serde_with@3.20.0		X									X					
+serde_with_macros@3.20.0		X									X					
+sha1@0.10.6		X									X					
+sha2@0.10.9		X									X					
+shlex@1.3.0		X									X					
+simd-adler32@0.3.9											X					
+simdutf8@0.1.5		X									X					
+siphasher@1.0.3		X									X					
+sketches-ddsketch@0.2.2		X														
+slab@0.4.12											X					
+smallvec@1.15.1		X									X					
+snafu@0.8.9		X									X					
+snafu@0.9.0		X									X					
+snafu-derive@0.8.9		X									X					
+snafu-derive@0.9.0		X									X					
+snap@1.1.1					X											
+socket2@0.6.3		X									X					
+stable_deref_trait@1.2.1		X									X					
+strsim@0.11.1											X					
+strum@0.27.2											X					
+strum_macros@0.27.2											X					
+subtle@2.6.1					X											
+syn@2.0.117		X									X					
+sync_wrapper@1.0.2		X														
+synstructure@0.13.2											X					
+system-configuration@0.7.0		X									X					
+system-configuration-sys@0.6.0		X									X					
+tantivy@0.22.1											X					
+tantivy-bitpacker@0.6.0											X					
+tantivy-columnar@0.3.0											X					
+tantivy-common@0.7.0											X					
+tantivy-fst@0.5.0											X			X		
+tantivy-query-grammar@0.22.0											X					
+tantivy-sstable@0.3.0											X					
+tantivy-stacker@0.3.0											X					
+tantivy-tokenizer-api@0.3.0											X					
+tempfile@3.27.0		X									X					
+thiserror@1.0.69		X									X					
+thiserror@2.0.18		X									X					
+thiserror-impl@1.0.69		X									X					
+thiserror-impl@2.0.18		X									X					
+thrift@0.17.0		X														
+time@0.3.47		X									X					
+time-core@0.1.8		X									X					
+tiny-keccak@2.0.2							X									
+tinystr@0.8.3													X			
+tokio@1.52.3											X					
+tokio-macros@2.7.0											X					
+tokio-native-tls@0.3.1											X					
+tokio-rustls@0.26.4		X									X					
+tokio-util@0.7.18											X					
+tower@0.5.3											X					
+tower-http@0.6.11											X					
+tower-layer@0.3.3											X					
+tower-service@0.3.3											X					
+tracing@0.1.44											X					
+tracing-core@0.1.36											X					
+try-lock@0.2.5											X					
+twox-hash@2.1.2											X					
+typed-builder@0.19.1		X									X					
+typed-builder-macro@0.19.1		X									X					
+typenum@1.20.0		X									X					
+unicode-ident@1.0.24		X									X		X			
+unicode-segmentation@1.13.2		X									X					
+unicode-width@0.2.2		X									X					
+untrusted@0.9.0									X							
+url@2.5.8		X									X					
+urlencoding@2.1.3											X					
+utf8-ranges@1.0.5											X			X		
+utf8_iter@1.0.4		X									X					
+uuid@1.23.1		X									X					
+vcpkg@0.2.15		X									X					
+version_check@0.9.5		X									X					
+want@0.3.1											X					
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X					
+wasip2@1.0.3+wasi-0.2.9		X	X								X					
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X					
+wasite@0.1.0		X				X					X					
+wasm-bindgen@0.2.121		X									X					
+wasm-bindgen-futures@0.4.71		X									X					
+wasm-bindgen-macro@0.2.121		X									X					
+wasm-bindgen-macro-support@0.2.121		X									X					
+wasm-bindgen-shared@0.2.121		X									X					
+wasm-streams@0.4.2		X									X					
+web-sys@0.3.98		X									X					
+webpki-roots@1.0.7								X								
+whoami@1.6.1		X				X					X					
+winapi@0.3.9		X									X					
+winapi-i686-pc-windows-gnu@0.4.0		X									X					
+winapi-x86_64-pc-windows-gnu@0.4.0		X									X					
+windows-core@0.62.2		X									X					
+windows-implement@0.60.2		X									X					
+windows-interface@0.59.3		X									X					
+windows-link@0.2.1		X									X					
+windows-registry@0.6.1		X									X					
+windows-result@0.4.1		X									X					
+windows-strings@0.5.1		X									X					
+windows-sys@0.52.0		X									X					
+windows-sys@0.59.0		X									X					
+windows-sys@0.60.2		X									X					
+windows-sys@0.61.2		X									X					
+windows-targets@0.52.6		X									X					
+windows-targets@0.53.5		X									X					
+windows_aarch64_gnullvm@0.52.6		X									X					
+windows_aarch64_gnullvm@0.53.1		X									X					
+windows_aarch64_msvc@0.52.6		X									X					
+windows_aarch64_msvc@0.53.1		X									X					
+windows_i686_gnu@0.52.6		X									X					
+windows_i686_gnu@0.53.1		X									X					
+windows_i686_gnullvm@0.52.6		X									X					
+windows_i686_gnullvm@0.53.1		X									X					
+windows_i686_msvc@0.52.6		X									X					
+windows_i686_msvc@0.53.1		X									X					
+windows_x86_64_gnu@0.52.6		X									X					
+windows_x86_64_gnu@0.53.1		X									X					
+windows_x86_64_gnullvm@0.52.6		X									X					
+windows_x86_64_gnullvm@0.53.1		X									X					
+windows_x86_64_msvc@0.52.6		X									X					
+windows_x86_64_msvc@0.53.1		X									X					
+wit-bindgen@0.51.0		X	X								X					
+wit-bindgen@0.57.1		X	X								X					
+writeable@0.6.3													X			
+yansi@1.0.1		X									X					
+yoke@0.8.2													X			
+yoke-derive@0.8.2													X			
+zerocopy@0.8.48		X		X							X					
+zerocopy-derive@0.8.48		X		X							X					
+zerofrom@0.1.8													X			
+zerofrom-derive@0.1.7													X			
+zeroize@1.8.2		X									X					
+zerotrie@0.2.4													X			
+zerovec@0.11.6													X			
+zerovec-derive@0.11.3													X			
+zlib-rs@0.6.3															X	
+zmij@1.0.21											X					
+zstd@0.13.3											X					
+zstd-safe@7.2.4		X									X					
+zstd-sys@2.0.16+zstd.1.5.7		X									X					


### PR DESCRIPTION
## Summary
- Regenerated `DEPENDENCIES.rust.tsv` for all crates via `scripts/dependencies.py generate` in preparation for the 0.2.0 release.

## Test plan
- [x] `python3.11 scripts/dependencies.py generate` ran successfully across all 6 packages.
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)