### PR TITLE
[python] Push down like/startsWith/endsWith/contains predicates

### DIFF
--- a/bindings/python/src/predicate.rs
+++ b/bindings/python/src/predicate.rs
@@ -105,7 +105,7 @@ fn float_val(value: &Bound<'_, PyAny>) -> PyResult<f64> {
 
 /// Operators recognized by the lightweight dict format but not translatable to a
 /// Rust [`Predicate`] for pushdown.
-const METHOD_NOT_SUPPORTED: &[&str] = &["like", "startsWith", "endsWith", "contains", "not"];
+const METHOD_NOT_SUPPORTED: &[&str] = &["not"];
 
 /// Recursively convert a lightweight dict predicate into a Rust [`Predicate`].
 ///
@@ -242,6 +242,25 @@ fn leaf_to_predicate(
             }
             pb.is_not_in(&field, ds)
         }
+        "startsWith" => pb.starts_with(&field, one(to_datums(literals_obj)?)?),
+        "endsWith" => pb.ends_with(&field, one(to_datums(literals_obj)?)?),
+        "contains" => pb.contains(&field, one(to_datums(literals_obj)?)?),
+        "like" => {
+            // 1 literal: pattern with the default '\' escape.
+            // 2 literals: [pattern, escape] where escape is a single character
+            // (SQL `LIKE .. ESCAPE ..`).
+            let mut ds = to_datums(literals_obj)?;
+            let escape = match ds.len() {
+                1 => None,
+                2 => Some(escape_char(ds.pop().unwrap())?),
+                n => {
+                    return Err(PyValueError::new_err(format!(
+                        "'like' expects 1 or 2 literals (pattern[, escape]), got {n}"
+                    )));
+                }
+            };
+            pb.like(&field, ds.pop().unwrap(), escape)
+        }
         other => {
             return Err(PyNotImplementedError::new_err(format!(
                 "unknown or unsupported predicate operator '{other}'"
@@ -294,6 +313,21 @@ fn with_field_context(err: PyErr, field: &str, data_type: &DataType) -> PyErr {
             err
         }
     })
+}
+
+/// Extract a single-character `like` ESCAPE literal from an already-converted
+/// string `Datum`.
+fn escape_char(datum: Datum) -> PyResult<char> {
+    let Datum::String(s) = datum else {
+        return Err(PyValueError::new_err("'like' escape must be a str literal"));
+    };
+    let mut chars = s.chars();
+    match (chars.next(), chars.next()) {
+        (Some(c), None) => Ok(c),
+        _ => Err(PyValueError::new_err(format!(
+            "'like' escape must be a single character, got {s:?}"
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -357,22 +391,185 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_operator_like_raises_not_implemented() {
-        Python::attach(|py| {
-            let fields = test_fields();
-            let dict = leaf_dict(py, "like", "name", &[]);
-            let err = dict_to_predicate(&dict, &fields).unwrap_err();
-            assert!(err.is_instance_of::<PyNotImplementedError>(py));
-        });
-    }
-
-    #[test]
     fn unsupported_operator_not_raises_not_implemented() {
         Python::attach(|py| {
             let fields = test_fields();
             let dict = leaf_dict(py, "not", "id", &[1]);
             let err = dict_to_predicate(&dict, &fields).unwrap_err();
             assert!(err.is_instance_of::<PyNotImplementedError>(py));
+        });
+    }
+
+    // ---- string operators ----
+
+    /// Build a leaf dict with string literals.
+    fn str_leaf_dict<'py>(
+        py: Python<'py>,
+        method: &str,
+        field: &str,
+        literals: &[&str],
+    ) -> Bound<'py, PyDict> {
+        let d = PyDict::new(py);
+        d.set_item("method", method).unwrap();
+        d.set_item("field", field).unwrap();
+        let lits = PyList::empty(py);
+        for v in literals {
+            lits.append(*v).unwrap();
+        }
+        d.set_item("literals", lits).unwrap();
+        d
+    }
+
+    fn expect_leaf_op(pred: &Predicate, expected: PredicateOperator) {
+        match pred {
+            Predicate::Leaf { op, .. } => assert_eq!(*op, expected),
+            other => panic!("expected Leaf, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn starts_with_leaf_converts() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = str_leaf_dict(py, "startsWith", "name", &["ab"]);
+            let pred = dict_to_predicate(&dict, &fields).unwrap();
+            expect_leaf_op(&pred, PredicateOperator::StartsWith);
+        });
+    }
+
+    #[test]
+    fn ends_with_leaf_converts() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = str_leaf_dict(py, "endsWith", "name", &["ab"]);
+            let pred = dict_to_predicate(&dict, &fields).unwrap();
+            expect_leaf_op(&pred, PredicateOperator::EndsWith);
+        });
+    }
+
+    #[test]
+    fn contains_leaf_converts() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = str_leaf_dict(py, "contains", "name", &["ab"]);
+            let pred = dict_to_predicate(&dict, &fields).unwrap();
+            expect_leaf_op(&pred, PredicateOperator::Contains);
+        });
+    }
+
+    #[test]
+    fn like_prefix_pattern_optimizes_to_starts_with() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = str_leaf_dict(py, "like", "name", &["ab%"]);
+            let pred = dict_to_predicate(&dict, &fields).unwrap();
+            expect_leaf_op(&pred, PredicateOperator::StartsWith);
+        });
+    }
+
+    #[test]
+    fn like_residual_pattern_stays_like() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = str_leaf_dict(py, "like", "name", &["a%b%c"]);
+            let pred = dict_to_predicate(&dict, &fields).unwrap();
+            expect_leaf_op(&pred, PredicateOperator::Like);
+        });
+    }
+
+    #[test]
+    fn like_accepts_backslash_escape_literal() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = str_leaf_dict(py, "like", "name", &["100\\%%", "\\"]);
+            let pred = dict_to_predicate(&dict, &fields).unwrap();
+            // Escaped-wildcard patterns are not rewritten by the core's LIKE
+            // optimization; they stay as a residual Like leaf.
+            expect_leaf_op(&pred, PredicateOperator::Like);
+        });
+    }
+
+    #[test]
+    fn like_rejects_non_backslash_escape() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = str_leaf_dict(py, "like", "name", &["100!%%", "!"]);
+            let err = dict_to_predicate(&dict, &fields).unwrap_err();
+            assert!(err.is_instance_of::<PyValueError>(py));
+        });
+    }
+
+    #[test]
+    fn like_rejects_multi_char_escape() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = str_leaf_dict(py, "like", "name", &["a%", "ab"]);
+            let err = dict_to_predicate(&dict, &fields).unwrap_err();
+            assert!(err.is_instance_of::<PyValueError>(py));
+        });
+    }
+
+    #[test]
+    fn like_rejects_three_literals() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = str_leaf_dict(py, "like", "name", &["a%", "\\", "x"]);
+            let err = dict_to_predicate(&dict, &fields).unwrap_err();
+            assert!(err.is_instance_of::<PyValueError>(py));
+        });
+    }
+
+    #[test]
+    fn string_op_empty_pattern_folds_to_is_not_null() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            for method in ["startsWith", "endsWith", "contains"] {
+                let dict = str_leaf_dict(py, method, "name", &[""]);
+                let pred = dict_to_predicate(&dict, &fields).unwrap();
+                expect_leaf_op(&pred, PredicateOperator::IsNotNull);
+            }
+        });
+    }
+
+    #[test]
+    fn string_op_on_non_string_column_raises_value_error() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            for method in ["startsWith", "endsWith", "contains", "like"] {
+                let dict = str_leaf_dict(py, method, "id", &["a"]);
+                let err = dict_to_predicate(&dict, &fields).unwrap_err();
+                assert!(err.is_instance_of::<PyValueError>(py), "{method}");
+            }
+        });
+    }
+
+    #[test]
+    fn string_op_wrong_literal_count_raises_value_error() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            for method in ["startsWith", "endsWith", "contains", "like"] {
+                let dict = str_leaf_dict(py, method, "name", &[]);
+                let err = dict_to_predicate(&dict, &fields).unwrap_err();
+                assert!(err.is_instance_of::<PyValueError>(py), "{method} zero");
+            }
+            for method in ["startsWith", "endsWith", "contains"] {
+                let dict = str_leaf_dict(py, method, "name", &["a", "b"]);
+                let err = dict_to_predicate(&dict, &fields).unwrap_err();
+                assert!(err.is_instance_of::<PyValueError>(py), "{method} two");
+            }
+        });
+    }
+
+    #[test]
+    fn string_op_unknown_field_raises_value_error() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            // Now that string operators are supported, they follow the normal
+            // leaf path: field resolution happens first, so an unknown field is
+            // a ValueError (not NotImplementedError as before).
+            let dict = str_leaf_dict(py, "like", "nope", &["x"]);
+            let err = dict_to_predicate(&dict, &fields).unwrap_err();
+            assert!(err.is_instance_of::<PyValueError>(py));
         });
     }
 
