### PR TITLE
fix(scan): prune OR predicates using stats

### DIFF
--- a/crates/integration_tests/tests/read_tables.rs
+++ b/crates/integration_tests/tests/read_tables.rs
@@ -752,7 +752,7 @@ async fn test_read_multi_partitioned_table_or_of_mixed_ands_prunes_partitions() 
         Predicate::and(vec![
             pb.equal("dt", Datum::String("2024-01-01".into())).unwrap(),
             pb.equal("hr", Datum::Int(10)).unwrap(),
-            pb.greater_than("id", Datum::Int(10)).unwrap(),
+            pb.greater_than("id", Datum::Int(0)).unwrap(),
         ]),
         Predicate::and(vec![
             pb.equal("dt", Datum::String("2024-01-01".into())).unwrap(),
@@ -780,8 +780,9 @@ async fn test_read_multi_partitioned_table_or_of_mixed_ands_prunes_partitions() 
     );
 }
 
-/// A directly mixed OR like `dt = '...' OR id > 10` is still not safely
-/// splittable into a partition predicate, so no partitions should be pruned.
+/// A directly mixed OR like `dt = '...' OR id > 0` is still not safely
+/// splittable into a partition predicate. The data predicate branch may match
+/// all provisioned files, so this isolates partition projection behavior.
 #[tokio::test]
 async fn test_read_partitioned_table_mixed_or_filter_preserves_all() {
     use paimon::spec::{Datum, Predicate, PredicateBuilder};
@@ -793,7 +794,7 @@ async fn test_read_partitioned_table_mixed_or_filter_preserves_all() {
 
     let filter = Predicate::or(vec![
         pb.equal("dt", Datum::String("2024-01-01".into())).unwrap(),
-        pb.greater_than("id", Datum::Int(10)).unwrap(),
+        pb.greater_than("id", Datum::Int(0)).unwrap(),
     ]);
 
     let (plan, batches) = scan_and_read_with_filter(&table, filter).await;

--- a/crates/paimon/src/predicate_stats.rs
+++ b/crates/paimon/src/predicate_stats.rs
@@ -139,7 +139,10 @@ fn predicate_may_match_with_schema<T: StatsAccessor>(
         Predicate::And(children) => children
             .iter()
             .all(|child| predicate_may_match_with_schema(child, stats, field_mapping, file_fields)),
-        Predicate::Or(_) | Predicate::Not(_) => true,
+        Predicate::Or(children) => children
+            .iter()
+            .any(|child| predicate_may_match_with_schema(child, stats, field_mapping, file_fields)),
+        Predicate::Not(_) => true,
         Predicate::Leaf {
             index,
             data_type,

--- a/crates/paimon/src/table/stats_filter.rs
+++ b/crates/paimon/src/table/stats_filter.rs
@@ -375,7 +375,16 @@ fn data_evolution_predicate_may_match(
                 row_count,
             )
         }),
-        Predicate::Or(_) | Predicate::Not(_) => true,
+        Predicate::Or(children) => children.iter().any(|child| {
+            data_evolution_predicate_may_match(
+                child,
+                table_fields,
+                field_sources,
+                file_stats,
+                row_count,
+            )
+        }),
+        Predicate::Not(_) => true,
         Predicate::Leaf {
             index,
             data_type,

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -843,7 +843,10 @@ mod tests {
     use crate::table::bucket_filter::{compute_target_buckets, extract_predicate_for_keys};
     use crate::table::partition_filter::PartitionFilter;
     use crate::table::source::{DataSplit, DataSplitBuilder, DeletionFile};
-    use crate::table::stats_filter::{data_file_matches_predicates, group_by_overlapping_row_id};
+    use crate::table::stats_filter::{
+        data_evolution_group_matches_predicates, data_file_matches_predicates,
+        group_by_overlapping_row_id,
+    };
     use crate::table::Table;
     use crate::Error;
     use chrono::{DateTime, Utc};
@@ -1327,7 +1330,7 @@ mod tests {
     }
 
     #[test]
-    fn test_data_file_matches_unsupported_predicate_fails_open() {
+    fn test_data_file_matches_or_prunes_when_no_child_matches() {
         let fields = int_field();
         let file = test_data_file_meta(
             int_stats_row(Some(10)),
@@ -1341,11 +1344,101 @@ mod tests {
             pb.greater_than("id", Datum::Int(25)).unwrap(),
         ]);
 
+        assert!(!data_file_matches_predicates(
+            &file,
+            &[predicate],
+            TEST_SCHEMA_ID,
+            &test_schema_fields(),
+        ));
+    }
+
+    #[test]
+    fn test_data_file_matches_or_keeps_when_any_child_matches() {
+        let fields = int_field();
+        let file = test_data_file_meta(
+            int_stats_row(Some(10)),
+            int_stats_row(Some(20)),
+            vec![Some(0)],
+            5,
+        );
+        let pb = PredicateBuilder::new(&fields);
+        let predicate = Predicate::or(vec![
+            pb.less_than("id", Datum::Int(15)).unwrap(),
+            pb.greater_than("id", Datum::Int(25)).unwrap(),
+        ]);
+
         assert!(data_file_matches_predicates(
             &file,
             &[predicate],
             TEST_SCHEMA_ID,
             &test_schema_fields(),
+        ));
+    }
+
+    #[test]
+    fn test_data_file_matches_not_fails_open() {
+        let fields = int_field();
+        let file = test_data_file_meta(
+            int_stats_row(Some(10)),
+            int_stats_row(Some(20)),
+            vec![Some(0)],
+            5,
+        );
+        let predicate = Predicate::negate(
+            PredicateBuilder::new(&fields)
+                .less_than("id", Datum::Int(5))
+                .unwrap(),
+        );
+
+        assert!(data_file_matches_predicates(
+            &file,
+            &[predicate],
+            TEST_SCHEMA_ID,
+            &test_schema_fields(),
+        ));
+    }
+
+    #[test]
+    fn test_data_evolution_group_matches_or_prunes_when_no_child_matches() {
+        let fields = int_field();
+        let file = test_data_file_meta(
+            int_stats_row(Some(10)),
+            int_stats_row(Some(20)),
+            vec![Some(0)],
+            5,
+        );
+        let pb = PredicateBuilder::new(&fields);
+        let predicate = Predicate::or(vec![
+            pb.less_than("id", Datum::Int(5)).unwrap(),
+            pb.greater_than("id", Datum::Int(25)).unwrap(),
+        ]);
+
+        assert!(!data_evolution_group_matches_predicates(
+            &[file],
+            &[predicate],
+            &fields,
+        ));
+    }
+
+    #[test]
+    fn test_data_evolution_group_matches_or_keeps_when_any_child_matches() {
+        let fields = int_field();
+        let file = test_data_file_meta(
+            int_stats_row(Some(10)),
+            int_stats_row(Some(20)),
+            vec![Some(0)],
+            5,
+        );
+        let pb = PredicateBuilder::new(&fields);
+        let predicate = Predicate::or(vec![
+            pb.less_than("id", Datum::Int(15)).unwrap(),
+            pb.greater_than("id", Datum::Int(25)).unwrap(),
+        ]);
+
+        assert!(data_evolution_group_matches_predicates(
+            &[file],
+            &[predicate],
+            &fields,
         ));
     }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

Data stats pruning currently treats `Predicate::Or` as unsupported and fails open. This means predicates like `id < 5 OR id > 25` cannot prune files whose stats range is `[10, 20]`, even though no branch can match.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - Evaluate `Predicate::Or` in the shared stats may-match evaluator with `any(child may match)`.
  - Apply the same OR semantics to data-evolution group stats pruning.
  - Keep `Predicate::Not` fail-open.
  - Add regression tests for OR prune/keep behavior and NOT fail-open behavior.

### Tests

<!-- List unit tests or integration cases to verify this change -->

  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --workspace --features fulltext,vortex,mosaic -- -D warnings`
  - `cargo test -p paimon --all-targets --features fulltext,vortex,mosaic`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
