### PR TITLE
test: add mixed-format drop column schema evolution coverage

### DIFF
--- a/crates/integration_tests/tests/read_tables.rs
+++ b/crates/integration_tests/tests/read_tables.rs
@@ -1587,20 +1587,9 @@ async fn test_read_schema_evolution_rename_column() {
 /// Old Parquet/ORC data files have the dropped column; new Avro files do not.
 #[tokio::test]
 async fn test_read_mixed_format_schema_evolution_drop_column() {
-    let (plan, batches) =
-        scan_and_read_with_fs_catalog("mixed_format_schema_evolution_drop_column", None).await;
-
-    let formats: HashSet<&str> = plan
-        .splits()
-        .iter()
-        .flat_map(|split| split.data_files())
-        .filter_map(|file| file.file_name.rsplit_once('.').map(|(_, ext)| ext))
-        .collect();
-    assert_eq!(
-        formats,
-        HashSet::from(["avro", "orc", "parquet"]),
-        "mixed_format_schema_evolution_drop_column should scan all provisioned file formats"
-    );
+    let table_name = "mixed_format_schema_evolution_drop_column";
+    let (plan, batches) = scan_and_read_with_fs_catalog(table_name, None).await;
+    assert_plan_file_formats(&plan, &["avro", "orc", "parquet"], table_name);
 
     for batch in &batches {
         assert!(

--- a/crates/integration_tests/tests/read_tables.rs
+++ b/crates/integration_tests/tests/read_tables.rs
@@ -1507,7 +1507,6 @@ async fn test_read_schema_evolution_drop_column() {
 async fn test_read_schema_evolution_rename_column() {
     let (plan, batches) =
         scan_and_read_with_fs_catalog("schema_evolution_rename_column", None).await;
-
     let formats: HashSet<&str> = plan
         .splits()
         .iter()
@@ -1580,6 +1579,62 @@ async fn test_read_schema_evolution_rename_column() {
             "parquet-old-2".to_string(),
         ],
         "Projection on renamed column should still use field-id mapping"
+    );
+}
+
+/// Test reading a mixed-format table after ALTER TABLE DROP COLUMN.
+/// Old Parquet/ORC data files have the dropped column; new Avro files do not.
+#[tokio::test]
+async fn test_read_mixed_format_schema_evolution_drop_column() {
+    let (plan, batches) =
+        scan_and_read_with_fs_catalog("mixed_format_schema_evolution_drop_column", None).await;
+
+    let formats: HashSet<&str> = plan
+        .splits()
+        .iter()
+        .flat_map(|split| split.data_files())
+        .filter_map(|file| file.file_name.rsplit_once('.').map(|(_, ext)| ext))
+        .collect();
+    assert_eq!(
+        formats,
+        HashSet::from(["avro", "orc", "parquet"]),
+        "mixed_format_schema_evolution_drop_column should scan all provisioned file formats"
+    );
+
+    for batch in &batches {
+        assert!(
+            batch.column_by_name("score").is_none(),
+            "Dropped column 'score' should not appear in output"
+        );
+    }
+
+    let mut rows: Vec<(i32, String)> = Vec::new();
+    for batch in &batches {
+        let id = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .expect("id");
+        let name = batch
+            .column_by_name("name")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .expect("name");
+        for i in 0..batch.num_rows() {
+            rows.push((id.value(i), name.value(i).to_string()));
+        }
+    }
+    rows.sort_by_key(|(id, _)| *id);
+
+    assert_eq!(
+        rows,
+        vec![
+            (1, "parquet-alice".into()),
+            (2, "parquet-bob".into()),
+            (3, "orc-carol".into()),
+            (4, "orc-dave".into()),
+            (5, "avro-eve".into()),
+            (6, "avro-frank".into()),
+        ],
+        "Mixed-format DROP COLUMN should expose only remaining columns from all file formats"
     );
 }
 

--- a/crates/integration_tests/tests/read_tables.rs
+++ b/crates/integration_tests/tests/read_tables.rs
@@ -1507,6 +1507,7 @@ async fn test_read_schema_evolution_drop_column() {
 async fn test_read_schema_evolution_rename_column() {
     let (plan, batches) =
         scan_and_read_with_fs_catalog("schema_evolution_rename_column", None).await;
+
     let formats: HashSet<&str> = plan
         .splits()
         .iter()
@@ -1635,6 +1636,53 @@ async fn test_read_mixed_format_schema_evolution_drop_column() {
             (6, "avro-frank".into()),
         ],
         "Mixed-format DROP COLUMN should expose only remaining columns from all file formats"
+    );
+
+    let (_, projected_batches) = scan_and_read_with_fs_catalog(
+        "mixed_format_schema_evolution_drop_column",
+        Some(&["name", "id"]),
+    )
+    .await;
+
+    let mut projected_rows: Vec<(i32, String)> = Vec::new();
+    for batch in &projected_batches {
+        let schema = batch.schema();
+        let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(
+            field_names,
+            vec!["name", "id"],
+            "Projection should preserve caller-specified order after DROP COLUMN"
+        );
+        assert!(
+            batch.column_by_name("score").is_none(),
+            "Dropped column 'score' should not appear in projected output"
+        );
+
+        let name = batch
+            .column_by_name("name")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .expect("projected name");
+        let id = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .expect("projected id");
+        for i in 0..batch.num_rows() {
+            projected_rows.push((id.value(i), name.value(i).to_string()));
+        }
+    }
+    projected_rows.sort_by_key(|(id, _)| *id);
+
+    assert_eq!(
+        projected_rows,
+        vec![
+            (1, "parquet-alice".into()),
+            (2, "parquet-bob".into()),
+            (3, "orc-carol".into()),
+            (4, "orc-dave".into()),
+            (5, "avro-eve".into()),
+            (6, "avro-frank".into()),
+        ],
+        "Projection should read remaining columns across old and new file schemas"
     );
 }
 

--- a/dev/spark/provision.py
+++ b/dev/spark/provision.py
@@ -646,6 +646,50 @@ def main():
         """
     )
 
+    # ===== Mixed-format Schema Evolution: Drop Column =====
+    # Old Parquet/ORC files have (id, name, score); after DROP COLUMN, Avro files
+    # have only (id, name). Reader should ignore the dropped column in old files.
+    spark.sql(
+        """
+        CREATE TABLE IF NOT EXISTS mixed_format_schema_evolution_drop_column (
+            id INT,
+            name STRING,
+            score INT
+        ) USING paimon
+        TBLPROPERTIES (
+            'file.format' = 'parquet'
+        )
+        """
+    )
+    spark.sql(
+        """
+        INSERT INTO mixed_format_schema_evolution_drop_column VALUES
+            (1, 'parquet-alice', 100),
+            (2, 'parquet-bob', 200)
+        """
+    )
+    spark.sql(
+        "ALTER TABLE mixed_format_schema_evolution_drop_column SET TBLPROPERTIES ('file.format' = 'orc')"
+    )
+    spark.sql(
+        """
+        INSERT INTO mixed_format_schema_evolution_drop_column VALUES
+            (3, 'orc-carol', 300),
+            (4, 'orc-dave', 400)
+        """
+    )
+    spark.sql("ALTER TABLE mixed_format_schema_evolution_drop_column DROP COLUMN score")
+    spark.sql(
+        "ALTER TABLE mixed_format_schema_evolution_drop_column SET TBLPROPERTIES ('file.format' = 'avro')"
+    )
+    spark.sql(
+        """
+        INSERT INTO mixed_format_schema_evolution_drop_column VALUES
+            (5, 'avro-eve'),
+            (6, 'avro-frank')
+        """
+    )
+
     # ===== Complex Types table: ARRAY, MAP, STRUCT =====
     spark.sql(
         """


### PR DESCRIPTION
### Purpose

Linked issue: #258

This PR adds focused coverage for mixed-format schema evolution after `DROP COLUMN`.

The fixture writes old-schema data files in Parquet and ORC with a dropped column, then drops that column and writes new-schema data files in Avro. The read test verifies that Rust can scan all three formats together while exposing only the remaining table columns. It also verifies that reordered projection, such as` ["name", "id"]`, preserves the caller-specified output order and still never exposes the dropped column.

### Brief change log

* Add `mixed_format_schema_evolution_drop_column` to the Spark provisioning script.
* Write old-schema Paimon data files in Parquet and ORC formats with `(id, name, score)`.
* Drop `score`, switch to Avro, and write new-schema files with `(id, name)`.
* Add a Rust integration test that:
  * verifies the scan plan includes `parquet`, `orc`, and `avro` data files;
  * reads the table through `FileSystemCatalog`;
  * checks that the dropped `score` column is not present in output batches;
  * validates decoded `id` and `name` rows across all file formats.
  * verifies reordered projection with` ["name", "id"] `preserves requested output order;
  * checks that projected output also never exposes the dropped score column.

### Tests

* `cargo fmt --all`
* `cargo test -p paimon-integration-tests test_read_mixed_format_schema_evolution_drop_column --no-run`
* `cargo check -p paimon-integration-tests`
* `python3 -m py_compile dev/spark/provision.py`
* `git diff --check -- dev/spark/provision.py crates/integration_tests/tests/read_tables.rs`

Full runtime execution of the new integration test requires regenerating the Spark-provisioned warehouse with `make docker-up`.

### API and Format

No API or persistent format changes.

### Documentation

No documentation changes.