@@ -385,18 +582,6 @@ mod tests {
             let dict = PyDict::new(py);
             dict.set_item("method", "not").unwrap();
             dict.set_item("children", PyList::empty(py)).unwrap();
-            let err = dict_to_predicate(&dict, &fields).unwrap_err();
-            assert!(err.is_instance_of::<PyNotImplementedError>(py));
-        });
-    }
-
-    #[test]
-    fn unsupported_operator_like_with_unknown_field_raises_not_implemented() {
-        Python::attach(|py| {
-            let fields = test_fields();
-            // 'like' with an unknown field: unsupported operator precedes field
-            // resolution, so NotImplementedError (not the unknown-field ValueError).
-            let dict = leaf_dict(py, "like", "nope", &[]);
             let err = dict_to_predicate(&dict, &fields).unwrap_err();
             assert!(err.is_instance_of::<PyNotImplementedError>(py));
         });
@@ -429,7 +614,7 @@ mod tests {
         Python::attach(|py| {
             let fields = test_fields();
             let ok = leaf_dict(py, "equal", "id", &[1]);
-            let bad = leaf_dict(py, "like", "name", &[]);
+            let bad = leaf_dict(py, "not", "name", &[]);
             let children = PyList::empty(py);
             children.append(ok).unwrap();
             children.append(bad).unwrap();

--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -174,13 +174,12 @@ def test_filter_bool_literal_converts():
         assert plan is not None
 
 
-@pytest.mark.parametrize("method", ["like", "startsWith", "not"])
-def test_filter_unsupported_operator_raises(method):
+def test_filter_unsupported_operator_raises():
     with tempfile.TemporaryDirectory() as warehouse:
         table = _make_table_with_data(warehouse)
         with pytest.raises(NotImplementedError):
             table.new_read_builder().with_filter(
-                {"method": method, "field": "name", "literals": ["x"]})
+                {"method": "not", "field": "name", "literals": ["x"]})
 
 
 def test_filter_unsupported_operator_precedes_shape_errors():
@@ -190,9 +189,92 @@ def test_filter_unsupported_operator_precedes_shape_errors():
         # 'not' with no field -> NotImplementedError, not ValueError about missing field
         with pytest.raises(NotImplementedError):
             b.with_filter({"method": "not", "children": []})
-        # 'like' with unknown field -> NotImplementedError, not ValueError about unknown field
-        with pytest.raises(NotImplementedError):
-            b.with_filter({"method": "like", "field": "nope", "literals": ["x"]})
+
+
+def _make_string_table(warehouse):
+    ctx = SQLContext()
+    ctx.register_catalog("paimon", {"warehouse": warehouse})
+    ctx.sql("CREATE SCHEMA paimon.sdb")
+    ctx.sql("CREATE TABLE paimon.sdb.st (id INT, name STRING)")
+    # Two separate INSERTs -> two files, so file stats can prune per-file.
+    ctx.sql("INSERT INTO paimon.sdb.st VALUES (1, 'apple'), (2, 'apricot')")
+    ctx.sql("INSERT INTO paimon.sdb.st VALUES (3, 'banana'), (4, 'cherry')")
+    return PaimonCatalog({"warehouse": warehouse}).get_table("sdb.st")
+
+
+def _read_ids(builder):
+    splits = builder.new_scan().plan().splits()
+    batches = builder.new_read().read(splits)
+    if not batches:
+        return []
+    return sorted(pa.Table.from_batches(batches).column("id").to_pylist())
+
+
+def test_filter_starts_with_prunes_and_reads():
+    with tempfile.TemporaryDirectory() as warehouse:
+        table = _make_string_table(warehouse)
+        b = table.new_read_builder().with_filter(
+            {"method": "startsWith", "field": "name", "literals": ["ap"]})
+        assert len(b.new_scan().plan().splits()) == 1
+        assert _read_ids(b) == [1, 2]
+
+
+def test_filter_ends_with_reads_matching_rows():
+    with tempfile.TemporaryDirectory() as warehouse:
+        table = _make_string_table(warehouse)
+        b = table.new_read_builder().with_filter(
+            {"method": "endsWith", "field": "name", "literals": ["y"]})
+        assert _read_ids(b) == [4]
+
+
+def test_filter_contains_reads_matching_rows():
+    with tempfile.TemporaryDirectory() as warehouse:
+        table = _make_string_table(warehouse)
+        b = table.new_read_builder().with_filter(
+            {"method": "contains", "field": "name", "literals": ["an"]})
+        assert _read_ids(b) == [3]
+
+
+def test_filter_like_prefix_reads_matching_rows():
+    with tempfile.TemporaryDirectory() as warehouse:
+        table = _make_string_table(warehouse)
+        b = table.new_read_builder().with_filter(
+            {"method": "like", "field": "name", "literals": ["ap%"]})
+        assert _read_ids(b) == [1, 2]
+
+
+def test_filter_like_residual_pattern_reads_matching_rows():
+    with tempfile.TemporaryDirectory() as warehouse:
+        table = _make_string_table(warehouse)
+        # '_' single-char wildcard is not rewritten; exercises the Like evaluator.
+        b = table.new_read_builder().with_filter(
+            {"method": "like", "field": "name", "literals": ["b_nana"]})
+        assert _read_ids(b) == [3]
+
+
+def test_filter_like_escape_literal():
+    with tempfile.TemporaryDirectory() as warehouse:
+        table = _make_string_table(warehouse)
+        b = table.new_read_builder()
+        # Optional second literal is the ESCAPE character; only '\\' is accepted.
+        assert b.with_filter(
+            {"method": "like", "field": "name",
+             "literals": ["100\\%%", "\\"]}).new_scan().plan() is not None
+        with pytest.raises(ValueError):
+            b.with_filter(
+                {"method": "like", "field": "name", "literals": ["100!%%", "!"]})
+        with pytest.raises(ValueError):
+            b.with_filter(
+                {"method": "like", "field": "name", "literals": ["a%", "ab"]})
+
+
+def test_filter_string_op_on_non_string_column_raises():
+    with tempfile.TemporaryDirectory() as warehouse:
+        table = _make_string_table(warehouse)
+        b = table.new_read_builder()
+        for method in ["startsWith", "endsWith", "contains", "like"]:
+            with pytest.raises(ValueError):
+                b.with_filter({"method": method, "field": "id", "literals": ["a"]})
 
 
 def test_filter_unsupported_type_raises():
@@ -258,7 +340,9 @@ def test_filter_compound_with_unsupported_child_fails():
         table = _make_table_with_data(warehouse)
         pred = {"method": "and", "children": [
             {"method": "equal", "field": "id", "literals": [1]},
-            {"method": "like", "field": "name", "literals": ["a%"]},
+            {"method": "not", "children": [
+                {"method": "equal", "field": "name", "literals": ["a"]},
+            ]},
         ]}
         with pytest.raises(NotImplementedError):
             table.new_read_builder().with_filter(pred)


### PR DESCRIPTION
### Purpose

The Python binding's `METHOD_NOT_SUPPORTED` list rejects `like` / `startsWith` / `endsWith` / `contains` with `NotImplementedError`, even though the core `PredicateBuilder` has supported `StartsWith`/`EndsWith`/`Contains`/`Like` (and the stats/reader-pruning evaluators handle them) since #425. Any query with a string-prefix/suffix/substring filter therefore cannot be pushed down through the DataFrame-style read path. This PR is pure binding wiring — zero core change.

Linked issue: none.

### Brief change log

- Remove the four string operators from `METHOD_NOT_SUPPORTED` (`not` remains rejected) and add match arms in `leaf_to_predicate`:
  - `startsWith` / `endsWith` / `contains`: exactly 1 string literal → `PredicateBuilder::{starts_with,ends_with,contains}`. An empty pattern folds to `IsNotNull` in the core builder.
  - `like`: `[pattern]` or `[pattern, escape]`, mirroring SQL `LIKE .. ESCAPE ..`. The escape must be a single character; the core accepts only `'\\'` and rejects anything else. Prefix / suffix / contains-shaped patterns are rewritten by the core's LIKE optimization (`ab%` → StartsWith); residual patterns (`_`, multi-segment `%`, escaped wildcards) stay as a `Like` leaf.
- String operators now follow the normal leaf path: unknown field or non-string column raises `ValueError` (previously the blanket `NotImplementedError` preceded field resolution). The two tests asserting that precedence are updated accordingly; `not` keeps its precedence behavior.

### Tests

- Rust: `cargo test -p pypaimon_rust` — 38 passed. New unit tests cover each operator's leaf conversion, LIKE prefix-optimization and residual shapes, escape acceptance/rejection (non-backslash, multi-char, 3 literals), empty-pattern → IsNotNull folding, non-string column rejection, and literal-count validation.
- Python: `uv run --no-sync pytest tests/test_read.py` — 39 passed. New end-to-end tests build a two-file string table and assert `startsWith` prunes splits via file stats and each operator returns exactly the matching rows through `TableRead.read`, including a `b_nana` residual-LIKE evaluator case.

### API and Format

No API surface change (the same `with_filter(dict)` accepts more operators). No storage format change.

### Documentation

Behavior documented inline on the new match arms and `escape_char` helper.