### PR TITLE
feat: support canonical Lumina index type

### DIFF
--- a/crates/paimon/src/lumina/mod.rs
+++ b/crates/paimon/src/lumina/mod.rs
@@ -20,7 +20,16 @@ pub mod reader;
 
 use std::collections::HashMap;
 
-pub const LUMINA_VECTOR_ANN_IDENTIFIER: &str = "lumina-vector-ann";
+pub const LUMINA_IDENTIFIER: &str = "lumina";
+pub const LEGACY_LUMINA_VECTOR_ANN_IDENTIFIER: &str = "lumina-vector-ann";
+pub const LUMINA_VECTOR_ANN_IDENTIFIER: &str = LEGACY_LUMINA_VECTOR_ANN_IDENTIFIER;
+
+pub fn is_lumina_index_type(index_type: &str) -> bool {
+    matches!(
+        index_type,
+        LUMINA_IDENTIFIER | LEGACY_LUMINA_VECTOR_ANN_IDENTIFIER
+    )
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LuminaVectorMetric {
@@ -505,6 +514,17 @@ mod tests {
             );
         }
         assert!(LuminaVectorMetric::from_string("hamming").is_err());
+    }
+
+    #[test]
+    fn test_lumina_index_type_identifier_helper() {
+        assert!(is_lumina_index_type(LUMINA_IDENTIFIER));
+        assert!(is_lumina_index_type(LEGACY_LUMINA_VECTOR_ANN_IDENTIFIER));
+        assert!(is_lumina_index_type(LUMINA_VECTOR_ANN_IDENTIFIER));
+        assert!(!is_lumina_index_type(""));
+        assert!(!is_lumina_index_type("btree"));
+        assert!(!is_lumina_index_type("lumina-vector"));
+        assert!(!is_lumina_index_type("LUMINA"));
     }
 
     #[test]

--- a/crates/paimon/src/table/vector_search_builder.rs
+++ b/crates/paimon/src/table/vector_search_builder.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::lumina::reader::LuminaVectorGlobalIndexReader;
-use crate::lumina::{GlobalIndexIOMeta, SearchResult, VectorSearch, LUMINA_VECTOR_ANN_IDENTIFIER};
+use crate::lumina::{is_lumina_index_type, GlobalIndexIOMeta, SearchResult, VectorSearch};
 use crate::spec::{DataField, FileKind, IndexManifest};
 use crate::table::snapshot_manager::SnapshotManager;
 use crate::table::{find_field_id_by_name, RowRange, Table};
