### PR TITLE
docs(python): fix README fence and document current read/write APIs

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -92,7 +92,7 @@ write_builder.new_commit().commit(commit_messages)
 
 # --- Time travel: read a past version ---
 # Supported options: scan.version, scan.timestamp-millis, scan.snapshot-id, or scan.tag-name
-read_builder_tt = table.new_read_builder({"scan.version": "2"})
+read_builder_tt = table.new_read_builder({"scan.snapshot-id": "1"})
 scan_tt = read_builder_tt.new_scan()
 plan_tt = scan_tt.plan()
 batches_tt = read_builder_tt.new_read().read(plan_tt.splits())

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -50,6 +50,41 @@ ctx.sql("DROP TEMPORARY TABLE paimon.default.my_temp")
 
 For the full SQL reference, see the [SQL Integration docs](https://paimon.apache.org/docs/master/sql/).
 
+### Native Read / Write
+
+Beyond SQL, you can use the lower-level read and write APIs directly from Python.
+Time travel is supported via the `options` dict on `new_read_builder`.
+
+```python
+from pypaimon_rust.datafusion import PaimonCatalog
+
+catalog = PaimonCatalog({"warehouse": "/tmp/paimon-warehouse"})
+
+# Table must already exist — create it via SQL, the REST API, or another client
+table = catalog.get_table("my_db.my_table")
+
+# Time travel: pass timestamp-millis, version, snapshot-id, or tag-name
+reader = (
+    table.new_read_builder({"scan.timestamp-millis": "1718208000000"})
+    .with_projection(["id", "name"])
+    .with_limit(100)
+    .new_read()
+)
+
+# Scan → Read: plan splits first, then read batches
+scan = table.new_read_builder().new_scan()
+plan = scan.plan()
+batches = reader.read(plan.splits())
+
+# Write: build → write Arrow batches → commit
+write_builder = table.new_write_builder()
+writer = write_builder.new_write()
+writer.write_arrow(batch)
+commit_messages = writer.prepare_commit()
+
+write_builder.new_commit().commit(commit_messages)
+```
+
 ## Setup
 
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/):
@@ -82,4 +117,4 @@ cd bindings/python
 
 ```shell
 make test
-```````
+```

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -50,41 +50,6 @@ ctx.sql("DROP TEMPORARY TABLE paimon.default.my_temp")
 
 For the full SQL reference, see the [SQL Integration docs](https://paimon.apache.org/docs/master/sql/).
 
-### Native Read / Write
-
-Beyond SQL, you can use the lower-level read and write APIs directly from Python.
-Time travel is supported via the `options` dict on `new_read_builder`.
-
-```python
-from pypaimon_rust.datafusion import PaimonCatalog
-
-catalog = PaimonCatalog({"warehouse": "/tmp/paimon-warehouse"})
-
-# Table must already exist — create it via SQL, the REST API, or another client
-table = catalog.get_table("my_db.my_table")
-
-# Time travel: pass timestamp-millis, version, snapshot-id, or tag-name
-reader = (
-    table.new_read_builder({"scan.timestamp-millis": "1718208000000"})
-    .with_projection(["id", "name"])
-    .with_limit(100)
-    .new_read()
-)
-
-# Scan → Read: plan splits first, then read batches
-scan = table.new_read_builder().new_scan()
-plan = scan.plan()
-batches = reader.read(plan.splits())
-
-# Write: build → write Arrow batches → commit
-write_builder = table.new_write_builder()
-writer = write_builder.new_write()
-writer.write_arrow(batch)
-commit_messages = writer.prepare_commit()
-
-write_builder.new_commit().commit(commit_messages)
-```
-
 ## Setup
 
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/):
@@ -117,4 +82,4 @@ cd bindings/python
 
 ```shell
 make test
-```
+```````

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -50,6 +50,57 @@ ctx.sql("DROP TEMPORARY TABLE paimon.default.my_temp")
 
 For the full SQL reference, see the [SQL Integration docs](https://paimon.apache.org/docs/master/sql/).
 
+### Native Read / Write
+
+Beyond SQL, you can use the lower-level read and write APIs directly from Python.
+Time travel is supported via the `options` dict on `new_read_builder`.
+
+```python
+import pyarrow as pa
+from pypaimon_rust.datafusion import SQLContext, PaimonCatalog
+
+WAREHOUSE = "/tmp/paimon-warehouse"
+
+# --- DDL/DML via DataFusion SQLContext ---
+ctx = SQLContext()
+ctx.register_catalog("paimon", {"warehouse": WAREHOUSE})
+ctx.sql("CREATE SCHEMA paimon.my_db")
+ctx.sql("CREATE TABLE paimon.my_db.users (id INT, name STRING, PRIMARY KEY (id))")
+ctx.sql("INSERT INTO paimon.my_db.users VALUES (1, 'alice'), (2, 'bob')")
+catalog = PaimonCatalog({"warehouse": WAREHOUSE})
+table = catalog.get_table("my_db.users")
+
+# --- Read data ---
+read_builder = table.new_read_builder().with_projection(["id", "name"]).with_limit(100)
+scan = read_builder.new_scan()
+plan = scan.plan()
+batches = read_builder.new_read().read(plan.splits())
+
+print(f"\nRead: {batches[0].num_rows} rows")
+print(batches[0])
+
+# --- Write data, from a PyArrow RecordBatch ---
+batch = pa.record_batch(
+    [[3, 4], ["charlie", "diana"]],
+    schema=pa.schema([("id", pa.int32()), ("name", pa.utf8())]),
+)
+write_builder = table.new_write_builder()
+writer = write_builder.new_write()
+writer.write_arrow(batch)
+commit_messages = writer.prepare_commit()
+write_builder.new_commit().commit(commit_messages)
+
+# --- Time travel: read a past version ---
+# Supported options: scan.version, scan.timestamp-millis, scan.snapshot-id, or scan.tag-name
+read_builder_tt = table.new_read_builder({"scan.version": "2"})
+scan_tt = read_builder_tt.new_scan()
+plan_tt = scan_tt.plan()
+batches_tt = read_builder_tt.new_read().read(plan_tt.splits())
+
+print(f"\nRead: {batches_tt[0].num_rows} rows")
+print(batches_tt[0])
+```
+
 ## Setup
 
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/):
@@ -82,4 +133,4 @@ cd bindings/python
 
 ```shell
 make test
-```````
+```


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
The Python README had a broken markdown fence at the end and was missing documentation for the lower-level `PaimonCatalog → Table → ReadBuilder / WriteBuilder` APIs, which are the primary interface for programmatic read and write when not using SQL. 

<!-- What is the purpose of the change -->

### changes
- Fix the broken closing fence                                                                             
- Add "Native Read / Write" examples
<!-- Please describe the changes made in this pull request and explain how they address the issue -->