### PR TITLE
fix(vortex): avoid footer read deadlock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ edition = "2021"
 homepage = "https://paimon.apache.org/docs/rust/"
 repository = "https://github.com/apache/paimon-rust"
 license = "Apache-2.0"
-rust-version = "1.86.0"
+rust-version = "1.91.0"
 
 [workspace.dependencies]
 arrow = "58.0"
@@ -40,6 +40,6 @@ datafusion = "53.0.0"
 datafusion-ffi = "53.0.0"
 paimon = { version = "0.3.0", path = "crates/paimon" }
 parquet = "58.0"
-constant_time_eq = ">=0.4.0, <0.5.1"
+constant_time_eq = ">=0.4.0, <0.5.0"
 tokio = "1.39.2"
 tokio-util = "0.7"

--- a/crates/paimon/Cargo.toml
+++ b/crates/paimon/Cargo.toml
@@ -104,7 +104,7 @@ tantivy = { version = "0.22", optional = true }
 tempfile = { version = "3", optional = true }
 paimon-mosaic-core = { version = "0.1.0", optional = true }
 paimon-vindex-core = "0.1.0"
-vortex = { version = "0.68", features = ["tokio"], optional = true }
+vortex = { version = "0.75.0", features = ["tokio"], optional = true }
 libloading = "0.9"
 # Keep CI on the dependency set that passed before unicode-segmentation 1.13.3.
 # The 1.13.3 resolver update correlates with Linux Vortex tests hanging.

--- a/crates/paimon/src/arrow/format/vortex.rs
+++ b/crates/paimon/src/arrow/format/vortex.rs
@@ -30,14 +30,14 @@ use arrow_ord::cmp::{
     eq as arrow_eq, gt as arrow_gt, gt_eq as arrow_gt_eq, lt as arrow_lt, lt_eq as arrow_lt_eq,
     neq as arrow_neq,
 };
-use arrow_schema::{ArrowError, DataType as ArrowDataType, SchemaRef};
+use arrow_schema::{ArrowError, DataType as ArrowDataType, Field, SchemaRef};
 use async_trait::async_trait;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
-use vortex::array::arrow::{FromArrowArray, IntoArrowArray};
+use vortex::array::arrow::{ArrowSessionExt, FromArrowArray};
 use vortex::array::dtype::arrow::FromArrowType;
 use vortex::array::dtype::DType;
-use vortex::array::ArrayRef;
+use vortex::array::{ArrayRef, VortexSessionExecute};
 use vortex::buffer::ByteBuffer;
 use vortex::file::{OpenOptionsSessionExt, WriteOptionsSessionExt};
 use vortex::io::runtime::current::CurrentThreadRuntime;
@@ -225,7 +225,7 @@ fn read_vortex_batches(
         else {
             continue;
         };
-        let batch = vortex_array_to_record_batch(vortex_array, &scan_schema)?;
+        let batch = vortex_array_to_record_batch(&session, vortex_array, &scan_schema)?;
         batches.push(filter_and_project_batch(
             batch,
             &target_schema,
@@ -840,11 +840,19 @@ fn row_ranges_to_selection(ranges: &[RowRange], total_rows: u64) -> Selection {
 
 /// Convert a Vortex ArrayRef to an Arrow RecordBatch.
 fn vortex_array_to_record_batch(
+    session: &VortexSession,
     vortex_array: ArrayRef,
     schema: &SchemaRef,
 ) -> crate::Result<RecordBatch> {
-    let arrow_array = vortex_array
-        .into_arrow(&ArrowDataType::Struct(schema.fields().clone()))
+    let target_field = Field::new(
+        "",
+        ArrowDataType::Struct(schema.fields().clone()),
+        vortex_array.dtype().is_nullable(),
+    );
+    let mut ctx = session.create_execution_ctx();
+    let arrow_array = session
+        .arrow()
+        .execute_arrow(vortex_array, Some(&target_field), &mut ctx)
         .map_err(|e| Error::DataInvalid {
             message: format!("Failed to convert Vortex array to Arrow: {e}"),
             source: None,


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

Vortex 0.68 can hang while decoding file footers because `session.layouts().registry()` keeps a session borrow alive while `session.allows_unknown()` may lazily insert default session state. That can require a write lock on the same session map and deadlock.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - Upgrade Vortex from 0.68 to 0.75.0, where `allows_unknown()` no longer lazily writes session state.
  - Adapt Vortex-to-Arrow conversion to the Vortex session execution API.
  - Keep `constant_time_eq` below 0.5.0 so fresh dependency resolution remains compatible with Rust 1.91.

### Tests

<!-- List unit tests or integration cases to verify this change -->

  - `RUSTUP_TOOLCHAIN=1.91.0 cargo fmt --all -- --check`
  - `git diff --check`
  - `RUSTUP_TOOLCHAIN=1.91.0 cargo clippy --all-targets --workspace --features fulltext,vortex,mosaic -- -D warnings`
  - `RUSTUP_TOOLCHAIN=1.91.0 cargo build --features fulltext,vortex,mosaic`
  - `RUSTUP_TOOLCHAIN=1.91.0 cargo test -p paimon --all-targets --features fulltext,vortex,mosaic`
  - `timeout 120s taskset -c 0 env RUSTUP_TOOLCHAIN=1.91.0 cargo test -p paimon-datafusion --features vortex --test vortex_tables -- --nocapture`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