@@ -130,7 +130,7 @@ async fn evaluate_vector_search(
         .iter()
         .filter(|e| {
             e.kind == FileKind::Add
-                && e.index_file.index_type == LUMINA_VECTOR_ANN_IDENTIFIER
+                && is_lumina_index_type(&e.index_file.index_type)
                 && e.index_file
                     .global_index_meta
                     .as_ref()
@@ -190,6 +190,7 @@ async fn evaluate_vector_search(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lumina::{LEGACY_LUMINA_VECTOR_ANN_IDENTIFIER, LUMINA_IDENTIFIER};
     use crate::spec::{DataType, GlobalIndexMeta, IndexFileMeta, IndexManifestEntry, IntType};
 
     fn make_field(id: i32, name: &str) -> DataField {
@@ -238,31 +239,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_evaluate_ignores_non_lumina_index_type() {
+        let file_io = crate::io::FileIOBuilder::new("memory").build().unwrap();
+        let fields = vec![make_field(2, "embedding")];
+        let vs = VectorSearch::new(vec![1.0], 10, "embedding".to_string()).unwrap();
+
+        let entry = make_lumina_entry("test.idx", "btree", FileKind::Add, 2);
+
+        let result = evaluate_vector_search(
+            &file_io,
+            "memory:///test_table",
+            &HashMap::new(),
+            &[entry],
+            &vs,
+            &fields,
+        )
+        .await
+        .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
     async fn test_evaluate_no_matching_field() {
         let file_io = crate::io::FileIOBuilder::new("memory").build().unwrap();
         let fields = vec![make_field(1, "id")];
         let vs = VectorSearch::new(vec![1.0], 10, "embedding".to_string()).unwrap();
 
-        let entry = IndexManifestEntry {
-            kind: FileKind::Add,
-            partition: vec![],
-            bucket: 0,
-            index_file: IndexFileMeta {
-                index_type: LUMINA_VECTOR_ANN_IDENTIFIER.to_string(),
-                file_name: "test.idx".to_string(),
-                file_size: 100,
-                row_count: 10,
-                deletion_vectors_ranges: None,
-                global_index_meta: Some(GlobalIndexMeta {
-                    row_range_start: 0,
-                    row_range_end: 9,
-                    index_field_id: 99,
-                    extra_field_ids: None,
-                    index_meta: None,
-                }),
-            },
-            version: 1,
-        };
+        let entry = make_lumina_entry(
+            "test.idx",
+            LEGACY_LUMINA_VECTOR_ANN_IDENTIFIER,
+            FileKind::Add,
+            99,
+        );
 
         let result = evaluate_vector_search(
             &file_io,
@@ -283,26 +291,12 @@ mod tests {
         let fields = vec![make_field(2, "embedding")];
         let vs = VectorSearch::new(vec![1.0], 10, "embedding".to_string()).unwrap();
 
-        let entry = IndexManifestEntry {
-            kind: FileKind::Delete,
-            partition: vec![],
-            bucket: 0,
-            index_file: IndexFileMeta {
-                index_type: LUMINA_VECTOR_ANN_IDENTIFIER.to_string(),
-                file_name: "test.idx".to_string(),
-                file_size: 100,
-                row_count: 10,
-                deletion_vectors_ranges: None,
-                global_index_meta: Some(GlobalIndexMeta {
-                    row_range_start: 0,
-                    row_range_end: 9,
-                    index_field_id: 2,
-                    extra_field_ids: None,
-                    index_meta: None,
-                }),
-            },
-            version: 1,
-        };
+        let entry = make_lumina_entry(
+            "test.idx",
+            LEGACY_LUMINA_VECTOR_ANN_IDENTIFIER,
+            FileKind::Delete,
+            2,
+        );
 
         let result = evaluate_vector_search(
             &file_io,
@@ -315,5 +309,88 @@ mod tests {
         .await
         .unwrap();
         assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_accepts_canonical_lumina_index_type() {
+        let file_io = crate::io::FileIOBuilder::new("memory").build().unwrap();
+        let fields = vec![make_field(2, "embedding")];
+        let vs = VectorSearch::new(vec![1.0], 10, "embedding".to_string()).unwrap();
+
+        let entry = make_lumina_entry("missing.idx", LUMINA_IDENTIFIER, FileKind::Add, 2);
+
+        let err = evaluate_vector_search(
+            &file_io,
+            "memory:///test_table",
+            &HashMap::new(),
+            &[entry],
+            &vs,
+            &fields,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Failed to read Lumina index file 'missing.idx'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_accepts_legacy_lumina_index_type() {
+        let file_io = crate::io::FileIOBuilder::new("memory").build().unwrap();
+        let fields = vec![make_field(2, "embedding")];
+        let vs = VectorSearch::new(vec![1.0], 10, "embedding".to_string()).unwrap();
+
+        let entry = make_lumina_entry(
+            "missing.idx",
+            LEGACY_LUMINA_VECTOR_ANN_IDENTIFIER,
+            FileKind::Add,
+            2,
+        );
+
+        let err = evaluate_vector_search(
+            &file_io,
+            "memory:///test_table",
+            &HashMap::new(),
+            &[entry],
+            &vs,
+            &fields,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Failed to read Lumina index file 'missing.idx'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    fn make_lumina_entry(
+        file_name: &str,
+        index_type: &str,
+        kind: FileKind,
+        index_field_id: i32,
+    ) -> IndexManifestEntry {
+        IndexManifestEntry {
+            kind,
+            partition: vec![],
+            bucket: 0,
+            index_file: IndexFileMeta {
+                index_type: index_type.to_string(),
+                file_name: file_name.to_string(),
+                file_size: 100,
+                row_count: 10,
+                deletion_vectors_ranges: None,
+                global_index_meta: Some(GlobalIndexMeta {
+                    row_range_start: 0,
+                    row_range_end: 9,
+                    index_field_id,
+                    extra_field_ids: None,
+                    index_meta: None,
+                }),
+            },
+            version: 1,
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

Rust vector search previously only recognized Lumina index manifest entries with `index_type = "lumina-vector-ann"`. Java now uses `index_type = "lumina"` as the canonical Lumina identifier while keeping `lumina-vector-ann` only for legacy compatibility.

This PR adds the canonical Lumina identifier and a shared helper for Lumina index type detection. `VectorSearchBuilder` now accepts both `lumina` and `lumina-vector-ann` manifest entries, while preserving existing behavior for non-Lumina indexes, delete entries, and field mismatches.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
