### PR TITLE
fix(scan): net manifest add/delete by full file identity including level

### DIFF
--- a/crates/paimon/src/spec/manifest_entry.rs
+++ b/crates/paimon/src/spec/manifest_entry.rs
@@ -35,10 +35,19 @@ pub struct Identifier {
 }
 
 impl Hash for Identifier {
+    // Hash every field that participates in `Eq`, matching Java
+    // `FileEntry.Identifier.hashCode`. `level` in particular must be included:
+    // a single-run compaction upgrades a file in place (same name, new level),
+    // producing distinct identifiers that would otherwise all collide and
+    // degrade the hash sets used to net add/delete entries during scan.
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.partition.hash(state);
         self.bucket.hash(state);
+        self.level.hash(state);
         self.file_name.hash(state);
+        self.extra_files.hash(state);
+        self.embedded_index.hash(state);
+        self.external_path.hash(state);
     }
 }
 
@@ -226,3 +235,46 @@ pub const MANIFEST_ENTRY_SCHEMA: &str = r#"["null", {
         {"name": "_VERSION", "type": "int"}
     ]
 }]"#;
+
+#[cfg(test)]
+mod tests {
+    use super::Identifier;
+    use std::collections::HashSet;
+
+    fn ident(file_name: &str, level: i32) -> Identifier {
+        Identifier {
+            partition: vec![1, 2, 3],
+            bucket: 0,
+            level,
+            file_name: file_name.to_string(),
+            extra_files: Vec::new(),
+            embedded_index: None,
+            external_path: None,
+        }
+    }
+
+    /// A single-run compaction upgrades a file in place: same name, new level.
+    /// The two identifiers must be distinct (Eq) and must not collapse together
+    /// in a HashSet (Hash), otherwise netting add/delete by identifier would
+    /// drop the upgraded file. Guards both the `Eq` and the `Hash` impl.
+    #[test]
+    fn test_identifier_distinguishes_in_place_level_upgrade() {
+        let l0 = ident("f.parquet", 0);
+        let l5 = ident("f.parquet", 5);
+
+        assert_ne!(l0, l5, "same name at different levels are different files");
+
+        let mut set = HashSet::new();
+        set.insert(l0.clone());
+        assert!(
+            !set.contains(&l5),
+            "upgraded file must not alias the old one"
+        );
+        set.insert(l5.clone());
+        assert_eq!(set.len(), 2, "both levels coexist as distinct identifiers");
+
+        // Equal identifiers must hash/compare equal (set dedups them).
+        set.insert(ident("f.parquet", 5));
+        assert_eq!(set.len(), 2, "equal identifiers dedup");
+    }
+}

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -236,39 +236,32 @@ fn build_deletion_files_map(
     map
 }
 
-/// Merges add/delete manifest entries following pypaimon's `adds - deletes` behavior.
+/// Nets add/delete manifest entries for a scan, returning only the live ADD set.
 ///
-/// The identifier must be rich enough to match Paimon's file identity, otherwise a delete
-/// for one file version can incorrectly remove another with the same file name.
+/// Mirrors Java `AbstractFileStoreScan.readAndMergeFileEntries`: first collect
+/// the full [`Identifier`] of every DELETE entry, then keep the ADD entries
+/// whose identifier is not in that set. The identity is the complete Paimon file
+/// identity (`partition, bucket, level, file_name, extra_files, embedded_index,
+/// external_path`, matching Java `FileEntry.Identifier`).
+///
+/// Keying on file name alone is wrong: a single-run compaction upgrades a file
+/// *in place* — `DELETE f@oldLevel` plus `ADD f@newLevel` with the same file
+/// name (`PojoDataFileMeta.upgrade` reuses the name, only changing `level`). An
+/// identity without `level` lets the DELETE cancel the upgraded ADD, dropping
+/// the file from the scan and silently losing its rows on read.
+///
+/// Collecting deletes first (rather than insert/remove while iterating) makes
+/// the result independent of ADD/DELETE ordering, matching the Java scan path.
 fn merge_manifest_entries(entries: Vec<ManifestEntry>) -> Vec<ManifestEntry> {
-    let mut delete_entries = Vec::with_capacity(entries.len() / 4);
-    let mut added_entries = Vec::with_capacity(entries.len());
-
-    for entry in entries {
-        match entry.kind() {
-            FileKind::Add => added_entries.push(entry),
-            FileKind::Delete => delete_entries.push(entry),
-        }
-    }
-
-    if delete_entries.is_empty() {
-        return added_entries;
-    }
-
-    let deleted_keys: HashSet<(&[u8], i32, &str)> = delete_entries
+    use crate::spec::Identifier;
+    let deleted: HashSet<Identifier> = entries
         .iter()
-        .map(|e| (e.partition(), e.bucket(), e.file().file_name.as_str()))
+        .filter(|e| *e.kind() == FileKind::Delete)
+        .map(|e| e.identifier())
         .collect();
-
-    added_entries
+    entries
         .into_iter()
-        .filter(|entry| {
-            !deleted_keys.contains(&(
-                entry.partition(),
-                entry.bucket(),
-                entry.file().file_name.as_str(),
-            ))
-        })
+        .filter(|e| *e.kind() == FileKind::Add && !deleted.contains(&e.identifier()))
         .collect()
 }
 
