### PR TITLE
fix: handle DataType::Vector in row.rs exhaustive match arms

### DIFF
--- a/crates/paimon/src/arrow/format/row.rs
+++ b/crates/paimon/src/arrow/format/row.rs
@@ -538,6 +538,9 @@ fn validate_supported_type(data_type: &DataType) -> crate::Result<()> {
             }
             Ok(())
         }
+        DataType::Vector(_) => Err(Error::Unsupported {
+            message: "VectorType is not supported in the .row format".to_string(),
+        }),
     }
 }
 
@@ -699,6 +702,11 @@ fn write_field_value(
         DataType::Row(r) => {
             let row = downcast::<StructArray>(array, data_type)?;
             write_struct_row(out, row, row_idx, r.fields())?;
+        }
+        DataType::Vector(_) => {
+            return Err(Error::Unsupported {
+                message: "VectorType is not supported in .row field serialization".to_string(),
+            });
         }
     }
     Ok(())
@@ -1208,6 +1216,11 @@ impl ColumnBuilder {
                 validities: Vec::with_capacity(capacity),
                 len: 0,
             },
+            DataType::Vector(_) => {
+                return Err(Error::Unsupported {
+                    message: "VectorType is not supported in .row ColumnBuilder".to_string(),
+                });
+            }
         })
     }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/paimon-rust/issues/417

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

 - Added  `DataType::Vector(_) => Err(Error::Unsupported)` arm to 3 non-exhaustive match blocks in  crates/paimon/src/arrow/format/row.rs
 - Consistent with how other files ( arrow/mod.rs ,  parquet.rs ,  vortex.rs ) already handle the same variant.

### Tests

<!-- List unit tests or integration cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
