### PR TITLE
docs: update release docs and fix bump-version script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The rust implementation of Apache Paimon.
 
 ## Issue Tracker
 
-See [Tracking issues of 0.1.0 version for Apache Paimon Rust](https://github.com/apache/paimon-rust/issues/3)
+See [GitHub Issues](https://github.com/apache/paimon-rust/issues)
 
 ## Contributing
 

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -53,7 +53,6 @@ cargo clippy --all-targets --workspace -- -D warnings
 
 - Check [open issues](https://github.com/apache/paimon-rust/issues) for tasks to work on
 - Issues labeled `good first issue` are great starting points
-- See the [0.1.0 tracking issue](https://github.com/apache/paimon-rust/issues/3) for the current roadmap
 
 ## Community
 

--- a/docs/src/release/creating-a-release.md
+++ b/docs/src/release/creating-a-release.md
@@ -215,7 +215,7 @@ git commit -m "chore: bump version to ${NEXT_VERSION}"
 git push origin main
 ```
 
-The script updates `version` in root `Cargo.toml` (`[workspace.package]` and `[workspace.dependencies]`). All member crates inherit the workspace version.
+The script updates `version` in root `Cargo.toml` (`[workspace.package]` and the `paimon` entry in `[workspace.dependencies]`). All member crates inherit the workspace version.
 
 ### Optional: Create PRs for release blog and download page
 
@@ -348,7 +348,7 @@ svn mv -m "Release paimon-rust ${RELEASE_VERSION}" \
 ### Verify published artifacts
 
 - **Rust:** [crates.io/crates/paimon](https://crates.io/crates/paimon) shows version `${RELEASE_VERSION}`
-- **Python:** [PyPI — pypaimon](https://pypi.org/project/pypaimon/) shows version `${RELEASE_VERSION}`
+- **Python:** [PyPI — pypaimon-rust](https://pypi.org/project/pypaimon-rust/) shows version `${RELEASE_VERSION}`
 - **Go:** `go list -m github.com/apache/paimon-rust/bindings/go@v${RELEASE_VERSION}` resolves
 
 ### Create GitHub Release
@@ -383,7 +383,7 @@ The Apache Paimon community is pleased to announce the release of
 Apache Paimon Rust ${RELEASE_VERSION}.
 
 Rust:   cargo add paimon
-Python: pip install pypaimon
+Python: pip install pypaimon-rust
 Go:     go get github.com/apache/paimon-rust/bindings/go@v${RELEASE_VERSION}
 
 Release notes:

--- a/docs/src/releases.md
+++ b/docs/src/releases.md
@@ -25,18 +25,23 @@ Apache Paimon Rust follows [Semantic Versioning](https://semver.org/). All relea
 
 ## Upcoming
 
-### 0.2.0 (In Development)
+### 0.3.0 (In Development)
 
-Planned features:
+See [GitHub Issues](https://github.com/apache/paimon-rust/issues) for the current roadmap.
+
+## Past Releases
+
+### [0.2.0](https://github.com/apache/paimon-rust/releases/tag/v0.2.0)
+
+Key features:
 
 - Primary-key table read/write support with sort-merge deduplication
 - DataFusion DML support (INSERT OVERWRITE, TRUNCATE TABLE, DROP PARTITION, CALL procedures)
-- System tables ($snapshots, $tags, $manifests, $schemas)
+- System tables ($snapshots, $tags, $manifests, $schemas, $partitions, $files, $table_indexes)
 - Multi-catalog support, session-scoped dynamic options (SET/RESET), and temporary tables
 - Lumina vector index read infrastructure and Vortex columnar file format support
 - Exact COUNT(*) pushdown via partition statistics
-
-## Past Releases
+- Partial-update merge engine support (fixed-bucket and dynamic-bucket)
 
 ### [0.1.0](https://github.com/apache/paimon-rust/releases/tag/v0.1.0)
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -39,14 +39,16 @@ if [ ! -f Cargo.toml ]; then
   exit 1
 fi
 
-# Replace version only within [workspace.package] section to avoid accidentally
-# modifying third-party dependency versions in [workspace.dependencies].
+# Replace version in [workspace.package] section.
+# Also update the paimon crate version in [workspace.dependencies].
 case "$(uname -s)" in
   Darwin)
     sed -i '' '/^\[workspace\.package\]/,/^\[/{s/version = "'"${FROM_VERSION}"'"/version = "'"${TO_VERSION}"'"/;}' Cargo.toml
+    sed -i '' 's/^paimon = { version = "'"${FROM_VERSION}"'"/paimon = { version = "'"${TO_VERSION}"'"/' Cargo.toml
     ;;
   *)
     sed -i '/^\[workspace\.package\]/,/^\[/{s/version = "'"${FROM_VERSION}"'"/version = "'"${TO_VERSION}"'"/;}' Cargo.toml
+    sed -i 's/^paimon = { version = "'"${FROM_VERSION}"'"/paimon = { version = "'"${TO_VERSION}"'"/' Cargo.toml
     ;;
 esac
 


### PR DESCRIPTION
## Summary
- Update issue tracker link from 0.1.0 tracking issue to general GitHub Issues page
- Remove outdated 0.1.0 roadmap reference from contributing guide
- Fix Python package name from `pypaimon` to `pypaimon-rust` in release guide and announce template
- Move 0.2.0 from Upcoming to Past Releases and add 0.3.0 as Upcoming
- Fix `bump-version.sh` to also update `paimon` crate version in `[workspace.dependencies]`

## Test plan
- [ ] Verify `bump-version.sh` correctly updates both `[workspace.package]` version and `paimon` entry in `[workspace.dependencies]`
- [ ] Review rendered docs pages for correct links and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)