### PR TITLE
fix(scan): prune IN predicates using file stats

### DIFF
--- a/crates/paimon/src/predicate_stats.rs
+++ b/crates/paimon/src/predicate_stats.rs
@@ -59,7 +59,8 @@ pub(crate) fn data_leaf_may_match<T: StatsAccessor>(
         PredicateOperator::IsNotNull => {
             return all_null != Some(true);
         }
-        PredicateOperator::In | PredicateOperator::NotIn => {
+        PredicateOperator::In => {}
+        PredicateOperator::NotIn => {
             return true;
         }
         PredicateOperator::EndsWith | PredicateOperator::Contains => {
@@ -113,6 +114,10 @@ pub(crate) fn data_leaf_may_match<T: StatsAccessor>(
     };
 
     match op {
+        PredicateOperator::In => literals.iter().any(|literal| {
+            !matches!(literal.partial_cmp(&min_value), Some(Ordering::Less))
+                && !matches!(literal.partial_cmp(&max_value), Some(Ordering::Greater))
+        }),
         PredicateOperator::Eq => {
             !matches!(literal.partial_cmp(&min_value), Some(Ordering::Less))
                 && !matches!(literal.partial_cmp(&max_value), Some(Ordering::Greater))
@@ -180,7 +185,6 @@ pub(crate) fn data_leaf_may_match<T: StatsAccessor>(
         }
         PredicateOperator::IsNull
         | PredicateOperator::IsNotNull
-        | PredicateOperator::In
         | PredicateOperator::NotIn
         | PredicateOperator::EndsWith
         | PredicateOperator::Contains

--- a/crates/paimon/src/predicate_stats.rs
+++ b/crates/paimon/src/predicate_stats.rs
@@ -23,6 +23,9 @@ pub(crate) trait StatsAccessor {
     fn null_count(&self, index: usize) -> Option<i64>;
     fn min_value(&self, index: usize, data_type: &DataType) -> Option<Datum>;
     fn max_value(&self, index: usize, data_type: &DataType) -> Option<Datum>;
+    fn supports_in_min_max_pruning(&self) -> bool {
+        false
+    }
 }
 
 pub(crate) fn predicates_may_match_with_schema<T: StatsAccessor>(
@@ -59,7 +62,10 @@ pub(crate) fn data_leaf_may_match<T: StatsAccessor>(
         PredicateOperator::IsNotNull => {
             return all_null != Some(true);
         }
-        PredicateOperator::In => {}
+        PredicateOperator::In if stats.supports_in_min_max_pruning() => {}
+        PredicateOperator::In => {
+            return true;
+        }
         PredicateOperator::NotIn => {
             return true;
         }
@@ -114,10 +120,18 @@ pub(crate) fn data_leaf_may_match<T: StatsAccessor>(
     };
 
     match op {
-        PredicateOperator::In => literals.iter().any(|literal| {
-            !matches!(literal.partial_cmp(&min_value), Some(Ordering::Less))
-                && !matches!(literal.partial_cmp(&max_value), Some(Ordering::Greater))
-        }),
+        PredicateOperator::In => {
+            if !matches!(
+                min_value.partial_cmp(&max_value),
+                Some(Ordering::Less | Ordering::Equal)
+            ) {
+                return true;
+            }
+            literals.iter().any(|literal| {
+                !matches!(literal.partial_cmp(&min_value), Some(Ordering::Less))
+                    && !matches!(literal.partial_cmp(&max_value), Some(Ordering::Greater))
+            })
+        }
         PredicateOperator::Eq => {
             !matches!(literal.partial_cmp(&min_value), Some(Ordering::Less))
                 && !matches!(literal.partial_cmp(&max_value), Some(Ordering::Greater))
@@ -528,6 +542,12 @@ mod tests {
     fn run_int(op: PredicateOperator, lits: &[Datum], stats: &MockStats) -> bool {
         let dt = DataType::Int(IntType::new());
         data_leaf_may_match(0, &dt, &dt, op, lits, stats)
+    }
+
+    #[test]
+    fn in_falls_open_when_accessor_does_not_opt_in() {
+        let stats = int_stats(10, 20);
+        assert!(run_int(PredicateOperator::In, &[Datum::Int(30)], &stats));
     }
 
     /// Stage 3 invariant: a `Between` leaf and the equivalent `GtEq+LtEq`

--- a/crates/paimon/src/table/stats_filter.rs
+++ b/crates/paimon/src/table/stats_filter.rs
@@ -32,6 +32,7 @@ pub(super) struct FileStatsRows {
     min_values: Option<BinaryRow>,
     max_values: Option<BinaryRow>,
     null_counts: Vec<Option<i64>>,
+    supports_in_min_max_pruning: bool,
     /// Maps schema field index → stats index. `None` means identity mapping
     /// (stats cover all schema fields in order). `Some` is used when
     /// `value_stats_cols` or `write_cols` is present (dense mode).
@@ -51,6 +52,7 @@ impl FileStatsRows {
             min_values,
             max_values,
             null_counts,
+            supports_in_min_max_pruning: false,
             stats_col_mapping: None,
         }
     }
@@ -92,6 +94,7 @@ impl FileStatsRows {
             min_values: BinaryRow::from_serialized_bytes(file.value_stats.min_values()).ok(),
             max_values: BinaryRow::from_serialized_bytes(file.value_stats.max_values()).ok(),
             null_counts: file.value_stats.null_counts().clone(),
+            supports_in_min_max_pruning: true,
             stats_col_mapping,
         }
     }
@@ -131,6 +134,10 @@ impl StatsAccessor for FileStatsRows {
         self.max_values
             .as_ref()
             .and_then(|row| extract_stats_datum(row, stats_index, data_type))
+    }
+
+    fn supports_in_min_max_pruning(&self) -> bool {
+        self.supports_in_min_max_pruning
     }
 }
 

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -2080,6 +2080,48 @@ mod tests {
     }
 
     #[test]
+    fn test_data_file_matches_in_with_inverted_stats_fails_open() {
+        let fields = int_field();
+        let file = test_data_file_meta(
+            int_stats_row(Some(20)),
+            int_stats_row(Some(10)),
+            vec![Some(0)],
+            5,
+        );
+        let predicate = PredicateBuilder::new(&fields)
+            .is_in("id", vec![Datum::Int(15)])
+            .unwrap();
+
+        assert!(data_file_matches_predicates(
+            &file,
+            &[predicate],
+            TEST_SCHEMA_ID,
+            &test_schema_fields(),
+        ));
+    }
+
+    #[test]
+    fn test_data_file_matches_not_in_fails_open() {
+        let fields = int_field();
+        let file = test_data_file_meta(
+            int_stats_row(Some(10)),
+            int_stats_row(Some(20)),
+            vec![Some(0)],
+            5,
+        );
+        let predicate = PredicateBuilder::new(&fields)
+            .is_not_in("id", vec![Datum::Int(10), Datum::Int(20)])
+            .unwrap();
+
+        assert!(data_file_matches_predicates(
+            &file,
+            &[predicate],
+            TEST_SCHEMA_ID,
+            &test_schema_fields(),
+        ));
+    }
+
+    #[test]
     fn test_data_file_matches_is_null_prunes_when_null_count_is_zero() {
         let fields = int_field();
         let file = test_data_file_meta(

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -2006,6 +2006,80 @@ mod tests {
     }
 
     #[test]
+    fn test_data_file_matches_in_prunes_when_all_literals_out_of_range() {
+        let fields = int_field();
+        let file = test_data_file_meta(
+            int_stats_row(Some(10)),
+            int_stats_row(Some(20)),
+            vec![Some(0)],
+            5,
+        );
+        let predicate = PredicateBuilder::new(&fields)
+            .is_in("id", vec![Datum::Int(1), Datum::Int(30)])
+            .unwrap();
+
+        assert!(!data_file_matches_predicates(
+            &file,
+            &[predicate],
+            TEST_SCHEMA_ID,
+            &test_schema_fields(),
+        ));
+    }
+
+    #[test]
+    fn test_data_file_matches_in_keeps_when_any_literal_in_range() {
+        let fields = int_field();
+        let file = test_data_file_meta(
+            int_stats_row(Some(10)),
+            int_stats_row(Some(20)),
+            vec![Some(0)],
+            5,
+        );
+        let predicate = PredicateBuilder::new(&fields)
+            .is_in("id", vec![Datum::Int(1), Datum::Int(15), Datum::Int(30)])
+            .unwrap();
+
+        assert!(data_file_matches_predicates(
+            &file,
+            &[predicate],
+            TEST_SCHEMA_ID,
+            &test_schema_fields(),
+        ));
+    }
+
+    #[test]
+    fn test_data_file_matches_in_prunes_all_null_file() {
+        let fields = int_field();
+        let file = test_data_file_meta(int_stats_row(None), int_stats_row(None), vec![Some(5)], 5);
+        let predicate = PredicateBuilder::new(&fields)
+            .is_in("id", vec![Datum::Int(10)])
+            .unwrap();
+
+        assert!(!data_file_matches_predicates(
+            &file,
+            &[predicate],
+            TEST_SCHEMA_ID,
+            &test_schema_fields(),
+        ));
+    }
+
+    #[test]
+    fn test_data_file_matches_in_with_corrupt_stats_fails_open() {
+        let fields = int_field();
+        let file = test_data_file_meta(Vec::new(), Vec::new(), vec![Some(0)], 5);
+        let predicate = PredicateBuilder::new(&fields)
+            .is_in("id", vec![Datum::Int(30)])
+            .unwrap();
+
+        assert!(data_file_matches_predicates(
+            &file,
+            &[predicate],
+            TEST_SCHEMA_ID,
+            &test_schema_fields(),
+        ));
+    }
+
+    #[test]
     fn test_data_file_matches_is_null_prunes_when_null_count_is_zero() {
         let fields = int_field();
         let file = test_data_file_meta(


### PR DESCRIPTION
## What changed

This adds file-stats pruning for non-partition `IN` predicates.

When a data file has value min/max stats, an `IN` predicate now keeps the file if at least one literal can fall inside the file range, and prunes the file only when every literal is outside `[min, max]`.

The pruning is deliberately scoped to data-file stats. Other stats consumers, such as partition manifest stats and reader-side row-group/page stats, continue to fail open for `IN` unless they explicitly opt in.

Conservative behavior is preserved:

- `NOT IN` still fails open.
- Missing, undecodable, inverted, or incomparable stats fail open.
- All-null data files are pruned for `IN`, matching normal comparison semantics.

## Why

Before this change, non-partition `IN` predicates skipped stats pruning completely. That could keep files whose min/max metadata already proves they cannot match, leading to unnecessary scan planning work and extra files/splits.

## Related issue

Fixes #385.

#381 already added the scan trace counters and pruning baselines from that issue; this PR completes the remaining non-partition `IN` stats-pruning part.

## Validation

- `cargo test -p paimon test_data_file_matches_in --lib`
- `cargo test -p paimon test_data_file_matches_not_in_fails_open --lib`
- `cargo test -p paimon predicate_stats::tests --lib`
- `cargo clippy -p paimon --lib --all-targets -- -D warnings`
- `cargo test -p paimon --lib`
- `cargo test -p paimon-datafusion --test scan_pruning_trace -- --nocapture`

Manual trace check for `id IN (15)` over three files with stats ranges `[1, 2]`, `[10, 20]`, and `[100, 101]`:

- `manifest_entries_read = 3`
- `manifest_entries_pruned_by_data_stats = 2`
- `manifest_entries_after_manifest_filters = 1`
- `final_files = 1`
