### PR TITLE
[table] Accept VECTOR<FLOAT> in Lumina index build

### DIFF
--- a/crates/paimon/src/lumina/mod.rs
+++ b/crates/paimon/src/lumina/mod.rs
@@ -227,6 +227,9 @@ pub const KEY_DIMENSION: &str = "index.dimension";
 pub const KEY_DISTANCE_METRIC: &str = "distance.metric";
 pub const KEY_INDEX_TYPE: &str = "index.type";
 
+/// Paimon-prefixed option key for the vector index dimension.
+pub const LUMINA_DIMENSION_OPTION: &str = "lumina.index.dimension";
+
 pub struct LuminaIndexMeta {
     options: HashMap<String, String>,
 }

--- a/crates/paimon/src/table/lumina_index_build_builder.rs
+++ b/crates/paimon/src/table/lumina_index_build_builder.rs
@@ -289,13 +289,18 @@ fn find_index_field<'a>(table: &'a Table, column: &str) -> Result<&'a DataField>
 }
 
 fn validate_vector_field(field: &DataField) -> Result<()> {
-    if !matches!(
+    let is_array_float = matches!(
         field.data_type(),
         DataType::Array(array) if matches!(array.element_type(), DataType::Float(_))
-    ) {
+    );
+    let is_vector_float = matches!(
+        field.data_type(),
+        DataType::Vector(vector) if matches!(vector.element_type(), DataType::Float(_))
+    );
+    if !is_array_float && !is_vector_float {
         return Err(Error::DataInvalid {
             message: format!(
-                "Lumina index requires ARRAY<FLOAT> column, got {:?} for column '{}'",
+                "Lumina index requires ARRAY<FLOAT> or VECTOR<FLOAT> column, got {:?} for column '{}'",
                 field.data_type(),
                 field.name()
             ),
@@ -820,7 +825,9 @@ mod tests {
     use crate::io::FileIO;
     use crate::io::FileIOBuilder;
     use crate::spec::stats::BinaryTableStats;
-    use crate::spec::{ArrayType, FloatType, IntType, ManifestEntry, Schema, TableSchema};
+    use crate::spec::{
+        ArrayType, DoubleType, FloatType, IntType, ManifestEntry, Schema, TableSchema, VectorType,
+    };
     use crate::table::TableWrite;
     use arrow_array::builder::{Float32Builder, Int64Builder, ListBuilder};
     use arrow_array::{ArrayRef, Int32Array};
@@ -1037,6 +1044,37 @@ mod tests {
         assert!(
             matches!(err, Error::DataInvalid { message, .. } if message.contains("row-count-per-shard"))
         );
+    }
+
+    #[test]
+    fn test_validate_vector_field_accepts_array_float() {
+        let field = DataField::new(
+            0,
+            "embedding".to_string(),
+            DataType::Array(ArrayType::new(DataType::Float(FloatType::new()))),
+        );
+        assert!(validate_vector_field(&field).is_ok());
+    }
+
+    #[test]
+    fn test_validate_vector_field_accepts_vector_float() {
+        let field = DataField::new(
+            0,
+            "embedding".to_string(),
+            DataType::Vector(VectorType::try_new(true, 4, DataType::Float(FloatType::new())).unwrap()),
+        );
+        assert!(validate_vector_field(&field).is_ok());
+    }
+
+    #[test]
+    fn test_validate_vector_field_rejects_vector_double() {
+        let field = DataField::new(
+            0,
+            "embedding".to_string(),
+            DataType::Vector(VectorType::try_new(true, 4, DataType::Double(DoubleType::new())).unwrap()),
+        );
+        let err = validate_vector_field(&field).expect_err("VECTOR<DOUBLE> must be rejected");
+        assert!(matches!(err, Error::DataInvalid { .. }));
     }
 
     #[tokio::test]

--- a/crates/paimon/src/table/lumina_index_build_builder.rs
+++ b/crates/paimon/src/table/lumina_index_build_builder.rs
@@ -610,22 +610,37 @@ fn extract_vectors_from_batches(
                     message: format!("_ROW_ID column not found in read batch: {e}"),
                     source: None,
                 })?;
-        let vectors_array = batch
-            .column(vector_index)
+        // Resolve the vector column as either List<Float32> (ARRAY<FLOAT>) or
+        // FixedSizeList<Float32> (VECTOR<FLOAT>). Both yield a Float32Array of
+        // values plus a per-row [start, end) slice.
+        let column = batch.column(vector_index);
+        enum VectorLayout<'a> {
+            List(&'a ListArray),
+            Fixed(&'a arrow_array::FixedSizeListArray),
+        }
+        let layout = if let Some(a) = column.as_any().downcast_ref::<ListArray>() {
+            VectorLayout::List(a)
+        } else if let Some(a) = column
             .as_any()
-            .downcast_ref::<ListArray>()
-            .ok_or_else(|| Error::DataInvalid {
-                message: "Lumina vector extraction requires Arrow List<Float32>".to_string(),
+            .downcast_ref::<arrow_array::FixedSizeListArray>()
+        {
+            VectorLayout::Fixed(a)
+        } else {
+            return Err(Error::DataInvalid {
+                message: "Lumina vector extraction requires Arrow List<Float32> or FixedSizeList<Float32>".to_string(),
                 source: None,
-            })?;
-        let values = vectors_array
-            .values()
-            .as_any()
-            .downcast_ref::<Float32Array>()
-            .ok_or_else(|| Error::DataInvalid {
-                message: "Lumina vector extraction requires Arrow List<Float32>".to_string(),
-                source: None,
-            })?;
+            });
+        };
+        let values = match layout {
+            VectorLayout::List(a) => a.values(),
+            VectorLayout::Fixed(a) => a.values(),
+        }
+        .as_any()
+        .downcast_ref::<Float32Array>()
+        .ok_or_else(|| Error::DataInvalid {
+            message: "Lumina vector extraction requires Float32 vector elements".to_string(),
+            source: None,
+        })?;
         let row_ids = batch
             .column(row_id_index)
             .as_any()
@@ -654,15 +669,26 @@ fn extract_vectors_from_batches(
             }
             expected_row_id += 1;
 
-            if vectors_array.is_null(row) {
+            let is_null = match layout {
+                VectorLayout::List(a) => a.is_null(row),
+                VectorLayout::Fixed(a) => a.is_null(row),
+            };
+            if is_null {
                 return Err(Error::DataInvalid {
                     message: "Lumina vector extraction found null vector row".to_string(),
                     source: None,
                 });
             }
-            let value_offsets = vectors_array.value_offsets();
-            let start = value_offsets[row] as usize;
-            let end = value_offsets[row + 1] as usize;
+            let (start, end) = match layout {
+                VectorLayout::List(a) => {
+                    let offsets = a.value_offsets();
+                    (offsets[row] as usize, offsets[row + 1] as usize)
+                }
+                VectorLayout::Fixed(a) => {
+                    let len = a.value_length() as usize;
+                    (row * len, (row + 1) * len)
+                }
+            };
             if end - start != dimension {
                 return Err(Error::DataInvalid {
                     message: format!(
@@ -829,7 +855,9 @@ mod tests {
         ArrayType, DoubleType, FloatType, IntType, ManifestEntry, Schema, TableSchema, VectorType,
     };
     use crate::table::TableWrite;
-    use arrow_array::builder::{Float32Builder, Int64Builder, ListBuilder};
+    use arrow_array::builder::{
+        FixedSizeListBuilder, Float32Builder, Int64Builder, ListBuilder,
+    };
     use arrow_array::{ArrayRef, Int32Array};
     use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
     use chrono::{DateTime, Utc};
@@ -1251,6 +1279,86 @@ mod tests {
         assert!(
             matches!(err, Error::DataInvalid { message, .. } if message.contains("List<Float32>"))
         );
+    }
+
+    fn fixed_size_vector_batch(
+        rows: Vec<Option<Vec<f32>>>,
+        row_ids: Vec<Option<i64>>,
+        len: i32,
+    ) -> RecordBatch {
+        let element_field = Arc::new(ArrowField::new("element", ArrowDataType::Float32, true));
+        let mut builder =
+            FixedSizeListBuilder::new(Float32Builder::new(), len).with_field(element_field);
+        for row in rows {
+            match row {
+                Some(values) => {
+                    for v in values {
+                        builder.values().append_value(v);
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    for _ in 0..len {
+                        builder.values().append_value(0.0);
+                    }
+                    builder.append(false);
+                }
+            }
+        }
+        let mut row_id_builder = Int64Builder::new();
+        for row_id in row_ids {
+            match row_id {
+                Some(value) => row_id_builder.append_value(value),
+                None => row_id_builder.append_null(),
+            }
+        }
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(
+                "embedding",
+                ArrowDataType::FixedSizeList(
+                    Arc::new(ArrowField::new("element", ArrowDataType::Float32, true)),
+                    len,
+                ),
+                true,
+            ),
+            ArrowField::new(ROW_ID_FIELD_NAME, ArrowDataType::Int64, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(builder.finish()) as ArrayRef,
+                Arc::new(row_id_builder.finish()) as ArrayRef,
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_extract_vectors_accepts_fixed_size_list_float32() {
+        let batch = fixed_size_vector_batch(
+            vec![Some(vec![1.0, 2.0]), Some(vec![3.0, 4.0])],
+            vec![Some(10), Some(11)],
+            2,
+        );
+        let vectors = extract_vectors_from_batches(&[batch], "embedding", 2, 10, 2).unwrap();
+        assert_eq!(vectors, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn test_extract_vectors_fixed_size_list_rejects_null_vector() {
+        let batch = fixed_size_vector_batch(vec![None], vec![Some(0)], 2);
+        let err = extract_vectors_from_batches(&[batch], "embedding", 2, 0, 1)
+            .expect_err("null vector should fail");
+        assert!(matches!(err, Error::DataInvalid { message, .. } if message.contains("null vector")));
+    }
+
+    #[test]
+    fn test_extract_vectors_fixed_size_list_dimension_mismatch() {
+        // Column is FixedSizeList of length 3, but caller expects dimension 2.
+        let batch = fixed_size_vector_batch(vec![Some(vec![1.0, 2.0, 3.0])], vec![Some(0)], 3);
+        let err = extract_vectors_from_batches(&[batch], "embedding", 2, 0, 1)
+            .expect_err("dimension mismatch should fail");
+        assert!(matches!(err, Error::DataInvalid { message, .. } if message.contains("dimension mismatch")));
     }
 
     #[test]

--- a/crates/paimon/src/table/lumina_index_build_builder.rs
+++ b/crates/paimon/src/table/lumina_index_build_builder.rs
@@ -94,6 +94,7 @@ impl<'a> LuminaIndexBuildBuilder<'a> {
 
         let resolved_options =
             resolve_lumina_options(self.table.schema().options(), &self.options)?;
+        let resolved_options = effective_lumina_options(index_field, resolved_options)?;
         let lumina_options = LuminaVectorIndexOptions::new(&resolved_options)?;
         let dimension = lumina_options.dimension;
         let index_meta = LuminaIndexMeta::new(lumina_options.to_lumina_options()).serialize()?;
@@ -308,6 +309,41 @@ fn validate_vector_field(field: &DataField) -> Result<()> {
         });
     }
     Ok(())
+}
+
+/// For a `VECTOR<FLOAT, N>` column, ensure the effective Lumina options carry
+/// `lumina.index.dimension = N`, so the native options and serialized index
+/// metadata match the column type. Absent → inject N; present-and-equal → keep;
+/// present-and-different → ConfigInvalid. Non-vector columns (e.g. ARRAY<FLOAT>)
+/// are returned unchanged so the existing option/default behavior is preserved.
+fn effective_lumina_options(
+    field: &DataField,
+    mut resolved: HashMap<String, String>,
+) -> Result<HashMap<String, String>> {
+    let DataType::Vector(vector) = field.data_type() else {
+        return Ok(resolved);
+    };
+    let n = vector.length().to_string();
+    match resolved.get(crate::lumina::LUMINA_DIMENSION_OPTION) {
+        None => {
+            resolved.insert(crate::lumina::LUMINA_DIMENSION_OPTION.to_string(), n);
+        }
+        Some(existing) if *existing == n => {}
+        Some(existing) => {
+            return Err(Error::ConfigInvalid {
+                message: format!(
+                    "Vector column '{}' has dimension {} from its type, but '{}' is set to '{}'. \
+                     Remove the option or set it to {}.",
+                    field.name(),
+                    n,
+                    crate::lumina::LUMINA_DIMENSION_OPTION,
+                    existing,
+                    n
+                ),
+            });
+        }
+    }
+    Ok(resolved)
 }
 
 fn resolve_lumina_options(
@@ -850,6 +886,7 @@ mod tests {
     use crate::catalog::Identifier;
     use crate::io::FileIO;
     use crate::io::FileIOBuilder;
+    use crate::lumina::LUMINA_DIMENSION_OPTION;
     use crate::spec::stats::BinaryTableStats;
     use crate::spec::{
         ArrayType, DoubleType, FloatType, IntType, ManifestEntry, Schema, TableSchema, VectorType,
@@ -1103,6 +1140,54 @@ mod tests {
         );
         let err = validate_vector_field(&field).expect_err("VECTOR<DOUBLE> must be rejected");
         assert!(matches!(err, Error::DataInvalid { .. }));
+    }
+
+    #[test]
+    fn test_effective_options_vector_absent_inserts_length() {
+        let field = DataField::new(
+            0,
+            "embedding".to_string(),
+            DataType::Vector(VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap()),
+        );
+        let opts = effective_lumina_options(&field, HashMap::new()).unwrap();
+        assert_eq!(opts.get(LUMINA_DIMENSION_OPTION).map(String::as_str), Some("256"));
+    }
+
+    #[test]
+    fn test_effective_options_vector_matching_option_ok() {
+        let field = DataField::new(
+            0,
+            "embedding".to_string(),
+            DataType::Vector(VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap()),
+        );
+        let resolved = HashMap::from([(LUMINA_DIMENSION_OPTION.to_string(), "256".to_string())]);
+        let opts = effective_lumina_options(&field, resolved).unwrap();
+        assert_eq!(opts.get(LUMINA_DIMENSION_OPTION).map(String::as_str), Some("256"));
+    }
+
+    #[test]
+    fn test_effective_options_vector_mismatch_errors() {
+        let field = DataField::new(
+            0,
+            "embedding".to_string(),
+            DataType::Vector(VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap()),
+        );
+        let resolved = HashMap::from([(LUMINA_DIMENSION_OPTION.to_string(), "128".to_string())]);
+        let err = effective_lumina_options(&field, resolved)
+            .expect_err("dimension mismatch must error");
+        assert!(matches!(err, Error::ConfigInvalid { .. }));
+    }
+
+    #[test]
+    fn test_effective_options_array_unchanged() {
+        let field = DataField::new(
+            0,
+            "embedding".to_string(),
+            DataType::Array(ArrayType::new(DataType::Float(FloatType::new()))),
+        );
+        // No dimension option set: array path must NOT inject one.
+        let opts = effective_lumina_options(&field, HashMap::new()).unwrap();
+        assert!(opts.get(LUMINA_DIMENSION_OPTION).is_none());
     }
 
     #[tokio::test]

--- a/crates/paimon/src/table/lumina_index_build_builder.rs
+++ b/crates/paimon/src/table/lumina_index_build_builder.rs
@@ -27,7 +27,7 @@ use crate::table::{
     CommitMessage, DataSplitBuilder, RowRange, SnapshotManager, Table, TableCommit,
 };
 use crate::{Error, Result};
-use arrow_array::{Array, Float32Array, Int64Array, ListArray, RecordBatch};
+use arrow_array::{Array, FixedSizeListArray, Float32Array, Int64Array, ListArray, RecordBatch};
 use bytes::Bytes;
 use futures::TryStreamExt;
 use std::collections::HashMap;
@@ -652,14 +652,11 @@ fn extract_vectors_from_batches(
         let column = batch.column(vector_index);
         enum VectorLayout<'a> {
             List(&'a ListArray),
-            Fixed(&'a arrow_array::FixedSizeListArray),
+            Fixed(&'a FixedSizeListArray),
         }
         let layout = if let Some(a) = column.as_any().downcast_ref::<ListArray>() {
             VectorLayout::List(a)
-        } else if let Some(a) = column
-            .as_any()
-            .downcast_ref::<arrow_array::FixedSizeListArray>()
-        {
+        } else if let Some(a) = column.as_any().downcast_ref::<FixedSizeListArray>() {
             VectorLayout::Fixed(a)
         } else {
             return Err(Error::DataInvalid {
@@ -892,9 +889,7 @@ mod tests {
         ArrayType, DoubleType, FloatType, IntType, ManifestEntry, Schema, TableSchema, VectorType,
     };
     use crate::table::TableWrite;
-    use arrow_array::builder::{
-        FixedSizeListBuilder, Float32Builder, Int64Builder, ListBuilder,
-    };
+    use arrow_array::builder::{FixedSizeListBuilder, Float32Builder, Int64Builder, ListBuilder};
     use arrow_array::{ArrayRef, Int32Array};
     use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
     use chrono::{DateTime, Utc};
@@ -1126,7 +1121,9 @@ mod tests {
         let field = DataField::new(
             0,
             "embedding".to_string(),
-            DataType::Vector(VectorType::try_new(true, 4, DataType::Float(FloatType::new())).unwrap()),
+            DataType::Vector(
+                VectorType::try_new(true, 4, DataType::Float(FloatType::new())).unwrap(),
+            ),
         );
         assert!(validate_vector_field(&field).is_ok());
     }
@@ -1136,7 +1133,9 @@ mod tests {
         let field = DataField::new(
             0,
             "embedding".to_string(),
-            DataType::Vector(VectorType::try_new(true, 4, DataType::Double(DoubleType::new())).unwrap()),
+            DataType::Vector(
+                VectorType::try_new(true, 4, DataType::Double(DoubleType::new())).unwrap(),
+            ),
         );
         let err = validate_vector_field(&field).expect_err("VECTOR<DOUBLE> must be rejected");
         assert!(matches!(err, Error::DataInvalid { .. }));
@@ -1147,10 +1146,15 @@ mod tests {
         let field = DataField::new(
             0,
             "embedding".to_string(),
-            DataType::Vector(VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap()),
+            DataType::Vector(
+                VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap(),
+            ),
         );
         let opts = effective_lumina_options(&field, HashMap::new()).unwrap();
-        assert_eq!(opts.get(LUMINA_DIMENSION_OPTION).map(String::as_str), Some("256"));
+        assert_eq!(
+            opts.get(LUMINA_DIMENSION_OPTION).map(String::as_str),
+            Some("256")
+        );
     }
 
     #[test]
@@ -1158,11 +1162,16 @@ mod tests {
         let field = DataField::new(
             0,
             "embedding".to_string(),
-            DataType::Vector(VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap()),
+            DataType::Vector(
+                VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap(),
+            ),
         );
         let resolved = HashMap::from([(LUMINA_DIMENSION_OPTION.to_string(), "256".to_string())]);
         let opts = effective_lumina_options(&field, resolved).unwrap();
-        assert_eq!(opts.get(LUMINA_DIMENSION_OPTION).map(String::as_str), Some("256"));
+        assert_eq!(
+            opts.get(LUMINA_DIMENSION_OPTION).map(String::as_str),
+            Some("256")
+        );
     }
 
     #[test]
@@ -1170,11 +1179,13 @@ mod tests {
         let field = DataField::new(
             0,
             "embedding".to_string(),
-            DataType::Vector(VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap()),
+            DataType::Vector(
+                VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap(),
+            ),
         );
         let resolved = HashMap::from([(LUMINA_DIMENSION_OPTION.to_string(), "128".to_string())]);
-        let err = effective_lumina_options(&field, resolved)
-            .expect_err("dimension mismatch must error");
+        let err =
+            effective_lumina_options(&field, resolved).expect_err("dimension mismatch must error");
         assert!(matches!(err, Error::ConfigInvalid { .. }));
     }
 
@@ -1196,15 +1207,22 @@ mod tests {
         let field = DataField::new(
             0,
             "embedding".to_string(),
-            DataType::Vector(VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap()),
+            DataType::Vector(
+                VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap(),
+            ),
         );
         // No lumina.index.dimension set by the user.
         let resolved = effective_lumina_options(&field, HashMap::new()).unwrap();
         let opts = LuminaVectorIndexOptions::new(&resolved).unwrap();
 
-        assert_eq!(opts.dimension, 256, "local dimension must be N, not default 128");
         assert_eq!(
-            opts.to_lumina_options().get(KEY_DIMENSION).map(String::as_str),
+            opts.dimension, 256,
+            "local dimension must be N, not default 128"
+        );
+        assert_eq!(
+            opts.to_lumina_options()
+                .get(KEY_DIMENSION)
+                .map(String::as_str),
             Some("256"),
             "native index.dimension must be N, not default 128"
         );
@@ -1454,7 +1472,9 @@ mod tests {
         let batch = fixed_size_vector_batch(vec![None], vec![Some(0)], 2);
         let err = extract_vectors_from_batches(&[batch], "embedding", 2, 0, 1)
             .expect_err("null vector should fail");
-        assert!(matches!(err, Error::DataInvalid { message, .. } if message.contains("null vector")));
+        assert!(
+            matches!(err, Error::DataInvalid { message, .. } if message.contains("null vector"))
+        );
     }
 
     #[test]
@@ -1463,7 +1483,46 @@ mod tests {
         let batch = fixed_size_vector_batch(vec![Some(vec![1.0, 2.0, 3.0])], vec![Some(0)], 3);
         let err = extract_vectors_from_batches(&[batch], "embedding", 2, 0, 1)
             .expect_err("dimension mismatch should fail");
-        assert!(matches!(err, Error::DataInvalid { message, .. } if message.contains("dimension mismatch")));
+        assert!(
+            matches!(err, Error::DataInvalid { message, .. } if message.contains("dimension mismatch"))
+        );
+    }
+
+    #[test]
+    fn test_extract_vectors_fixed_size_list_rejects_null_element() {
+        // A non-null vector row whose second child element is null. Mirrors the
+        // List path's test_extract_vectors_rejects_null_element so both layouts
+        // reject null elements identically.
+        let element_field = Arc::new(ArrowField::new("element", ArrowDataType::Float32, true));
+        let mut builder =
+            FixedSizeListBuilder::new(Float32Builder::new(), 2).with_field(element_field);
+        builder.values().append_value(1.0);
+        builder.values().append_null();
+        builder.append(true);
+        let row_ids = Arc::new(Int64Array::from(vec![Some(0)])) as ArrayRef;
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(
+                "embedding",
+                ArrowDataType::FixedSizeList(
+                    Arc::new(ArrowField::new("element", ArrowDataType::Float32, true)),
+                    2,
+                ),
+                true,
+            ),
+            ArrowField::new(ROW_ID_FIELD_NAME, ArrowDataType::Int64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(builder.finish()) as ArrayRef, row_ids],
+        )
+        .unwrap();
+
+        let err = extract_vectors_from_batches(&[batch], "embedding", 2, 0, 1)
+            .expect_err("null element should fail");
+
+        assert!(
+            matches!(err, Error::DataInvalid { message, .. } if message.contains("null vector element"))
+        );
     }
 
     #[test]

--- a/crates/paimon/src/table/lumina_index_build_builder.rs
+++ b/crates/paimon/src/table/lumina_index_build_builder.rs
@@ -1187,7 +1187,27 @@ mod tests {
         );
         // No dimension option set: array path must NOT inject one.
         let opts = effective_lumina_options(&field, HashMap::new()).unwrap();
-        assert!(opts.get(LUMINA_DIMENSION_OPTION).is_none());
+        assert!(!opts.contains_key(LUMINA_DIMENSION_OPTION));
+    }
+
+    #[test]
+    fn test_vector_without_option_propagates_dimension_to_native_options() {
+        use crate::lumina::{LuminaVectorIndexOptions, KEY_DIMENSION};
+        let field = DataField::new(
+            0,
+            "embedding".to_string(),
+            DataType::Vector(VectorType::try_new(true, 256, DataType::Float(FloatType::new())).unwrap()),
+        );
+        // No lumina.index.dimension set by the user.
+        let resolved = effective_lumina_options(&field, HashMap::new()).unwrap();
+        let opts = LuminaVectorIndexOptions::new(&resolved).unwrap();
+
+        assert_eq!(opts.dimension, 256, "local dimension must be N, not default 128");
+        assert_eq!(
+            opts.to_lumina_options().get(KEY_DIMENSION).map(String::as_str),
+            Some("256"),
+            "native index.dimension must be N, not default 128"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Part of #410 (PR 4). Integrates the native `VECTOR<FLOAT, N>` type with the Lumina
index build path. Previously only `ARRAY<FLOAT>` columns could be indexed; this
extends validation, dimension resolution, and Arrow vector extraction to also
accept `DataType::Vector`, deriving the dimension from the column type
(`VectorType::length`) instead of requiring an explicit `lumina.index.dimension`
option. This mirrors Java `LuminaVectorGlobalIndexWriter.validateAndResolveDimension`,
where both `ARRAY<FLOAT>` and `VECTOR<FLOAT>` are valid vector-index columns.

## Changes

- **Validation** (`validate_vector_field`): accept `VECTOR<FLOAT>` in addition to
  `ARRAY<FLOAT>`; reject non-float element types (e.g. `VECTOR<DOUBLE>`).
- **Dimension resolution** (`effective_lumina_options`, new): for a
  `VECTOR<FLOAT, N>` column, derive `lumina.index.dimension = N` from the type.
  Absent → inject `N`; present-and-equal → keep; present-and-different →
  `ConfigInvalid`. Non-vector columns (`ARRAY<FLOAT>`) are returned unchanged so
  existing option/default behavior is preserved. Matches Java's
  `testVectorTypeRejectsExplicitDimensionConflict`.
- **Extraction** (`extract_vectors_from_batches`): resolve the vector column as
  either `List<Float32>` (ARRAY) or `FixedSizeList<Float32>` (VECTOR) via a
  `VectorLayout` enum; both yield a `Float32Array` plus a per-row `[start, end)`
  slice, with identical null-vector / null-element / dimension-mismatch handling.
- Add `LUMINA_DIMENSION_OPTION` constant in `lumina/mod.rs`.

## Scope note

#410's PR 4 description names `lumina`/`vindex` index build **and**
`VectorSearchBuilder`. Only the Lumina build path is touched here, deliberately:

- **vindex index build** does not exist in Rust yet — `src/vindex/` currently has
  only a reader (from #399), no writer/builder. VECTOR support for vindex will be
  built in when the vindex build path is ported (the Java vindex writer already
  accepts both `ARRAY<FLOAT>` and `VECTOR<FLOAT>`, so it will be internal to that
  work rather than a follow-up integration).
- **`VectorSearchBuilder`** dispatches by field name and index-file type against
  already-built index files; it does not re-validate the source column as ARRAY
  vs VECTOR, so it is transparent to the column type and needs no change.

## Testing

- [x] `cargo fmt`
- [x] `cargo check -p paimon`
- [x] `cargo test -p paimon --lib lumina_index_build_builder` (28 passed, 1 ignored — the ignored test requires `LUMINA_LIB_PATH`)

New tests cover: VECTOR<FLOAT> accepted / VECTOR<DOUBLE> rejected; dimension
absent-inject / matching-ok / mismatch-errors / array-unchanged; dimension
propagation into native Lumina options; and FixedSizeList<Float32> extraction
incl. null-vector, null-element, and dimension-mismatch rejection.
