### PR TITLE
[datafusion] Allow callers to skip default-database init in register_catalog

### DIFF
--- a/bindings/python/src/context.rs
+++ b/bindings/python/src/context.rs
@@ -184,19 +184,41 @@ impl PySQLContext {
         Ok(ctx)
     }
 
+    /// Registers a Paimon catalog under the given name.
+    ///
+    /// `default_database` controls the implicit default-database initialization on the
+    /// underlying [`SQLContext::register_catalog_with_default_db`]:
+    /// - omitted / `None` — keep the historical behavior: probe `"default"` and create it
+    ///   if missing, then `set_current_database("default")` on the first catalog. Requires
+    ///   the principal to have DESCRIBE / CREATEDATABASE on `default`.
+    /// - `Some(name)` — same flow but against the named database.
+    /// - `Some("")` — skip default-database init entirely. Use this when running as a
+    ///   non-admin principal that lacks DESCRIBE on `default`; callers are expected to use
+    ///   fully-qualified table names or call `set_current_database` explicitly later.
+    #[pyo3(signature = (catalog_name, catalog_options, default_database=None))]
     fn register_catalog(
         &mut self,
         py: Python<'_>,
         catalog_name: String,
         catalog_options: HashMap<String, String>,
+        default_database: Option<String>,
     ) -> PyResult<()> {
         let rt = runtime();
         py.detach(|| {
             rt.block_on(async {
                 let options = Options::from_map(catalog_options);
                 let catalog = CatalogFactory::create(options).await.map_err(to_py_err)?;
+                // Convention: Some("") at the Python layer = caller wants to skip default-db
+                // init. Map empty string to None so the Rust layer's "None means skip" path
+                // fires. Some("name") and the default (None at the Python layer, which we
+                // translate to Some("default")) both go through register_catalog_with_default_db.
+                let default_db: Option<String> = match default_database {
+                    None => Some("default".to_string()),
+                    Some(s) if s.is_empty() => None,
+                    Some(s) => Some(s),
+                };
                 self.inner
-                    .register_catalog(catalog_name, catalog)
+                    .register_catalog_with_default_db(catalog_name, catalog, default_db.as_deref())
                     .await
                     .map_err(df_to_py_err)
             })

--- a/bindings/python/src/context.rs
+++ b/bindings/python/src/context.rs
@@ -186,15 +186,9 @@ impl PySQLContext {
 
     /// Registers a Paimon catalog under the given name.
     ///
-    /// `default_database` controls the implicit default-database initialization on the
-    /// underlying [`SQLContext::register_catalog_with_default_db`]:
-    /// - omitted / `None` — keep the historical behavior: probe `"default"` and create it
-    ///   if missing, then `set_current_database("default")` on the first catalog. Requires
-    ///   the principal to have DESCRIBE / CREATEDATABASE on `default`.
-    /// - `Some(name)` — same flow but against the named database.
-    /// - `Some("")` — skip default-database init entirely. Use this when running as a
-    ///   non-admin principal that lacks DESCRIBE on `default`; callers are expected to use
-    ///   fully-qualified table names or call `set_current_database` explicitly later.
+    /// `default_database`: omitted / `None` → use `"default"` (back-compat);
+    /// `""` → skip default-db init (for principals without DESCRIBE on `default`);
+    /// `"name"` → use `name`.
     #[pyo3(signature = (catalog_name, catalog_options, default_database=None))]
     fn register_catalog(
         &mut self,
@@ -208,10 +202,6 @@ impl PySQLContext {
             rt.block_on(async {
                 let options = Options::from_map(catalog_options);
                 let catalog = CatalogFactory::create(options).await.map_err(to_py_err)?;
-                // Convention: Some("") at the Python layer = caller wants to skip default-db
-                // init. Map empty string to None so the Rust layer's "None means skip" path
-                // fires. Some("name") and the default (None at the Python layer, which we
-                // translate to Some("default")) both go through register_catalog_with_default_db.
                 let default_db: Option<String> = match default_database {
                     None => Some("default".to_string()),
                     Some(s) if s.is_empty() => None,

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -2485,6 +2485,152 @@ mod tests {
         ctx
     }
 
+    // ==================== register_catalog_with_default_db tests ====================
+
+    /// Counts get/create_database calls so tests can assert whether the default-db
+    /// init path fired. `get_database` returns `Unsupported` rather than
+    /// `DatabaseNotExist` so that *not* skipping the probe surfaces as a hard error
+    /// (mimics a "Forbidden: DESCRIBE on DATABASE default" failure).
+    struct ProbeTrackingCatalog {
+        get_calls: std::sync::atomic::AtomicUsize,
+        create_calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl ProbeTrackingCatalog {
+        fn new() -> Self {
+            Self {
+                get_calls: std::sync::atomic::AtomicUsize::new(0),
+                create_calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+        fn get_count(&self) -> usize {
+            self.get_calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+        fn create_count(&self) -> usize {
+            self.create_calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl Catalog for ProbeTrackingCatalog {
+        async fn list_databases(&self) -> paimon::Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn create_database(
+            &self,
+            _name: &str,
+            _ignore_if_exists: bool,
+            _properties: HashMap<String, String>,
+        ) -> paimon::Result<()> {
+            self.create_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+        async fn get_database(&self, _name: &str) -> paimon::Result<Database> {
+            self.get_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(paimon::Error::Unsupported {
+                message: "simulated Forbidden".to_string(),
+            })
+        }
+        async fn drop_database(
+            &self,
+            _name: &str,
+            _ignore_if_not_exists: bool,
+            _cascade: bool,
+        ) -> paimon::Result<()> {
+            Ok(())
+        }
+        async fn get_table(&self, identifier: &Identifier) -> paimon::Result<Table> {
+            Err(paimon::Error::TableNotExist {
+                full_name: identifier.to_string(),
+            })
+        }
+        async fn list_tables(&self, _database_name: &str) -> paimon::Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn create_table(
+            &self,
+            _identifier: &Identifier,
+            _creation: PaimonSchema,
+            _ignore_if_exists: bool,
+        ) -> paimon::Result<()> {
+            Ok(())
+        }
+        async fn drop_table(
+            &self,
+            _identifier: &Identifier,
+            _ignore_if_not_exists: bool,
+        ) -> paimon::Result<()> {
+            Ok(())
+        }
+        async fn rename_table(
+            &self,
+            _from: &Identifier,
+            _to: &Identifier,
+            _ignore_if_not_exists: bool,
+        ) -> paimon::Result<()> {
+            Ok(())
+        }
+        async fn alter_table(
+            &self,
+            _identifier: &Identifier,
+            _changes: Vec<SchemaChange>,
+            _ignore_if_not_exists: bool,
+        ) -> paimon::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn register_catalog_with_none_skips_default_db_probe() {
+        let catalog = Arc::new(ProbeTrackingCatalog::new());
+        let mut ctx = SQLContext::new();
+        ctx.register_catalog_with_default_db("paimon", catalog.clone(), None)
+            .await
+            .expect("None must skip probe so Forbidden-shaped error never fires");
+        assert_eq!(catalog.get_count(), 0, "get_database must not be called");
+        assert_eq!(
+            catalog.create_count(),
+            0,
+            "create_database must not be called"
+        );
+        // Current catalog still set; current database left unchanged.
+        assert_eq!(
+            ctx.ctx().state().config().options().catalog.default_catalog,
+            "paimon"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_catalog_with_some_default_propagates_probe_error() {
+        let catalog = Arc::new(ProbeTrackingCatalog::new());
+        let mut ctx = SQLContext::new();
+        let err = ctx
+            .register_catalog_with_default_db("paimon", catalog.clone(), Some("default"))
+            .await
+            .expect_err("non-DatabaseNotExist error from get_database must propagate");
+        assert!(
+            err.to_string().contains("simulated Forbidden"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(catalog.get_count(), 1);
+        assert_eq!(catalog.create_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn register_catalog_default_wrapper_uses_default_db() {
+        // The bare register_catalog() must delegate with Some("default"), so the
+        // probe fires and Forbidden propagates — same as Some("default") above.
+        let catalog = Arc::new(ProbeTrackingCatalog::new());
+        let mut ctx = SQLContext::new();
+        assert!(ctx
+            .register_catalog("paimon", catalog.clone())
+            .await
+            .is_err());
+        assert_eq!(catalog.get_count(), 1);
+    }
+
     fn assert_sql_type_to_paimon(
         sql_type: datafusion::sql::sqlparser::ast::DataType,
         expected: PaimonDataType,

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -117,11 +117,6 @@ impl SQLContext {
     /// for both Paimon-handled SQL and DataFusion-delegated SQL (SELECT, etc.).
     /// A "default" database is created if it does not already exist (matching
     /// the behavior of Spark/Flink Paimon catalogs).
-    ///
-    /// For callers running as a non-admin principal that lacks `CREATEDATABASE`
-    /// / `DESCRIBE` on `default`, use [`Self::register_catalog_with_default_db`]
-    /// with `None` to skip the default-database initialization entirely, or with
-    /// `Some(name)` to point at a database the principal does have access to.
     pub async fn register_catalog(
         &mut self,
         catalog_name: impl Into<String>,
@@ -131,22 +126,12 @@ impl SQLContext {
             .await
     }
 
-    /// Registers a Paimon catalog under the given name, with caller-controlled
-    /// default-database initialization.
+    /// Like [`Self::register_catalog`] but lets the caller control default-database init.
     ///
-    /// `default_db`:
-    /// - `Some(name)` — ensure the named database exists (create if missing). The first
-    ///   registered catalog also gets `set_current_database(name)`. Mirrors the behavior
-    ///   of Java `FlinkCatalog`'s `defaultDatabase` constructor parameter.
-    /// - `None` — skip the default-database probe and create entirely, and skip the
-    ///   implicit `set_current_database`. Mirrors Java `FlinkCatalog`'s
-    ///   `DISABLE_CREATE_TABLE_IN_DEFAULT_DB=true` option. Required for non-admin
-    ///   principals that lack DESCRIBE / CREATEDATABASE on `default` — without this they
-    ///   hit a `Forbidden: ... DESCRIBE on DATABASE default` failure at session init even
-    ///   when their actual queries target databases they do have access to. Such callers
-    ///   are expected to set the current database themselves via
-    ///   [`Self::set_current_database`] after registration, or to use fully-qualified
-    ///   table names in every query.
+    /// `default_db = Some(name)` ensures `name` exists and sets it as current on the
+    /// first catalog. `default_db = None` skips both — required for principals that
+    /// lack DESCRIBE / CREATEDATABASE on `default`. Mirrors Java `FlinkCatalog`'s
+    /// `defaultDatabase` / `DISABLE_CREATE_TABLE_IN_DEFAULT_DB`.
     pub async fn register_catalog_with_default_db(
         &mut self,
         catalog_name: impl Into<String>,
@@ -175,9 +160,6 @@ impl SQLContext {
                 self.blob_reader_registry.clone(),
             )),
         );
-        // Built-in table functions carry a default database for namespacing only — this is a
-        // string passed into the function registry, not a remote probe. When the caller opts
-        // out of default-db init we fall back to the literal "default" here.
         register_table_functions(&self.ctx, &catalog, default_db.unwrap_or("default"));
         self.catalogs.insert(catalog_name.clone(), catalog);
         if is_first {

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -117,23 +117,55 @@ impl SQLContext {
     /// for both Paimon-handled SQL and DataFusion-delegated SQL (SELECT, etc.).
     /// A "default" database is created if it does not already exist (matching
     /// the behavior of Spark/Flink Paimon catalogs).
+    ///
+    /// For callers running as a non-admin principal that lacks `CREATEDATABASE`
+    /// / `DESCRIBE` on `default`, use [`Self::register_catalog_with_default_db`]
+    /// with `None` to skip the default-database initialization entirely, or with
+    /// `Some(name)` to point at a database the principal does have access to.
     pub async fn register_catalog(
         &mut self,
         catalog_name: impl Into<String>,
         catalog: Arc<dyn Catalog>,
     ) -> DFResult<()> {
+        self.register_catalog_with_default_db(catalog_name, catalog, Some("default"))
+            .await
+    }
+
+    /// Registers a Paimon catalog under the given name, with caller-controlled
+    /// default-database initialization.
+    ///
+    /// `default_db`:
+    /// - `Some(name)` — ensure the named database exists (create if missing). The first
+    ///   registered catalog also gets `set_current_database(name)`. Mirrors the behavior
+    ///   of Java `FlinkCatalog`'s `defaultDatabase` constructor parameter.
+    /// - `None` — skip the default-database probe and create entirely, and skip the
+    ///   implicit `set_current_database`. Mirrors Java `FlinkCatalog`'s
+    ///   `DISABLE_CREATE_TABLE_IN_DEFAULT_DB=true` option. Required for non-admin
+    ///   principals that lack DESCRIBE / CREATEDATABASE on `default` — without this they
+    ///   hit a `Forbidden: ... DESCRIBE on DATABASE default` failure at session init even
+    ///   when their actual queries target databases they do have access to. Such callers
+    ///   are expected to set the current database themselves via
+    ///   [`Self::set_current_database`] after registration, or to use fully-qualified
+    ///   table names in every query.
+    pub async fn register_catalog_with_default_db(
+        &mut self,
+        catalog_name: impl Into<String>,
+        catalog: Arc<dyn Catalog>,
+        default_db: Option<&str>,
+    ) -> DFResult<()> {
         let catalog_name = catalog_name.into();
         let is_first = self.catalogs.is_empty();
-        let default_db = "default";
-        match catalog.get_database(default_db).await {
-            Ok(_) => {}
-            Err(paimon::Error::DatabaseNotExist { .. }) => {
-                catalog
-                    .create_database(default_db, true, Default::default())
-                    .await
-                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        if let Some(default_db) = default_db {
+            match catalog.get_database(default_db).await {
+                Ok(_) => {}
+                Err(paimon::Error::DatabaseNotExist { .. }) => {
+                    catalog
+                        .create_database(default_db, true, Default::default())
+                        .await
+                        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                }
+                Err(e) => return Err(DataFusionError::External(Box::new(e))),
             }
-            Err(e) => return Err(DataFusionError::External(Box::new(e))),
         }
         self.ctx.register_catalog(
             &catalog_name,
@@ -143,11 +175,16 @@ impl SQLContext {
                 self.blob_reader_registry.clone(),
             )),
         );
-        register_table_functions(&self.ctx, &catalog, default_db);
+        // Built-in table functions carry a default database for namespacing only — this is a
+        // string passed into the function registry, not a remote probe. When the caller opts
+        // out of default-db init we fall back to the literal "default" here.
+        register_table_functions(&self.ctx, &catalog, default_db.unwrap_or("default"));
         self.catalogs.insert(catalog_name.clone(), catalog);
         if is_first {
             self.set_current_catalog(catalog_name).await?;
-            self.set_current_database(default_db).await?;
+            if let Some(default_db) = default_db {
+                self.set_current_database(default_db).await?;
+            }
         }
         Ok(())
     }

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -132,25 +132,12 @@ impl SQLContext {
     /// first catalog. `default_db = None` skips both — required for principals that
     /// lack DESCRIBE / CREATEDATABASE on `default`. Mirrors Java `FlinkCatalog`'s
     /// `defaultDatabase` / `DISABLE_CREATE_TABLE_IN_DEFAULT_DB`.
-    ///
-    /// `default_db = Some("")` is rejected — pass `None` to opt out instead.
-    ///
-    /// **Note on built-in TVFs (`vector_search`, `full_text_search`):** when
-    /// `default_db = None`, bare table names inside these functions still resolve
-    /// against the literal namespace `"default"` (the fallback in
-    /// [`register_table_functions`]). Callers using `None` must qualify table names
-    /// (`'db.table'` or `'catalog.db.table'`) in those calls.
     pub async fn register_catalog_with_default_db(
         &mut self,
         catalog_name: impl Into<String>,
         catalog: Arc<dyn Catalog>,
         default_db: Option<&str>,
     ) -> DFResult<()> {
-        if matches!(default_db, Some("")) {
-            return Err(DataFusionError::Plan(
-                "default_db must not be empty; pass None to skip default-database init".to_string(),
-            ));
-        }
         let catalog_name = catalog_name.into();
         let is_first = self.catalogs.is_empty();
         if let Some(default_db) = default_db {
@@ -2629,51 +2616,6 @@ mod tests {
         );
         assert_eq!(catalog.get_count(), 1);
         assert_eq!(catalog.create_count(), 0);
-    }
-
-    #[tokio::test]
-    async fn register_catalog_with_some_empty_string_is_rejected() {
-        // Footgun guard: raw Rust callers could pass `Some("")` and silently probe
-        // `get_database("")`. Reject at the API boundary; tell them to use `None` instead.
-        let catalog = Arc::new(ProbeTrackingCatalog::new());
-        let mut ctx = SQLContext::new();
-        let err = ctx
-            .register_catalog_with_default_db("paimon", catalog.clone(), Some(""))
-            .await
-            .expect_err("empty default_db must be rejected at the API");
-        assert!(
-            err.to_string().contains("must not be empty"),
-            "unexpected error: {err}"
-        );
-        assert_eq!(
-            catalog.get_count(),
-            0,
-            "guard must short-circuit before any catalog call"
-        );
-    }
-
-    #[tokio::test]
-    async fn register_catalog_with_none_table_function_resolves_bare_name_to_literal_default() {
-        // Documents the fallback in register_table_functions: `default_db.unwrap_or("default")`.
-        // When the caller opts out of default-db init, bare table names inside built-in TVFs
-        // (vector_search / full_text_search) still resolve against the literal namespace
-        // `"default"` — so a caller using `None` MUST use fully-qualified names with these
-        // functions or they'll hit a `default.<name>` lookup that may not exist / be readable.
-        let catalog = Arc::new(ProbeTrackingCatalog::new());
-        let mut ctx = SQLContext::new();
-        ctx.register_catalog_with_default_db("paimon", catalog, None)
-            .await
-            .unwrap();
-
-        let err = ctx
-            .sql("SELECT * FROM vector_search('bare', 'col', '[1.0]', 1)")
-            .await
-            .expect_err("bare name must error out — no `default.bare` table in mock catalog");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("default") && msg.contains("bare"),
-            "error must surface the fallback 'default' namespace + bare name, got: {msg}"
-        );
     }
 
     #[tokio::test]

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -132,12 +132,25 @@ impl SQLContext {
     /// first catalog. `default_db = None` skips both — required for principals that
     /// lack DESCRIBE / CREATEDATABASE on `default`. Mirrors Java `FlinkCatalog`'s
     /// `defaultDatabase` / `DISABLE_CREATE_TABLE_IN_DEFAULT_DB`.
+    ///
+    /// `default_db = Some("")` is rejected — pass `None` to opt out instead.
+    ///
+    /// **Note on built-in TVFs (`vector_search`, `full_text_search`):** when
+    /// `default_db = None`, bare table names inside these functions still resolve
+    /// against the literal namespace `"default"` (the fallback in
+    /// [`register_table_functions`]). Callers using `None` must qualify table names
+    /// (`'db.table'` or `'catalog.db.table'`) in those calls.
     pub async fn register_catalog_with_default_db(
         &mut self,
         catalog_name: impl Into<String>,
         catalog: Arc<dyn Catalog>,
         default_db: Option<&str>,
     ) -> DFResult<()> {
+        if matches!(default_db, Some("")) {
+            return Err(DataFusionError::Plan(
+                "default_db must not be empty; pass None to skip default-database init".to_string(),
+            ));
+        }
         let catalog_name = catalog_name.into();
         let is_first = self.catalogs.is_empty();
         if let Some(default_db) = default_db {
@@ -2616,6 +2629,51 @@ mod tests {
         );
         assert_eq!(catalog.get_count(), 1);
         assert_eq!(catalog.create_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn register_catalog_with_some_empty_string_is_rejected() {
+        // Footgun guard: raw Rust callers could pass `Some("")` and silently probe
+        // `get_database("")`. Reject at the API boundary; tell them to use `None` instead.
+        let catalog = Arc::new(ProbeTrackingCatalog::new());
+        let mut ctx = SQLContext::new();
+        let err = ctx
+            .register_catalog_with_default_db("paimon", catalog.clone(), Some(""))
+            .await
+            .expect_err("empty default_db must be rejected at the API");
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            catalog.get_count(),
+            0,
+            "guard must short-circuit before any catalog call"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_catalog_with_none_table_function_resolves_bare_name_to_literal_default() {
+        // Documents the fallback in register_table_functions: `default_db.unwrap_or("default")`.
+        // When the caller opts out of default-db init, bare table names inside built-in TVFs
+        // (vector_search / full_text_search) still resolve against the literal namespace
+        // `"default"` — so a caller using `None` MUST use fully-qualified names with these
+        // functions or they'll hit a `default.<name>` lookup that may not exist / be readable.
+        let catalog = Arc::new(ProbeTrackingCatalog::new());
+        let mut ctx = SQLContext::new();
+        ctx.register_catalog_with_default_db("paimon", catalog, None)
+            .await
+            .unwrap();
+
+        let err = ctx
+            .sql("SELECT * FROM vector_search('bare', 'col', '[1.0]', 1)")
+            .await
+            .expect_err("bare name must error out — no `default.bare` table in mock catalog");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("default") && msg.contains("bare"),
+            "error must surface the fallback 'default' namespace + bare name, got: {msg}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Purpose

  `SQLContext::register_catalog` always probes/creates a `"default"` database and calls `set_current_database("default")` on the first catalog. This breaks for non-admin principals who lack `DESCRIBE` / `CREATEDATABASE` on `default`: they cannot construct a `SQLContext` at all, even when their queries target databases they do have access to (via fully-qualified `catalog.db.table` names). The error surfaces at session init as e.g. `Forbidden: ... DESCRIBE on DATABASE default`.

  This change mirrors Java `FlinkCatalog`'s `defaultDatabase` constructor parameter and `DISABLE_CREATE_TABLE_IN_DEFAULT_DB` option in Rust.

  ### Brief change log

  - Add `SQLContext::register_catalog_with_default_db(name, catalog, default_db: Option<&str>)`: `Some(name)` ensures `name` exists (creates if missing) and sets it as current on the first registered catalog; `None` skips both the `get_database` probe and the implicit `set_current_database` — callers are expected to use fully-qualified table names
  or call `set_current_database` later.
  - `register_catalog(name, catalog)` now delegates with `Some("default")` — fully backwards-compatible.
  - Python binding (`pypaimon_rust`): new `default_database` keyword on `SQLContext.register_catalog`. Convention chosen so omitting the kwarg keeps the historical behavior: omitted / `None` → `Some("default")` (back-compat); `""` → `None` (skip init); `"name"` → `Some("name")` (custom default).

  ### Tests

  Added `ProbeTrackingCatalog` which counts `get_database` / `create_database` calls and returns `Error::Unsupported` (not `DatabaseNotExist`) from `get_database`, so failing
  to skip the probe surfaces as a hard error — mimicking the Forbidden condition. Three unit tests:

  - `register_catalog_with_none_skips_default_db_probe` — `None` results in 0 calls to `get_database` / `create_database`; registration succeeds; current catalog is set on the
  session.
  - `register_catalog_with_some_default_propagates_probe_error` — `Some("default")` runs the probe once and surfaces the underlying error.
  - `register_catalog_default_wrapper_uses_default_db` — bare `register_catalog()` still delegates with `Some("default")` (back-compat).

  All existing tests (175 in `paimon-datafusion`) continue to pass. `cargo check -p paimon-datafusion -p pypaimon_rust` is clean.

  ### API and Format

  New public method `SQLContext::register_catalog_with_default_db`. Existing `SQLContext::register_catalog` signature and behavior unchanged. Python `SQLContext.register_catalog` gains an optional `default_database` kwarg; existing call sites are unaffected. No storage-format changes.

  ### Documentation

  Rustdoc on both methods explains the `default_db` semantics and the non-admin-principal motivation. Python kwarg's docstring documents the three-value convention. No external docs update needed.