### PR TITLE
feat(spec): implement Display for DataFileMeta

### DIFF
--- a/crates/paimon/src/spec/data_file.rs
+++ b/crates/paimon/src/spec/data_file.rs
@@ -109,8 +109,35 @@ pub struct DataFileMeta {
 }
 
 impl Display for DataFileMeta {
-    fn fmt(&self, _: &mut Formatter<'_>) -> std::fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "DataFileMeta{{fileName={}, fileSize={}, rowCount={}, embeddedIndex={:?}, \
+             minKey={:?}, maxKey={:?}, keyStats={:?}, valueStats={:?}, \
+             minSequenceNumber={}, maxSequenceNumber={}, schemaId={}, level={}, \
+             extraFiles={:?}, creationTime={:?}, deleteRowCount={:?}, fileSource={:?}, \
+             valueStatsCols={:?}, externalPath={:?}, firstRowId={:?}, writeCols={:?}}}",
+            self.file_name,
+            self.file_size,
+            self.row_count,
+            self.embedded_index,
+            self.min_key,
+            self.max_key,
+            self.key_stats,
+            self.value_stats,
+            self.min_sequence_number,
+            self.max_sequence_number,
+            self.schema_id,
+            self.level,
+            self.extra_files,
+            self.creation_time,
+            self.delete_row_count,
+            self.file_source,
+            self.value_stats_cols,
+            self.external_path,
+            self.first_row_id,
+            self.write_cols,
+        )
     }
 }
 
@@ -118,5 +145,66 @@ impl DataFileMeta {
     /// Returns the row ID range `[first_row_id, first_row_id + row_count - 1]` if `first_row_id` is set.
     pub fn row_id_range(&self) -> Option<(i64, i64)> {
         self.first_row_id.map(|fid| (fid, fid + self.row_count - 1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_includes_all_data_file_meta_fields() {
+        let stats = BinaryTableStats::empty();
+        let file = DataFileMeta {
+            file_name: "data-1.parquet".to_string(),
+            file_size: 42,
+            row_count: 7,
+            min_key: vec![1],
+            max_key: vec![9],
+            key_stats: stats.clone(),
+            value_stats: stats,
+            min_sequence_number: 3,
+            max_sequence_number: 5,
+            schema_id: 11,
+            level: 2,
+            extra_files: vec!["extra-1".to_string()],
+            creation_time: DateTime::from_timestamp_millis(1_234),
+            delete_row_count: Some(1),
+            embedded_index: Some(vec![4, 5]),
+            file_source: Some(6),
+            value_stats_cols: Some(vec!["v".to_string()]),
+            external_path: Some("s3://bucket/data-1.parquet".to_string()),
+            first_row_id: Some(100),
+            write_cols: Some(vec!["k".to_string(), "v".to_string()]),
+        };
+
+        let display = file.to_string();
+        for expected in [
+            "DataFileMeta{fileName=data-1.parquet",
+            "fileSize=42",
+            "rowCount=7",
+            "embeddedIndex=Some([4, 5])",
+            "minKey=[1]",
+            "maxKey=[9]",
+            "keyStats=BinaryTableStats",
+            "valueStats=BinaryTableStats",
+            "minSequenceNumber=3",
+            "maxSequenceNumber=5",
+            "schemaId=11",
+            "level=2",
+            "extraFiles=[\"extra-1\"]",
+            "creationTime=Some(1970-01-01T00:00:01.234Z)",
+            "deleteRowCount=Some(1)",
+            "fileSource=Some(6)",
+            "valueStatsCols=Some([\"v\"])",
+            "externalPath=Some(\"s3://bucket/data-1.parquet\")",
+            "firstRowId=Some(100)",
+            "writeCols=Some([\"k\", \"v\"])",
+        ] {
+            assert!(
+                display.contains(expected),
+                "Display output missing `{expected}`: {display}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## What changed

Implemented `Display` for `DataFileMeta` and added a focused unit test covering all fields currently present on the Rust struct.

## Why

`DataFileMeta` previously used `todo!()` in its `Display` implementation, so formatting it would panic at runtime.

## CI fix

The first CI run failed because the test asserted the complete `BinaryTableStats::empty()` debug string. Under CI full-feature builds, empty row bytes are represented with a different length than the local default build. The test now checks the displayed field fragments instead of internal serialized byte details.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p paimon display_includes_all_data_file_meta_fields --features fulltext,vortex,mosaic`