### PR TITLE
build: pin unicode-segmentation for vortex tests

### DIFF
--- a/crates/paimon/Cargo.toml
+++ b/crates/paimon/Cargo.toml
@@ -104,6 +104,9 @@ tempfile = { version = "3", optional = true }
 vortex = { version = "0.68", features = ["tokio"], optional = true }
 kanal = { version = "0.1.1", optional = true }
 libloading = "0.8"
+# Keep CI on the dependency set that passed before unicode-segmentation 1.13.3.
+# The 1.13.3 resolver update correlates with Linux Vortex tests hanging.
+unicode-segmentation = "=1.13.2"
 
 [dev-dependencies]
 axum = { version = "0.7", features = ["macros", "tokio", "http1", "http2"] }


### PR DESCRIPTION
## Summary

Main CI is still hanging after reverting #346, so the object-storage change does not appear to be the root cause.

Comparing the successful #350 Ubuntu unit job with the hanging main Ubuntu unit job shows the same compiled crate set except for one resolved patch dependency:

- successful #350 PR merge-ref: `unicode-segmentation v1.13.2`
- hanging main run: `unicode-segmentation v1.13.3`

This PR pins `unicode-segmentation` to `=1.13.2` through the `paimon` crate so CI resolves back to the dependency set that passed before the Vortex tests started hanging.

## Changes

- Add an exact `unicode-segmentation = "=1.13.2"` dependency in `crates/paimon/Cargo.toml`.
- Leave the #346 object-storage changes intact.

## Testing

- [x] `cargo tree -p paimon --features fulltext,vortex -i unicode-segmentation` resolves `unicode-segmentation v1.13.2`
- [x] `cargo test -p paimon arrow::format::vortex::tests::test_vortex_read_with --all-targets --features fulltext,vortex -- --nocapture`
- [x] `cargo test -p paimon-datafusion --features vortex --test vortex_tables -- --nocapture`

## Notes

This is intended as a targeted unblock while the interaction between the latest `unicode-segmentation` patch and the Linux Vortex tests is investigated further.