@@ -827,6 +820,41 @@ mod tests {
             file_source: None,
             value_stats_cols: None,
         }
+    }
+
+    #[test]
+    fn test_merge_manifest_entries_keeps_in_place_upgraded_file() {
+        // Reproduces a single-run compaction "upgrade": the SAME file name is
+        // deleted at level 0 and re-added at a higher level (Paimon promotes a
+        // lone sorted run in place instead of rewriting it). Netting ADD/DELETE
+        // by file name alone (ignoring `level`) wrongly drops the upgraded file.
+        // Matches Java `FileEntry.Identifier`, which includes `level`.
+        use super::merge_manifest_entries;
+        use crate::spec::ManifestEntry;
+
+        let entry = |kind: FileKind, name: &str, level: i32| -> ManifestEntry {
+            let mut file = make_evo_file(name, 1, 1, 1, None);
+            file.level = level;
+            ManifestEntry::new(kind, Vec::new(), 0, 1, file, 2)
+        };
+
+        let entries = vec![
+            entry(FileKind::Add, "f.parquet", 0), // original level-0 write
+            entry(FileKind::Delete, "f.parquet", 0), // compaction removes the L0 version
+            entry(FileKind::Add, "f.parquet", 5), // same file upgraded to level 5
+            entry(FileKind::Add, "g.parquet", 0), // unrelated fresh file
+        ];
+
+        let mut live: Vec<(String, i32)> = merge_manifest_entries(entries)
+            .into_iter()
+            .map(|e| (e.file().file_name.clone(), e.file().level))
+            .collect();
+        live.sort();
+        assert_eq!(
+            live,
+            vec![("f.parquet".to_string(), 5), ("g.parquet".to_string(), 0)],
+            "upgraded file (f@L5) must survive; only f@L0 is cancelled by the DELETE"
+        );
     }
 
     fn file_names(groups: &[Vec<DataFileMeta>]) -> Vec<Vec<&str>> {


### PR DESCRIPTION
### Purpose

Linked issue: close #376

When planning a scan, `merge_manifest_entries` (`crates/paimon/src/table/table_scan.rs`) nets manifest `ADD`/`DELETE` entries by `(partition, bucket, file_name)`, **omitting `level`**. A single-sorted-run compaction upgrades a file *in place* (Java `PojoDataFileMeta.upgrade` reuses the file name and only bumps `level`), emitting `DELETE f@oldLevel` + `ADD f@newLevel` with the same name. The level-less key lets the `DELETE` cancel the upgraded `ADD` too, so the live file is dropped from the plan and **its rows are silently lost on read**.

This mirrors the fix to Java semantics: `FileEntry.Identifier` includes `level`, and `AbstractFileStoreScan.readAndMergeFileEntries` nets add/delete by that full identifier.

### Brief change log

- Rewrite `merge_manifest_entries` to collect every `DELETE`'s full `Identifier` (incl. `level`) and keep `ADD`s whose `identifier()` is not deleted — reusing the existing `ManifestEntry::identifier()`. This matches Java `AbstractFileStoreScan.readAndMergeFileEntries` and is independent of add/delete ordering.
- Align `Identifier`'s `Hash` impl with its `Eq` (and Java `FileEntry.Identifier.hashCode`): hash all identity fields (`partition, bucket, level, file_name, extra_files, embedded_index, external_path`). The previous `Hash` only hashed `partition/bucket/file_name`, so in-place upgraded files all collided in the dedup set.

### Tests

Two hermetic unit tests (pure logic, no external deps):

- `table_scan::tests::test_merge_manifest_entries_keeps_in_place_upgraded_file`: feeds `ADD f@L0, DELETE f@L0, ADD f@L5, ADD g@L0` and asserts the live set is `{f@L5, g@L0}`.
- `manifest_entry::tests::test_identifier_distinguishes_in_place_level_upgrade`: `f@L0` and `f@L5` are unequal and do not alias in a `HashSet<Identifier>`.

Before/after (revert the fix → the first test fails, restore → passes):
```
# before fix
test ... test_merge_manifest_entries_keeps_in_place_upgraded_file ... FAILED
  left: [("g.parquet", 0)]
 right: [("f.parquet", 5), ("g.parquet", 0)]
# after fix
test result: ok. 684 passed; 0 failed
```
`cargo fmt --all -- --check` and `cargo clippy -p paimon --all-targets` are clean.

### API and Format

No public API or storage-format changes.

### Documentation

Not needed.