### PR TITLE
fix: preserve snapshot properties

### DIFF
--- a/crates/paimon/src/spec/snapshot.rs
+++ b/crates/paimon/src/spec/snapshot.rs
@@ -103,6 +103,10 @@ pub struct Snapshot {
     #[builder(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
     statistics: Option<String>,
+    /// user-facing properties of this snapshot
+    #[builder(default = None)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    properties: Option<HashMap<String, String>>,
     /// next row id for row tracking
     #[builder(default = None)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -206,6 +210,12 @@ impl Snapshot {
         self.statistics.as_deref()
     }
 
+    /// Get the properties of this snapshot.
+    #[inline]
+    pub fn properties(&self) -> Option<&HashMap<String, String>> {
+        self.properties.as_ref()
+    }
+
     /// Get the next row id of this snapshot.
     #[inline]
     pub fn next_row_id(&self) -> Option<i64> {
@@ -261,6 +271,10 @@ mod tests {
                     .delta_record_count(Some(2))
                     .changelog_record_count(Some(2))
                     .statistics(Some("statistics_string".to_string()))
+                    .properties(Some(HashMap::from([(
+                        "scan.snapshot-id".to_string(),
+                        "2".to_string(),
+                    )])))
                     .build(),
             ),
             (

--- a/crates/paimon/tests/fixtures/snapshot/snapshot-v3.json
+++ b/crates/paimon/tests/fixtures/snapshot/snapshot-v3.json
@@ -13,5 +13,8 @@
   "totalRecordCount": 4,
   "deltaRecordCount": 2,
   "changelogRecordCount": 2,
-  "statistics": "statistics_string"
+  "statistics": "statistics_string",
+  "properties": {
+    "scan.snapshot-id": "2"
+  }
 }


### PR DESCRIPTION
## Summary
- Preserve the Java snapshot `properties` map in Rust snapshot metadata.
- Add fixture coverage for deserializing and round-tripping non-empty properties.

## Tests
- `cargo fmt --check`
- `cargo test -p paimon spec::snapshot::tests::test_snapshot_serialization_deserialization`
- `git diff --check`