### PR TITLE
fix(scan): use evaluated fields for global index fallback

### DIFF
--- a/crates/paimon/src/table/global_index_scanner.rs
+++ b/crates/paimon/src/table/global_index_scanner.rs
@@ -36,13 +36,19 @@ use std::sync::Mutex;
 
 type BoxedCmp = Box<dyn Fn(&[u8], &[u8]) -> Ordering + Send + Sync>;
 
-type EvaluateFuture<'a> =
-    std::pin::Pin<Box<dyn std::future::Future<Output = Result<Option<Vec<RowRange>>>> + Send + 'a>>;
+type EvaluateFuture<'a> = std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<Option<GlobalIndexScanResult>>> + Send + 'a>,
+>;
 
 type PredicateTuple<'a> = (PredicateOperator, &'a [Datum], &'a DataType);
 
 const BTREE_INDEX_TYPE: &str = "btree";
 const INDEX_DIR: &str = "index";
+
+struct GlobalIndexScanResult {
+    row_ranges: Vec<RowRange>,
+    evaluated_field_ids: HashSet<i32>,
+}
 
 /// Evaluates global index predicates and returns matching row ranges.
 ///
@@ -143,7 +149,7 @@ impl GlobalIndexScanner {
 
     /// Evaluate a predicate against the global indexes and return matching row ranges.
     /// Returns `None` if the predicate cannot be evaluated by the global index.
-    pub(crate) fn evaluate<'a>(&'a self, predicate: &'a Predicate) -> EvaluateFuture<'a> {
+    fn evaluate<'a>(&'a self, predicate: &'a Predicate) -> EvaluateFuture<'a> {
         Box::pin(async move {
             match predicate {
                 Predicate::Leaf {
@@ -167,6 +173,12 @@ impl GlobalIndexScanner {
                     };
                     self.evaluate_leaf(entries, &[(*op, literals.as_slice(), data_type)])
                         .await
+                        .map(|ranges| {
+                            ranges.map(|row_ranges| GlobalIndexScanResult {
+                                row_ranges,
+                                evaluated_field_ids: HashSet::from([field_id]),
+                            })
+                        })
                 }
                 Predicate::And(children) => {
                     // Group leaf predicates by field_id to reuse readers
@@ -199,45 +211,61 @@ impl GlobalIndexScanner {
                         non_leaf_children.push(child);
                     }
 
-                    let mut result: Option<Vec<RowRange>> = None;
+                    let mut row_ranges: Option<Vec<RowRange>> = None;
+                    let mut evaluated_field_ids = HashSet::new();
 
                     // Evaluate grouped leaves (one open per file)
                     for (field_id, predicates) in &leaf_groups {
                         if let Some(entries) = self.entries_for_field(*field_id) {
                             if let Some(ranges) = self.evaluate_leaf(entries, predicates).await? {
-                                result = Some(match result {
+                                row_ranges = Some(match row_ranges {
                                     None => ranges,
                                     Some(existing) => intersect_sorted_ranges(&existing, &ranges),
                                 });
+                                evaluated_field_ids.insert(*field_id);
                             }
                         }
                     }
 
                     // Evaluate non-leaf children recursively
                     for child in non_leaf_children {
-                        if let Some(ranges) = self.evaluate(child).await? {
-                            result = Some(match result {
-                                None => ranges,
-                                Some(existing) => intersect_sorted_ranges(&existing, &ranges),
+                        if let Some(child_result) = self.evaluate(child).await? {
+                            row_ranges = Some(match row_ranges {
+                                None => child_result.row_ranges,
+                                Some(existing) => {
+                                    intersect_sorted_ranges(&existing, &child_result.row_ranges)
+                                }
                             });
+                            evaluated_field_ids.extend(child_result.evaluated_field_ids);
                         }
                     }
 
-                    Ok(result)
+                    Ok(row_ranges.map(|row_ranges| GlobalIndexScanResult {
+                        row_ranges,
+                        evaluated_field_ids,
+                    }))
                 }
                 Predicate::Or(children) => {
                     let mut all_ranges: Vec<RowRange> = Vec::new();
+                    let mut evaluated_field_ids = HashSet::new();
                     for child in children {
                         match self.evaluate(child).await? {
-                            Some(ranges) => all_ranges.extend(ranges),
+                            Some(child_result) => {
+                                all_ranges.extend(child_result.row_ranges);
+                                evaluated_field_ids.extend(child_result.evaluated_field_ids);
+                            }
                             None => return Ok(None),
                         }
                     }
-                    if all_ranges.is_empty() {
-                        Ok(Some(Vec::new()))
+                    let row_ranges = if all_ranges.is_empty() {
+                        Vec::new()
                     } else {
-                        Ok(Some(super::merge_row_ranges(all_ranges)))
-                    }
+                        super::merge_row_ranges(all_ranges)
+                    };
+                    Ok(Some(GlobalIndexScanResult {
+                        row_ranges,
+                        evaluated_field_ids,
+                    }))
                 }
                 _ => Ok(None),
             }
@@ -423,6 +451,7 @@ impl GlobalIndexScanner {
     /// data-file row ranges collected by the scan. The caller unions these
     /// ranges with indexed matches, and the normal read filter evaluates the
     /// predicate on the raw rows.
+    #[cfg(test)]
     fn unindexed_ranges(
         &self,
         predicate: &Predicate,
@@ -431,21 +460,33 @@ impl GlobalIndexScanner {
         data_ranges: &[RowRange],
     ) -> Result<Vec<RowRange>> {
         let field_ids = self.collect_field_ids(predicate)?;
-        Ok(unindexed_ranges_for_coverage(
+        Ok(self.unindexed_ranges_for_field_ids(&field_ids, search_mode, next_row_id, data_ranges))
+    }
+
+    fn unindexed_ranges_for_field_ids(
+        &self,
+        field_ids: &HashSet<i32>,
+        search_mode: GlobalIndexSearchMode,
+        next_row_id: Option<i64>,
+        data_ranges: &[RowRange],
+    ) -> Vec<RowRange> {
+        unindexed_ranges_for_coverage(
             &self.coverage_by_field,
-            &field_ids,
+            field_ids,
             search_mode,
             next_row_id,
             data_ranges,
-        ))
+        )
     }
 
+    #[cfg(test)]
     fn collect_field_ids(&self, predicate: &Predicate) -> Result<HashSet<i32>> {
         let mut field_ids = HashSet::new();
         self.collect_field_ids_inner(predicate, &mut field_ids)?;
         Ok(field_ids)
     }
 
+    #[cfg(test)]
     fn collect_field_ids_inner(
         &self,
         predicate: &Predicate,
@@ -784,16 +825,17 @@ pub(crate) async fn evaluate_global_index(
 
     let combined = Predicate::and(evaluation.predicates.to_vec());
 
-    let mut row_ranges = match scanner.evaluate(&combined).await? {
-        Some(row_ranges) => row_ranges,
+    let scan_result = match scanner.evaluate(&combined).await? {
+        Some(scan_result) => scan_result,
         None => return Ok(None),
     };
-    row_ranges.extend(scanner.unindexed_ranges(
-        &combined,
+    let mut row_ranges = scan_result.row_ranges;
+    row_ranges.extend(scanner.unindexed_ranges_for_field_ids(
+        &scan_result.evaluated_field_ids,
         evaluation.search_mode,
         evaluation.next_row_id,
         evaluation.data_ranges,
-    )?);
+    ));
     Ok(Some(super::merge_row_ranges(row_ranges)))
 }
 
@@ -1141,6 +1183,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_evaluate_extra_field_only_without_composite_reader_falls_back() {
+        let (file_io, table_path, file_name, _tmp) =
+            setup_testdata_table("btree_int_100_no_compress.bin");
+        let meta = BTreeIndexMeta::new(Some(le_int_key(0)), Some(le_int_key(198)), false);
+        let mut entry = make_global_index_entry(&file_name, 1, 0, 99, &meta);
+        entry
+            .index_file
+            .global_index_meta
+            .as_mut()
+            .unwrap()
+            .extra_field_ids = Some(vec![2]);
+        let fields = two_field_schema_fields();
+        let predicates = vec![int_eq("value", 1, 50)];
+
+        let result =
+            evaluate_global_index_fast(&file_io, &table_path, &[entry], &predicates, &fields)
+                .await
+                .unwrap();
+        assert!(
+            result.is_none(),
+            "extra-field-only predicates must fall back until composite-key btree reads are supported"
+        );
+    }
+
+    #[tokio::test]
     async fn test_evaluate_global_index_eq() {
         let (file_io, table_path, file_name, _tmp) =
             setup_testdata_table("btree_int_100_no_compress.bin");
@@ -1190,6 +1257,58 @@ mod tests {
         assert_eq!(
             result.unwrap(),
             vec![RowRange::new(25, 25), RowRange::new(100, 149)]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_global_index_and_uses_evaluated_field_coverage_for_raw_fallback() {
+        let src = format!(
+            "{}/testdata/btree/btree_int_100_no_compress.bin",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let tmp = tempfile::tempdir().unwrap();
+        let index_dir = tmp.path().join("index");
+        std::fs::create_dir_all(&index_dir).unwrap();
+        std::fs::copy(&src, index_dir.join("index_part1.bin")).unwrap();
+        std::fs::copy(&src, index_dir.join("index_part2.bin")).unwrap();
+
+        let table_path = format!("file://{}", tmp.path().display());
+        let file_io = crate::io::FileIOBuilder::new("file").build().unwrap();
+        let meta = BTreeIndexMeta::new(Some(le_int_key(0)), Some(le_int_key(198)), false);
+
+        let mut first = make_global_index_entry("index_part1.bin", 1, 0, 49, &meta);
+        first
+            .index_file
+            .global_index_meta
+            .as_mut()
+            .unwrap()
+            .extra_field_ids = Some(vec![2]);
+        let second = make_global_index_entry("index_part2.bin", 1, 50, 99, &meta);
+        let entries = vec![first, second];
+        let fields = two_field_schema_fields();
+
+        let predicates = vec![Predicate::and(vec![
+            int_eq("id", 0, 50),
+            int_eq("value", 1, 8),
+        ])];
+        let result = super::evaluate_global_index(super::GlobalIndexEvaluation {
+            file_io: &file_io,
+            table_path: &table_path,
+            index_entries: &entries,
+            predicates: &predicates,
+            schema_fields: &fields,
+            search_mode: GlobalIndexSearchMode::Full,
+            next_row_id: Some(100),
+            data_ranges: &[],
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.unwrap(),
+            vec![RowRange::new(25, 25), RowRange::new(75, 75)],
+            "raw fallback should use only the id field that was actually evaluated; \
+             the unevaluated extra field must not widen or narrow fallback coverage"
         );
     }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Global index coverage currently includes `extra_field_ids`, but Rust can only read BTree entries by `index_field_id`. For predicates like `primary AND extra`, the scanner may evaluate only the primary-field conjunct while fallback coverage is computed from all predicate fields, including an extra field that was not actually evaluated.

This PR tracks which fields were actually evaluated by the global index scanner and uses only those fields when adding raw fallback ranges. Extra-field-only predicates continue to fall back until composite-key BTree reads are supported.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - Return evaluated field ids together with global index row ranges.
  - Compute raw fallback ranges from evaluated fields only.
  - Add regression tests for extra-field-only fallback and mixed primary/extra predicates.

### Tests

<!-- List unit tests or integration cases to verify this change -->

  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --workspace --features fulltext,vortex,mosaic -- -D warnings`
  - `cargo test -p paimon --all-targets --features fulltext,vortex,mosaic`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
