### PR TITLE
ci: revert pypa/gh-action-pypi-publish to v1.13.0

### DIFF
--- a/.github/workflows/release_python_binding.yml
+++ b/.github/workflows/release_python_binding.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Publish to TestPyPI
         if: contains(github.ref, '-')
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
@@ -162,7 +162,7 @@ jobs:
 
       - name: Publish to PyPI
         if: ${{ !contains(github.ref, '-') }}
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           skip-existing: true
           packages-dir: bindings/python/dist


### PR DESCRIPTION
## Summary
- Revert `pypa/gh-action-pypi-publish` from v1.14.0 (`cef221092ed1bacb1cc03d23a2d87d1d172e277b`) to v1.13.0 (`ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e`)
- The v1.14.0 SHA was bumped by Dependabot in #297, but it has not been added to the Apache GitHub organization's allowed actions list yet
- This causes the **Release Python Binding** workflow to fail with: `The action pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b is not allowed`

## Motivation
The Apache GitHub organization enforces an allowlist for third-party GitHub Actions. The v1.14.0 commit SHA is not yet approved, blocking all Python package releases. Reverting to the previously approved v1.13.0 restores the release pipeline.

We can upgrade again once the Apache INFRA team adds the new SHA to the allowlist.