### PR TITLE
feat(variant): support shredding read and write

### DIFF
--- a/crates/paimon/src/arrow/format/mod.rs
+++ b/crates/paimon/src/arrow/format/mod.rs
@@ -22,6 +22,7 @@ mod mosaic;
 mod orc;
 mod parquet;
 mod row;
+mod shredding;
 #[cfg(feature = "vortex")]
 mod vortex;
 
@@ -35,6 +36,7 @@ use crate::Error;
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
+use std::collections::HashMap;
 
 /// Predicates with the file-level field context needed for pushdown.
 /// Only used by formats that support predicate pushdown (e.g. Parquet).
@@ -98,37 +100,45 @@ pub(crate) trait FormatFileWriter: Send {
 pub(crate) fn create_format_reader(
     path: &str,
     blob_as_descriptor: bool,
+    read_fields: &[DataField],
 ) -> crate::Result<Box<dyn FormatFileReader>> {
     let lower = path.to_ascii_lowercase();
-    if lower.ends_with(".parquet") {
-        Ok(Box::new(parquet::ParquetFormatReader))
+    let reader: Box<dyn FormatFileReader> = if lower.ends_with(".parquet") {
+        Box::new(parquet::ParquetFormatReader)
     } else if lower.ends_with(".blob") {
-        Ok(Box::new(blob::BlobFormatReader::new(
+        Box::new(blob::BlobFormatReader::new(
             path.to_string(),
             blob_as_descriptor,
-        )))
+        ))
     } else if lower.ends_with(".orc") {
-        Ok(Box::new(orc::OrcFormatReader))
+        Box::new(orc::OrcFormatReader)
     } else if lower.ends_with(".avro") {
-        Ok(Box::new(avro::AvroFormatReader))
+        Box::new(avro::AvroFormatReader)
     } else if lower.ends_with(".row") {
-        Ok(Box::new(row::RowFormatReader))
+        Box::new(row::RowFormatReader)
     } else {
         #[cfg(feature = "mosaic")]
         if lower.ends_with(".mosaic") {
-            return Ok(Box::new(mosaic::MosaicFormatReader));
+            return Ok(shredding::maybe_wrap_reader(
+                Box::new(mosaic::MosaicFormatReader),
+                read_fields,
+            ));
         }
         #[cfg(feature = "vortex")]
         if lower.ends_with(".vortex") {
-            return Ok(Box::new(vortex::VortexFormatReader));
+            return Ok(shredding::maybe_wrap_reader(
+                Box::new(vortex::VortexFormatReader),
+                read_fields,
+            ));
         }
-        Err(Error::Unsupported {
+        return Err(Error::Unsupported {
             message: format!(
                 "unsupported file format: expected {}, got: {path}",
                 supported_read_formats().join(", ")
             ),
-        })
-    }
+        });
+    };
+    Ok(shredding::maybe_wrap_reader(reader, read_fields))
 }
 
 fn supported_read_formats() -> Vec<&'static str> {
@@ -153,13 +163,23 @@ pub(crate) async fn create_format_writer(
     zstd_level: i32,
     file_io: Option<crate::io::FileIO>,
     write_fields: Option<&[DataField]>,
+    format_options: Option<&HashMap<String, String>>,
 ) -> crate::Result<Box<dyn FormatFileWriter>> {
     let path = output.location();
     let lower = path.to_ascii_lowercase();
     if lower.ends_with(".parquet") {
-        Ok(Box::new(
-            parquet::ParquetFormatWriter::new(output, schema, compression, zstd_level).await?,
-        ))
+        let writer_factory = Box::new(parquet::ParquetPhysicalWriterFactory::new(
+            output,
+            compression,
+            zstd_level,
+        ));
+        shredding::ShreddingFormatWriter::create(
+            writer_factory,
+            schema,
+            write_fields,
+            format_options,
+        )
+        .await
     } else if lower.ends_with(".blob") {
         Ok(Box::new(
             blob::BlobFormatWriter::new(output, file_io).await?,

--- a/crates/paimon/src/arrow/format/parquet.rs
+++ b/crates/paimon/src/arrow/format/parquet.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use super::shredding::PhysicalFormatWriterFactory;
 use super::{FilePredicates, FormatFileReader, FormatFileWriter};
 use crate::arrow::filtering::{predicates_may_match_with_schema, StatsAccessor};
 use crate::io::{FileRead, OutputFile};
@@ -63,6 +64,36 @@ pub(crate) struct ParquetFormatWriter {
     inner: AsyncArrowWriter<Box<dyn crate::io::AsyncFileWrite>>,
 }
 
+pub(crate) struct ParquetPhysicalWriterFactory {
+    output: OutputFile,
+    compression: String,
+    zstd_level: i32,
+}
+
+impl ParquetPhysicalWriterFactory {
+    pub(crate) fn new(output: &OutputFile, compression: &str, zstd_level: i32) -> Self {
+        Self {
+            output: output.clone(),
+            compression: compression.to_string(),
+            zstd_level,
+        }
+    }
+}
+
+#[async_trait]
+impl PhysicalFormatWriterFactory for ParquetPhysicalWriterFactory {
+    async fn create_writer(
+        &mut self,
+        schema: arrow_schema::SchemaRef,
+        _write_fields: Option<&[DataField]>,
+    ) -> crate::Result<Box<dyn FormatFileWriter>> {
+        Ok(Box::new(
+            ParquetFormatWriter::new(&self.output, schema, &self.compression, self.zstd_level)
+                .await?,
+        ))
+    }
+}
+
 impl ParquetFormatWriter {
     pub(crate) async fn new(
         output: &OutputFile,
@@ -72,15 +103,23 @@ impl ParquetFormatWriter {
     ) -> crate::Result<Self> {
         let async_write = output.async_writer().await?;
         let codec = parse_compression(compression, zstd_level);
-        let props = WriterProperties::builder().set_compression(codec).build();
-        let inner = AsyncArrowWriter::try_new(async_write, schema, Some(props)).map_err(|e| {
-            crate::Error::DataInvalid {
-                message: format!("Failed to create parquet writer: {e}"),
-                source: None,
-            }
-        })?;
+        let inner = create_parquet_arrow_writer(async_write, schema, codec)?;
         Ok(Self { inner })
     }
+}
+
+fn create_parquet_arrow_writer(
+    async_write: Box<dyn crate::io::AsyncFileWrite>,
+    schema: arrow_schema::SchemaRef,
+    codec: Compression,
+) -> crate::Result<AsyncArrowWriter<Box<dyn crate::io::AsyncFileWrite>>> {
+    let props = WriterProperties::builder().set_compression(codec).build();
+    AsyncArrowWriter::try_new(async_write, schema, Some(props)).map_err(|e| {
+        crate::Error::DataInvalid {
+            message: format!("Failed to create parquet writer: {e}"),
+            source: None,
+        }
+    })
 }
 
 /// Map Paimon `file.compression` value to parquet [`Compression`].
@@ -222,8 +261,7 @@ impl FormatFileReader for ParquetFormatReader {
             batch_stream_builder = batch_stream_builder.with_batch_size(size);
         }
 
-        let batch_stream = batch_stream_builder.build()?;
-        Ok(batch_stream.map(|r| r.map_err(Error::from)).boxed())
+        Ok(batch_stream_builder.build()?.map_err(Error::from).boxed())
     }
 }
 
@@ -1615,12 +1653,16 @@ mod tests {
         AsyncArrowWriter, PageIndexPolicy, ParquetMetaDataReader, Predicate, PredicateOperator,
         RowSelection,
     };
-    use crate::arrow::format::FormatFileWriter;
+    use crate::arrow::format::{create_format_reader, create_format_writer, FormatFileWriter};
+    use crate::arrow::{build_target_arrow_schema, variant_arrow_type};
     use crate::io::FileIOBuilder;
-    use crate::spec::{DataField, DataType, Datum, IntType, PredicateBuilder};
-    use arrow_array::{Int32Array, RecordBatch};
+    use crate::spec::{DataField, DataType, Datum, IntType, PredicateBuilder, VariantType};
+    use crate::variant::GenericVariant;
+    use arrow_array::{BinaryArray, Int32Array, RecordBatch, StructArray};
     use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+    use futures::TryStreamExt;
     use parquet::schema::{parser::parse_message_type, types::SchemaDescriptor};
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     fn test_fields() -> Vec<DataField> {
@@ -2079,6 +2121,261 @@ mod tests {
             .downcast_ref::<Float32Array>()
             .expect("child should be Float32Array");
         assert_eq!(floats.values(), &[1.0, 2.0]);
+    }
+
+    #[tokio::test]
+    async fn test_parquet_variant_shredding_write_read_roundtrip() {
+        let fields = vec![
+            DataField::new(0, "id".to_string(), DataType::Int(IntType::new())),
+            DataField::new(1, "v".to_string(), DataType::Variant(VariantType::new())),
+        ];
+        let options = HashMap::from([(
+            "parquet.variant.shreddingSchema".to_string(),
+            r#"{"type":"ROW","fields":[{"name":"v","type":{"type":"ROW","fields":[{"name":"age","type":"BIGINT"},{"name":"city","type":"STRING"}]}}]}"#.to_string(),
+        )]);
+        let variants = [
+            GenericVariant::parse_json(r#"{"age":27,"city":"Beijing"}"#).unwrap(),
+            GenericVariant::parse_json(r#"{"age":27}"#).unwrap(),
+            GenericVariant::parse_json(r#"{"city":"Beijing","other":"xxx"}"#).unwrap(),
+            GenericVariant::parse_json(r#"{"age":"27"}"#).unwrap(),
+        ];
+        let value_items = variants
+            .iter()
+            .map(|variant| Some(variant.value()))
+            .collect::<Vec<_>>();
+        let metadata_items = variants
+            .iter()
+            .map(|variant| Some(variant.metadata()))
+            .collect::<Vec<_>>();
+        let variant_fields = match variant_arrow_type() {
+            arrow_schema::DataType::Struct(fields) => fields,
+            _ => unreachable!("variant_arrow_type is a struct"),
+        };
+        let variant_column = StructArray::try_new(
+            variant_fields,
+            vec![
+                Arc::new(BinaryArray::from(value_items)),
+                Arc::new(BinaryArray::from(metadata_items)),
+            ],
+            None,
+        )
+        .unwrap();
+        let logical_schema = build_target_arrow_schema(&fields).unwrap();
+        let batch = RecordBatch::try_new(
+            logical_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+                Arc::new(variant_column),
+            ],
+        )
+        .unwrap();
+
+        let file_io = FileIOBuilder::new("memory").build().unwrap();
+        let path = format!("memory:/variant_shredding_{}.parquet", uuid::Uuid::new_v4());
+        let output = file_io.new_output(&path).unwrap();
+        let mut writer = create_format_writer(
+            &output,
+            logical_schema,
+            "zstd",
+            1,
+            None,
+            Some(&fields),
+            Some(&options),
+        )
+        .await
+        .unwrap();
+        writer.write(&batch).await.unwrap();
+        let file_size = writer.close().await.unwrap();
+
+        let raw_bytes = file_io.new_input(&path).unwrap().read().await.unwrap();
+        let raw_batches =
+            parquet::arrow::arrow_reader::ParquetRecordBatchReader::try_new(raw_bytes, 1024)
+                .unwrap()
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap();
+        let raw_variant_column = raw_batches[0].column_by_name("v").unwrap();
+        let arrow_schema::DataType::Struct(raw_variant_fields) = raw_variant_column.data_type()
+        else {
+            panic!("expected physical variant column to be a struct");
+        };
+        assert!(raw_variant_fields
+            .iter()
+            .any(|field| field.name() == "typed_value"));
+
+        let input = file_io.new_input(&path).unwrap();
+        let file_reader = input.reader().await.unwrap();
+        let reader = create_format_reader(&path, false, &fields).unwrap();
+        let batches = reader
+            .read_batch_stream(Box::new(file_reader), file_size, &fields, None, None, None)
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        let payload = batches[0]
+            .column_by_name("v")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let values = payload
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        let metadata = payload
+            .column_by_name("metadata")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        for (idx, expected) in variants.iter().enumerate() {
+            let actual = GenericVariant::from_parts(
+                values.value(idx).to_vec(),
+                metadata.value(idx).to_vec(),
+            )
+            .unwrap();
+            assert_eq!(actual.to_json().unwrap(), expected.to_json().unwrap());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_parquet_variant_infer_shredding_write_read_roundtrip() {
+        let fields = vec![
+            DataField::new(0, "id".to_string(), DataType::Int(IntType::new())),
+            DataField::new(1, "v".to_string(), DataType::Variant(VariantType::new())),
+        ];
+        let options = HashMap::from([
+            (
+                "variant.inferShreddingSchema".to_string(),
+                "true".to_string(),
+            ),
+            (
+                "variant.shredding.maxInferBufferRow".to_string(),
+                "2".to_string(),
+            ),
+        ]);
+        let first_variants = vec![
+            GenericVariant::parse_json(r#"{"age":27,"city":"Beijing"}"#).unwrap(),
+            GenericVariant::parse_json(r#"{"age":28,"city":"Hangzhou"}"#).unwrap(),
+        ];
+        let late_variants =
+            vec![GenericVariant::parse_json(r#"{"age":"old","city":"Shanghai"}"#).unwrap()];
+        let logical_schema = build_target_arrow_schema(&fields).unwrap();
+        let make_batch = |ids: Vec<i32>, variants: &[GenericVariant]| {
+            let value_items = variants
+                .iter()
+                .map(|variant| Some(variant.value()))
+                .collect::<Vec<_>>();
+            let metadata_items = variants
+                .iter()
+                .map(|variant| Some(variant.metadata()))
+                .collect::<Vec<_>>();
+            let variant_fields = match variant_arrow_type() {
+                arrow_schema::DataType::Struct(fields) => fields,
+                _ => unreachable!("variant_arrow_type is a struct"),
+            };
+            let variant_column = StructArray::try_new(
+                variant_fields,
+                vec![
+                    Arc::new(BinaryArray::from(value_items)),
+                    Arc::new(BinaryArray::from(metadata_items)),
+                ],
+                None,
+            )
+            .unwrap();
+            RecordBatch::try_new(
+                logical_schema.clone(),
+                vec![Arc::new(Int32Array::from(ids)), Arc::new(variant_column)],
+            )
+            .unwrap()
+        };
+
+        let file_io = FileIOBuilder::new("memory").build().unwrap();
+        let path = format!(
+            "memory:/variant_infer_shredding_{}.parquet",
+            uuid::Uuid::new_v4()
+        );
+        let output = file_io.new_output(&path).unwrap();
+        let mut writer = create_format_writer(
+            &output,
+            logical_schema.clone(),
+            "zstd",
+            1,
+            None,
+            Some(&fields),
+            Some(&options),
+        )
+        .await
+        .unwrap();
+        writer
+            .write(&make_batch(vec![1, 2], &first_variants))
+            .await
+            .unwrap();
+        writer
+            .write(&make_batch(vec![3], &late_variants))
+            .await
+            .unwrap();
+        let file_size = writer.close().await.unwrap();
+
+        let raw_bytes = file_io.new_input(&path).unwrap().read().await.unwrap();
+        let raw_batches =
+            parquet::arrow::arrow_reader::ParquetRecordBatchReader::try_new(raw_bytes, 1024)
+                .unwrap()
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap();
+        let raw_variant_column = raw_batches[0].column_by_name("v").unwrap();
+        let arrow_schema::DataType::Struct(raw_variant_fields) = raw_variant_column.data_type()
+        else {
+            panic!("expected physical variant column to be a struct");
+        };
+        assert!(raw_variant_fields
+            .iter()
+            .any(|field| field.name() == "typed_value"));
+
+        let input = file_io.new_input(&path).unwrap();
+        let file_reader = input.reader().await.unwrap();
+        let reader = create_format_reader(&path, false, &fields).unwrap();
+        let batches = reader
+            .read_batch_stream(Box::new(file_reader), file_size, &fields, None, None, None)
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        let payload = batches[0]
+            .column_by_name("v")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let values = payload
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        let metadata = payload
+            .column_by_name("metadata")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        let expected = first_variants
+            .iter()
+            .chain(late_variants.iter())
+            .collect::<Vec<_>>();
+        for (idx, expected) in expected.iter().enumerate() {
+            let actual = GenericVariant::from_parts(
+                values.value(idx).to_vec(),
+                metadata.value(idx).to_vec(),
+            )
+            .unwrap();
+            assert_eq!(actual.to_json().unwrap(), expected.to_json().unwrap());
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/paimon/src/arrow/format/shredding.rs
+++ b/crates/paimon/src/arrow/format/shredding.rs
@@ -1,0 +1,299 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::{FilePredicates, FormatFileReader, FormatFileWriter};
+use crate::arrow::build_target_arrow_schema;
+use crate::arrow::shredding::{
+    assemble_shredded_variant_batch, batch_to_shredded_physical,
+    configured_variant_shredding_fields, contains_variant_fields, infer_variant_shredding_fields,
+    should_infer_variant_shredding_fields, variant_shredding_infer_buffer_row_count,
+};
+use crate::io::FileRead;
+use crate::spec::DataField;
+use crate::table::{ArrowRecordBatchStream, RowRange};
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use futures::StreamExt;
+use std::collections::HashMap;
+
+#[async_trait]
+pub(crate) trait PhysicalFormatWriterFactory: Send {
+    async fn create_writer(
+        &mut self,
+        schema: SchemaRef,
+        write_fields: Option<&[DataField]>,
+    ) -> crate::Result<Box<dyn FormatFileWriter>>;
+}
+
+pub(crate) struct ShreddingFormatReader {
+    inner: Box<dyn FormatFileReader>,
+}
+
+pub(crate) fn maybe_wrap_reader(
+    reader: Box<dyn FormatFileReader>,
+    read_fields: &[DataField],
+) -> Box<dyn FormatFileReader> {
+    if contains_variant_fields(read_fields) {
+        Box::new(ShreddingFormatReader::new(reader))
+    } else {
+        reader
+    }
+}
+
+impl ShreddingFormatReader {
+    pub(crate) fn new(inner: Box<dyn FormatFileReader>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl FormatFileReader for ShreddingFormatReader {
+    async fn read_batch_stream(
+        &self,
+        reader: Box<dyn FileRead>,
+        file_size: u64,
+        read_fields: &[DataField],
+        predicates: Option<&FilePredicates>,
+        batch_size: Option<usize>,
+        row_selection: Option<Vec<RowRange>>,
+    ) -> crate::Result<ArrowRecordBatchStream> {
+        let stream = self
+            .inner
+            .read_batch_stream(
+                reader,
+                file_size,
+                read_fields,
+                predicates,
+                batch_size,
+                row_selection,
+            )
+            .await?;
+        if !contains_variant_fields(read_fields) {
+            return Ok(stream);
+        }
+        let read_fields = read_fields.to_vec();
+        Ok(stream
+            .map(move |batch| match batch {
+                Ok(batch) => assemble_shredded_variant_batch(batch, &read_fields),
+                Err(e) => Err(e),
+            })
+            .boxed())
+    }
+}
+
+pub(crate) struct ShreddingFormatWriter {
+    state: ShreddingWriterState,
+}
+
+enum ShreddingWriterState {
+    Ready {
+        inner: Box<dyn FormatFileWriter>,
+        logical_write_fields: Option<Vec<DataField>>,
+        physical_write_fields: Option<Vec<DataField>>,
+    },
+    Infer {
+        writer_factory: Option<Box<dyn PhysicalFormatWriterFactory>>,
+        schema: SchemaRef,
+        logical_write_fields: Vec<DataField>,
+        format_options: HashMap<String, String>,
+        buffered_batches: Vec<RecordBatch>,
+        buffered_row_count: usize,
+        infer_buffer_row_count: usize,
+    },
+    Closed,
+}
+
+impl ShreddingFormatWriter {
+    pub(crate) async fn create(
+        mut writer_factory: Box<dyn PhysicalFormatWriterFactory>,
+        schema: SchemaRef,
+        write_fields: Option<&[DataField]>,
+        format_options: Option<&HashMap<String, String>>,
+    ) -> crate::Result<Box<dyn FormatFileWriter>> {
+        let Some(fields) = write_fields else {
+            return writer_factory.create_writer(schema, write_fields).await;
+        };
+        if !contains_variant_fields(fields) {
+            return writer_factory.create_writer(schema, write_fields).await;
+        }
+
+        let Some(options) = format_options else {
+            return writer_factory.create_writer(schema, write_fields).await;
+        };
+
+        if let Some(physical_fields) = configured_variant_shredding_fields(fields, options)? {
+            let writer_schema = build_target_arrow_schema(&physical_fields)?;
+            let inner = writer_factory
+                .create_writer(writer_schema, Some(&physical_fields))
+                .await?;
+            return Ok(Box::new(Self {
+                state: ShreddingWriterState::Ready {
+                    inner,
+                    logical_write_fields: Some(fields.to_vec()),
+                    physical_write_fields: Some(physical_fields),
+                },
+            }));
+        }
+
+        if should_infer_variant_shredding_fields(fields, options)? {
+            return Ok(Box::new(Self {
+                state: ShreddingWriterState::Infer {
+                    writer_factory: Some(writer_factory),
+                    schema,
+                    logical_write_fields: fields.to_vec(),
+                    format_options: options.clone(),
+                    buffered_batches: Vec::new(),
+                    buffered_row_count: 0,
+                    infer_buffer_row_count: variant_shredding_infer_buffer_row_count(options)?,
+                },
+            }));
+        }
+
+        writer_factory.create_writer(schema, write_fields).await
+    }
+
+    async fn finalize_inferred_writer(&mut self) -> crate::Result<()> {
+        let (mut writer_factory, schema, logical_write_fields, format_options, buffered_batches) =
+            match &mut self.state {
+                ShreddingWriterState::Ready { .. } => return Ok(()),
+                ShreddingWriterState::Closed => return Ok(()),
+                ShreddingWriterState::Infer {
+                    writer_factory,
+                    schema,
+                    logical_write_fields,
+                    format_options,
+                    buffered_batches,
+                    ..
+                } => (
+                    writer_factory
+                        .take()
+                        .ok_or_else(|| crate::Error::DataInvalid {
+                            message: "Variant shredding writer already finalized".to_string(),
+                            source: None,
+                        })?,
+                    schema.clone(),
+                    logical_write_fields.clone(),
+                    format_options.clone(),
+                    std::mem::take(buffered_batches),
+                ),
+            };
+
+        let physical_write_fields = infer_variant_shredding_fields(
+            &logical_write_fields,
+            &buffered_batches,
+            &format_options,
+        )?;
+        let writer_schema = if let Some(fields) = &physical_write_fields {
+            build_target_arrow_schema(fields)?
+        } else {
+            schema
+        };
+        let inner = writer_factory
+            .create_writer(writer_schema, physical_write_fields.as_deref())
+            .await?;
+        self.state = ShreddingWriterState::Ready {
+            inner,
+            logical_write_fields: physical_write_fields
+                .as_ref()
+                .map(|_| logical_write_fields.clone()),
+            physical_write_fields,
+        };
+
+        for batch in buffered_batches {
+            self.write(&batch).await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl FormatFileWriter for ShreddingFormatWriter {
+    async fn write(&mut self, batch: &RecordBatch) -> crate::Result<()> {
+        match &mut self.state {
+            ShreddingWriterState::Ready {
+                inner,
+                logical_write_fields,
+                physical_write_fields,
+            } => {
+                let physical_batch;
+                let batch_to_write = if let (Some(logical_fields), Some(physical_fields)) =
+                    (logical_write_fields, physical_write_fields)
+                {
+                    physical_batch =
+                        batch_to_shredded_physical(batch, logical_fields, physical_fields)?;
+                    &physical_batch
+                } else {
+                    batch
+                };
+                inner.write(batch_to_write).await
+            }
+            ShreddingWriterState::Infer {
+                buffered_batches,
+                buffered_row_count,
+                infer_buffer_row_count,
+                ..
+            } => {
+                let should_finalize = {
+                    buffered_batches.push(batch.clone());
+                    *buffered_row_count += batch.num_rows();
+                    *buffered_row_count >= *infer_buffer_row_count
+                };
+                if should_finalize {
+                    self.finalize_inferred_writer().await?;
+                }
+                Ok(())
+            }
+            ShreddingWriterState::Closed => Err(crate::Error::DataInvalid {
+                message: "Cannot write to closed shredding writer".to_string(),
+                source: None,
+            }),
+        }
+    }
+
+    fn num_bytes(&self) -> usize {
+        match &self.state {
+            ShreddingWriterState::Ready { inner, .. } => inner.num_bytes(),
+            ShreddingWriterState::Infer { .. } | ShreddingWriterState::Closed => 0,
+        }
+    }
+
+    fn in_progress_size(&self) -> usize {
+        match &self.state {
+            ShreddingWriterState::Ready { inner, .. } => inner.in_progress_size(),
+            ShreddingWriterState::Infer { .. } | ShreddingWriterState::Closed => 0,
+        }
+    }
+
+    async fn flush(&mut self) -> crate::Result<()> {
+        self.finalize_inferred_writer().await?;
+        match &mut self.state {
+            ShreddingWriterState::Ready { inner, .. } => inner.flush().await,
+            ShreddingWriterState::Infer { .. } => unreachable!("infer writer finalized above"),
+            ShreddingWriterState::Closed => Ok(()),
+        }
+    }
+
+    async fn close(mut self: Box<Self>) -> crate::Result<u64> {
+        self.finalize_inferred_writer().await?;
+        match std::mem::replace(&mut self.state, ShreddingWriterState::Closed) {
+            ShreddingWriterState::Ready { inner, .. } => inner.close().await,
+            ShreddingWriterState::Infer { .. } => unreachable!("infer writer finalized above"),
+            ShreddingWriterState::Closed => Ok(0),
+        }
+    }
+}

--- a/crates/paimon/src/arrow/mod.rs
+++ b/crates/paimon/src/arrow/mod.rs
@@ -18,6 +18,7 @@
 pub(crate) mod filtering;
 pub(crate) mod format;
 pub(crate) mod schema_evolution;
+pub(crate) mod shredding;
 
 use crate::spec::{
     ArrayType, BigIntType, BooleanType, DataField, DataType as PaimonDataType, DateType,

--- a/crates/paimon/src/arrow/shredding.rs
+++ b/crates/paimon/src/arrow/shredding.rs
@@ -1,0 +1,1422 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::arrow::{
+    arrow_to_paimon_type, build_target_arrow_schema, is_variant_arrow_fields, paimon_type_to_arrow,
+};
+use crate::spec::{ArrayType, DataField, DataType, RowType};
+use crate::variant::{
+    build_variant_schema, cast_shredded, infer_variant_shredding_schema, rebuild_shredded,
+    variant_shredding_type, GenericVariant, ShreddedRow, ShreddedValue,
+    VariantShreddingInferConfig, VARIANT_METADATA_FIELD_NAME, VARIANT_TYPED_VALUE_FIELD_NAME,
+    VARIANT_VALUE_FIELD_NAME,
+};
+use crate::{Error, Result};
+use arrow_array::{
+    new_null_array, Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array,
+    Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, ListArray,
+    RecordBatch, StringArray, StructArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+    TimestampNanosecondArray,
+};
+use arrow_buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Fields, TimeUnit};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VARIANT_SHREDDING_SCHEMA_OPTION: &str = "variant.shreddingSchema";
+const PARQUET_VARIANT_SHREDDING_SCHEMA_OPTION: &str = "parquet.variant.shreddingSchema";
+const VARIANT_INFER_SHREDDING_SCHEMA_OPTION: &str = "variant.inferShreddingSchema";
+const PARQUET_VARIANT_INFER_SHREDDING_SCHEMA_OPTION: &str = "parquet.variant.inferShreddingSchema";
+const VARIANT_SHREDDING_MAX_INFER_BUFFER_ROW_OPTION: &str = "variant.shredding.maxInferBufferRow";
+const VARIANT_SHREDDING_MAX_SCHEMA_DEPTH_OPTION: &str = "variant.shredding.maxSchemaDepth";
+const VARIANT_SHREDDING_MAX_SCHEMA_WIDTH_OPTION: &str = "variant.shredding.maxSchemaWidth";
+const VARIANT_SHREDDING_MIN_FIELD_CARDINALITY_RATIO_OPTION: &str =
+    "variant.shredding.minFieldCardinalityRatio";
+const DEFAULT_VARIANT_SHREDDING_MAX_INFER_BUFFER_ROW: usize = 4096;
+const DEFAULT_VARIANT_SHREDDING_MAX_SCHEMA_DEPTH: usize = 50;
+const DEFAULT_VARIANT_SHREDDING_MAX_SCHEMA_WIDTH: usize = 300;
+const DEFAULT_VARIANT_SHREDDING_MIN_FIELD_CARDINALITY_RATIO: f64 = 0.1;
+
+pub(crate) fn configured_variant_shredding_fields(
+    logical_fields: &[DataField],
+    options: &HashMap<String, String>,
+) -> Result<Option<Vec<DataField>>> {
+    let Some(configured) = configured_shredding_schema(options)? else {
+        return Ok(None);
+    };
+    let physical = physical_fields_for_configured_shredding(logical_fields, &configured)?;
+    if physical == logical_fields {
+        Ok(None)
+    } else {
+        Ok(Some(physical))
+    }
+}
+
+pub(crate) fn should_infer_variant_shredding_fields(
+    logical_fields: &[DataField],
+    options: &HashMap<String, String>,
+) -> Result<bool> {
+    if has_configured_shredding_schema(options) {
+        return Ok(false);
+    }
+    if !option_bool(
+        options,
+        &[
+            VARIANT_INFER_SHREDDING_SCHEMA_OPTION,
+            PARQUET_VARIANT_INFER_SHREDDING_SCHEMA_OPTION,
+        ],
+        false,
+    )? {
+        return Ok(false);
+    }
+    Ok(contains_variant_fields(logical_fields))
+}
+
+pub(crate) fn variant_shredding_infer_buffer_row_count(
+    options: &HashMap<String, String>,
+) -> Result<usize> {
+    option_usize(
+        options,
+        VARIANT_SHREDDING_MAX_INFER_BUFFER_ROW_OPTION,
+        DEFAULT_VARIANT_SHREDDING_MAX_INFER_BUFFER_ROW,
+    )
+}
+
+pub(crate) fn infer_variant_shredding_fields(
+    logical_fields: &[DataField],
+    sample_batches: &[RecordBatch],
+    options: &HashMap<String, String>,
+) -> Result<Option<Vec<DataField>>> {
+    let paths = paths_to_variant(logical_fields);
+    if paths.is_empty() {
+        return Ok(None);
+    }
+
+    let config = VariantShreddingInferConfig {
+        max_schema_depth: option_usize(
+            options,
+            VARIANT_SHREDDING_MAX_SCHEMA_DEPTH_OPTION,
+            DEFAULT_VARIANT_SHREDDING_MAX_SCHEMA_DEPTH,
+        )?,
+        min_field_cardinality_ratio: option_f64(
+            options,
+            VARIANT_SHREDDING_MIN_FIELD_CARDINALITY_RATIO_OPTION,
+            DEFAULT_VARIANT_SHREDDING_MIN_FIELD_CARDINALITY_RATIO,
+        )?,
+    };
+    let mut max_fields_remaining = option_usize(
+        options,
+        VARIANT_SHREDDING_MAX_SCHEMA_WIDTH_OPTION,
+        DEFAULT_VARIANT_SHREDDING_MAX_SCHEMA_WIDTH,
+    )?;
+
+    let row_type = RowType::new(logical_fields.to_vec());
+    let mut inferred_types = HashMap::new();
+    for path in paths {
+        let mut variants = Vec::new();
+        for batch in sample_batches {
+            for row in 0..batch.num_rows() {
+                if let Some(variant) = variant_at_path(batch, &row_type, &path, row)? {
+                    variants.push(variant);
+                }
+            }
+        }
+
+        let inferred =
+            infer_variant_shredding_schema(&variants, &config, &mut max_fields_remaining)?;
+        if !matches!(inferred, DataType::Variant(_)) {
+            inferred_types.insert(path, variant_shredding_type(&inferred)?);
+        }
+    }
+
+    let physical = update_inferred_variant_schema(&row_type, &inferred_types, &[])?;
+    let physical_fields = physical.fields().to_vec();
+    if physical_fields == logical_fields {
+        Ok(None)
+    } else {
+        Ok(Some(physical_fields))
+    }
+}
+
+fn has_configured_shredding_schema(options: &HashMap<String, String>) -> bool {
+    options.contains_key(VARIANT_SHREDDING_SCHEMA_OPTION)
+        || options.contains_key(PARQUET_VARIANT_SHREDDING_SCHEMA_OPTION)
+}
+
+fn configured_shredding_schema(options: &HashMap<String, String>) -> Result<Option<RowType>> {
+    let Some(raw) = options
+        .get(VARIANT_SHREDDING_SCHEMA_OPTION)
+        .or_else(|| options.get(PARQUET_VARIANT_SHREDDING_SCHEMA_OPTION))
+    else {
+        return Ok(None);
+    };
+    let mut value: serde_json::Value =
+        serde_json::from_str(raw).map_err(|e| Error::DataInvalid {
+            message: format!("Invalid variant shredding schema JSON: {e}"),
+            source: Some(Box::new(e)),
+        })?;
+    add_missing_field_ids(&mut value);
+    let data_type: DataType = serde_json::from_value(value).map_err(|e| Error::DataInvalid {
+        message: format!("Invalid variant shredding schema JSON: {e}"),
+        source: Some(Box::new(e)),
+    })?;
+    match data_type {
+        DataType::Row(row) => Ok(Some(row)),
+        other => Err(Error::DataInvalid {
+            message: format!("Invalid variant shredding schema: expected ROW, got {other:?}"),
+            source: None,
+        }),
+    }
+}
+
+fn add_missing_field_ids(value: &mut serde_json::Value) {
+    let serde_json::Value::Object(map) = value else {
+        return;
+    };
+
+    if let Some(serde_json::Value::Array(fields)) = map.get_mut("fields") {
+        for (idx, field) in fields.iter_mut().enumerate() {
+            let serde_json::Value::Object(field_map) = field else {
+                continue;
+            };
+            field_map
+                .entry("id")
+                .or_insert_with(|| serde_json::Value::Number((idx as i64).into()));
+            if let Some(field_type) = field_map.get_mut("type") {
+                add_missing_field_ids(field_type);
+            }
+        }
+    }
+    if let Some(element) = map.get_mut("element") {
+        add_missing_field_ids(element);
+    }
+    if let Some(key) = map.get_mut("key") {
+        add_missing_field_ids(key);
+    }
+    if let Some(value) = map.get_mut("value") {
+        add_missing_field_ids(value);
+    }
+}
+
+fn option_bool(
+    options: &HashMap<String, String>,
+    keys: &[&str],
+    default_value: bool,
+) -> Result<bool> {
+    let Some(value) = keys.iter().find_map(|key| options.get(*key)) else {
+        return Ok(default_value);
+    };
+    value.parse::<bool>().map_err(|e| Error::DataInvalid {
+        message: format!("Invalid boolean option value '{value}'"),
+        source: Some(Box::new(e)),
+    })
+}
+
+fn option_usize(
+    options: &HashMap<String, String>,
+    key: &str,
+    default_value: usize,
+) -> Result<usize> {
+    let Some(value) = options.get(key) else {
+        return Ok(default_value);
+    };
+    value.parse::<usize>().map_err(|e| Error::DataInvalid {
+        message: format!("Invalid integer option {key}={value}"),
+        source: Some(Box::new(e)),
+    })
+}
+
+fn option_f64(options: &HashMap<String, String>, key: &str, default_value: f64) -> Result<f64> {
+    let Some(value) = options.get(key) else {
+        return Ok(default_value);
+    };
+    value.parse::<f64>().map_err(|e| Error::DataInvalid {
+        message: format!("Invalid double option {key}={value}"),
+        source: Some(Box::new(e)),
+    })
+}
+
+pub(crate) fn contains_variant_fields(fields: &[DataField]) -> bool {
+    fields.iter().any(|field| match field.data_type() {
+        DataType::Variant(_) => true,
+        DataType::Row(row_type) => contains_variant_fields(row_type.fields()),
+        _ => false,
+    })
+}
+
+fn paths_to_variant(fields: &[DataField]) -> Vec<Vec<usize>> {
+    let mut result = Vec::new();
+    for (idx, field) in fields.iter().enumerate() {
+        match field.data_type() {
+            DataType::Variant(_) => result.push(vec![idx]),
+            DataType::Row(row_type) => {
+                for mut path in paths_to_variant(row_type.fields()) {
+                    path.insert(0, idx);
+                    result.push(path);
+                }
+            }
+            _ => {}
+        }
+    }
+    result
+}
+
+fn variant_at_path(
+    batch: &RecordBatch,
+    row_type: &RowType,
+    path: &[usize],
+    row: usize,
+) -> Result<Option<GenericVariant>> {
+    let Some((&field_idx, rest)) = path.split_first() else {
+        return Ok(None);
+    };
+    let Some(field) = row_type.fields().get(field_idx) else {
+        return Err(Error::DataInvalid {
+            message: "Invalid Variant inference path".to_string(),
+            source: None,
+        });
+    };
+    let Some(array) = batch.columns().get(field_idx) else {
+        return Err(Error::DataInvalid {
+            message: "Variant inference path is outside RecordBatch".to_string(),
+            source: None,
+        });
+    };
+    variant_at_path_in_array(array.as_ref(), field.data_type(), rest, row)
+}
+
+fn variant_at_path_in_array(
+    array: &dyn Array,
+    data_type: &DataType,
+    path: &[usize],
+    row: usize,
+) -> Result<Option<GenericVariant>> {
+    if path.is_empty() {
+        return variant_from_array(array, row);
+    }
+
+    let DataType::Row(row_type) = data_type else {
+        return Err(Error::DataInvalid {
+            message: "Variant inference path must traverse ROW fields".to_string(),
+            source: None,
+        });
+    };
+    if array.is_null(row) {
+        return Ok(None);
+    }
+    let struct_array = array
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| Error::DataInvalid {
+            message: "Variant inference ROW value must be StructArray".to_string(),
+            source: None,
+        })?;
+    let field_idx = path[0];
+    let Some(field) = row_type.fields().get(field_idx) else {
+        return Err(Error::DataInvalid {
+            message: "Invalid nested Variant inference path".to_string(),
+            source: None,
+        });
+    };
+    let Some(child) = struct_array.columns().get(field_idx) else {
+        return Err(Error::DataInvalid {
+            message: "Nested Variant inference path is outside StructArray".to_string(),
+            source: None,
+        });
+    };
+    variant_at_path_in_array(child.as_ref(), field.data_type(), &path[1..], row)
+}
+
+fn variant_from_array(array: &dyn Array, row: usize) -> Result<Option<GenericVariant>> {
+    if array.is_null(row) {
+        return Ok(None);
+    }
+    let input = array
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| Error::DataInvalid {
+            message: "Variant inference value must be StructArray".to_string(),
+            source: None,
+        })?;
+    let values = input
+        .column_by_name(VARIANT_VALUE_FIELD_NAME)
+        .and_then(|array| array.as_any().downcast_ref::<BinaryArray>())
+        .ok_or_else(|| Error::DataInvalid {
+            message: "Variant.value column must be BinaryArray".to_string(),
+            source: None,
+        })?;
+    let metadata = input
+        .column_by_name(VARIANT_METADATA_FIELD_NAME)
+        .and_then(|array| array.as_any().downcast_ref::<BinaryArray>())
+        .ok_or_else(|| Error::DataInvalid {
+            message: "Variant.metadata column must be BinaryArray".to_string(),
+            source: None,
+        })?;
+    GenericVariant::from_parts(values.value(row).to_vec(), metadata.value(row).to_vec()).map(Some)
+}
+
+fn update_inferred_variant_schema(
+    row_type: &RowType,
+    inferred_types: &HashMap<Vec<usize>, DataType>,
+    path: &[usize],
+) -> Result<RowType> {
+    let mut fields = Vec::with_capacity(row_type.fields().len());
+    for (idx, field) in row_type.fields().iter().enumerate() {
+        let mut full_path = path.to_vec();
+        full_path.push(idx);
+        let data_type = match field.data_type() {
+            DataType::Variant(_) => inferred_types
+                .get(&full_path)
+                .cloned()
+                .unwrap_or_else(|| field.data_type().clone()),
+            DataType::Row(child) => {
+                let updated = update_inferred_variant_schema(child, inferred_types, &full_path)?;
+                DataType::Row(updated).copy_with_nullable(field.data_type().is_nullable())?
+            }
+            _ => field.data_type().clone(),
+        };
+        fields.push(data_field_with_type(field, data_type));
+    }
+    Ok(RowType::new(fields))
+}
+
+fn physical_fields_for_configured_shredding(
+    logical_fields: &[DataField],
+    configured: &RowType,
+) -> Result<Vec<DataField>> {
+    logical_fields
+        .iter()
+        .map(|field| {
+            let physical_type = match field.data_type() {
+                DataType::Variant(_) => configured
+                    .fields()
+                    .iter()
+                    .find(|configured_field| configured_field.name() == field.name())
+                    .map(|configured_field| variant_shredding_type(configured_field.data_type()))
+                    .transpose()?
+                    .unwrap_or_else(|| field.data_type().clone()),
+                _ => field.data_type().clone(),
+            };
+            Ok(data_field_with_type(field, physical_type))
+        })
+        .collect()
+}
+
+fn data_field_with_type(field: &DataField, data_type: DataType) -> DataField {
+    DataField::new(field.id(), field.name().to_string(), data_type)
+        .with_description(field.description().map(ToString::to_string))
+}
+
+pub(crate) fn batch_to_shredded_physical(
+    batch: &RecordBatch,
+    logical_fields: &[DataField],
+    physical_fields: &[DataField],
+) -> Result<RecordBatch> {
+    if logical_fields == physical_fields {
+        return Ok(batch.clone());
+    }
+
+    let mut columns = Vec::with_capacity(batch.num_columns());
+    for (idx, logical_field) in logical_fields.iter().enumerate() {
+        let physical_field = &physical_fields[idx];
+        columns.push(array_to_shredded_physical(
+            batch.column(idx).as_ref(),
+            logical_field.data_type(),
+            physical_field.data_type(),
+            logical_field.name(),
+        )?);
+    }
+
+    let schema = build_target_arrow_schema(physical_fields)?;
+    RecordBatch::try_new(schema, columns).map_err(|e| Error::UnexpectedError {
+        message: format!("Failed to build shredded RecordBatch: {e}"),
+        source: Some(Box::new(e)),
+    })
+}
+
+fn array_to_shredded_physical(
+    array: &dyn Array,
+    logical_type: &DataType,
+    physical_type: &DataType,
+    column_name: &str,
+) -> Result<ArrayRef> {
+    if logical_type == physical_type {
+        return Ok(array.slice(0, array.len()));
+    }
+
+    match (logical_type, physical_type) {
+        (DataType::Variant(_), DataType::Row(_)) => shred_variant_array(array, physical_type),
+        (DataType::Row(logical), DataType::Row(physical)) => {
+            row_array_to_shredded_physical(array, logical, physical, column_name)
+        }
+        _ => Err(Error::Unsupported {
+            message: format!("Unsupported variant shredding conversion for column '{column_name}'"),
+        }),
+    }
+}
+
+fn row_array_to_shredded_physical(
+    array: &dyn Array,
+    logical_type: &RowType,
+    physical_type: &RowType,
+    column_name: &str,
+) -> Result<ArrayRef> {
+    if logical_type.fields().len() != physical_type.fields().len() {
+        return Err(Error::DataInvalid {
+            message: format!("Logical and physical ROW field counts differ for '{column_name}'"),
+            source: None,
+        });
+    }
+    let input = array
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| Error::DataInvalid {
+            message: format!("Variant shredding ROW column '{column_name}' must be StructArray"),
+            source: None,
+        })?;
+    let fields: Fields = physical_type
+        .fields()
+        .iter()
+        .map(|field| {
+            Ok(ArrowField::new(
+                field.name(),
+                paimon_type_to_arrow(field.data_type())?,
+                field.data_type().is_nullable(),
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into();
+    let columns = logical_type
+        .fields()
+        .iter()
+        .zip(physical_type.fields())
+        .enumerate()
+        .map(|(idx, (logical_field, physical_field))| {
+            if logical_field.name() != physical_field.name() {
+                return Err(Error::DataInvalid {
+                    message: format!(
+                        "Logical and physical ROW field names differ for '{column_name}'"
+                    ),
+                    source: None,
+                });
+            }
+            array_to_shredded_physical(
+                input.column(idx).as_ref(),
+                logical_field.data_type(),
+                physical_field.data_type(),
+                logical_field.name(),
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    if fields.is_empty() {
+        Ok(Arc::new(StructArray::new_empty_fields(
+            input.len(),
+            input.nulls().cloned(),
+        )))
+    } else {
+        Ok(Arc::new(
+            StructArray::try_new(fields, columns, input.nulls().cloned()).map_err(|e| {
+                Error::UnexpectedError {
+                    message: format!("Failed to build Variant shredded ROW column: {e}"),
+                    source: Some(Box::new(e)),
+                }
+            })?,
+        ))
+    }
+}
+
+fn shred_variant_array(array: &dyn Array, physical_type: &DataType) -> Result<ArrayRef> {
+    let DataType::Row(row_type) = physical_type else {
+        return Err(Error::DataInvalid {
+            message: format!("Variant shredding physical type must be ROW, got {physical_type:?}"),
+            source: None,
+        });
+    };
+    let schema = build_variant_schema(row_type)?;
+    let input = array
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| Error::DataInvalid {
+            message: "Variant column must be a StructArray".to_string(),
+            source: None,
+        })?;
+    let values = input
+        .column_by_name("value")
+        .and_then(|array| array.as_any().downcast_ref::<BinaryArray>())
+        .ok_or_else(|| Error::DataInvalid {
+            message: "Variant.value column must be BinaryArray".to_string(),
+            source: None,
+        })?;
+    let metadata = input
+        .column_by_name("metadata")
+        .and_then(|array| array.as_any().downcast_ref::<BinaryArray>())
+        .ok_or_else(|| Error::DataInvalid {
+            message: "Variant.metadata column must be BinaryArray".to_string(),
+            source: None,
+        })?;
+
+    let mut rows = Vec::with_capacity(input.len());
+    for row in 0..input.len() {
+        if input.is_null(row) {
+            rows.push(None);
+        } else {
+            let variant = GenericVariant::from_parts(
+                values.value(row).to_vec(),
+                metadata.value(row).to_vec(),
+            )?;
+            rows.push(Some(cast_shredded(&variant, &schema)?));
+        }
+    }
+    shredded_rows_to_struct_array(rows, row_type)
+}
+
+pub(crate) fn is_shredded_variant_array(array: &dyn Array) -> bool {
+    let ArrowDataType::Struct(fields) = array.data_type() else {
+        return false;
+    };
+    fields
+        .iter()
+        .any(|field| field.name() == VARIANT_TYPED_VALUE_FIELD_NAME)
+}
+
+pub(crate) fn assemble_shredded_variant_array(array: &dyn Array) -> Result<ArrayRef> {
+    let row_type = match arrow_to_paimon_type(array.data_type(), true)? {
+        DataType::Row(row) => row,
+        other => {
+            return Err(Error::DataInvalid {
+                message: format!("Shredded Variant physical type must be ROW, got {other:?}"),
+                source: None,
+            })
+        }
+    };
+    let schema = build_variant_schema(&row_type)?;
+    let input = array
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| Error::DataInvalid {
+            message: "Shredded Variant column must be a StructArray".to_string(),
+            source: None,
+        })?;
+
+    let mut variants = Vec::with_capacity(input.len());
+    for row in 0..input.len() {
+        if input.is_null(row) {
+            variants.push(None);
+        } else {
+            let shredded =
+                struct_row_at(input, row, &row_type)?.ok_or_else(|| Error::DataInvalid {
+                    message: "Shredded Variant row is null".to_string(),
+                    source: None,
+                })?;
+            variants.push(Some(rebuild_shredded(&shredded, &schema)?));
+        }
+    }
+    variant_array(variants)
+}
+
+pub(crate) fn assemble_shredded_variant_batch(
+    batch: RecordBatch,
+    read_fields: &[DataField],
+) -> Result<RecordBatch> {
+    let schema = batch.schema();
+    let mut changed = false;
+    let mut columns = Vec::with_capacity(batch.num_columns());
+    let mut output_fields = Vec::with_capacity(batch.num_columns());
+    let logical_schema = build_target_arrow_schema(read_fields)?;
+
+    for (idx, arrow_field) in schema.fields().iter().enumerate() {
+        let column = batch.column(idx);
+        let logical_idx = read_fields
+            .iter()
+            .position(|field| field.name() == arrow_field.name());
+
+        if let Some(field_idx) = logical_idx {
+            if let Some(assembled) =
+                assemble_array_to_logical(column.as_ref(), read_fields[field_idx].data_type())?
+            {
+                columns.push(assembled);
+                output_fields.push(logical_schema.field(field_idx).clone());
+                changed = true;
+                continue;
+            }
+        }
+
+        columns.push(column.clone());
+        output_fields.push(arrow_field.as_ref().clone());
+    }
+
+    if !changed {
+        return Ok(batch);
+    }
+
+    RecordBatch::try_new(Arc::new(arrow_schema::Schema::new(output_fields)), columns).map_err(|e| {
+        Error::UnexpectedError {
+            message: format!("Failed to build assembled Variant RecordBatch: {e}"),
+            source: Some(Box::new(e)),
+        }
+    })
+}
+
+fn assemble_array_to_logical(
+    array: &dyn Array,
+    logical_type: &DataType,
+) -> Result<Option<ArrayRef>> {
+    match logical_type {
+        DataType::Variant(_) if is_variant_storage_array(array) => {
+            Ok(Some(assemble_shredded_variant_array(array)?))
+        }
+        DataType::Row(row_type) => assemble_row_array_to_logical(array, row_type),
+        _ => Ok(None),
+    }
+}
+
+fn assemble_row_array_to_logical(
+    array: &dyn Array,
+    row_type: &RowType,
+) -> Result<Option<ArrayRef>> {
+    let ArrowDataType::Struct(_) = array.data_type() else {
+        return Ok(None);
+    };
+    let input = array
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| Error::DataInvalid {
+            message: "Variant assembled ROW column must be StructArray".to_string(),
+            source: None,
+        })?;
+    if input.num_columns() != row_type.fields().len() {
+        return Ok(None);
+    }
+
+    let mut changed = false;
+    let mut columns = Vec::with_capacity(input.num_columns());
+    for (idx, field) in row_type.fields().iter().enumerate() {
+        if let Some(assembled) =
+            assemble_array_to_logical(input.column(idx).as_ref(), field.data_type())?
+        {
+            columns.push(assembled);
+            changed = true;
+        } else {
+            columns.push(input.column(idx).clone());
+        }
+    }
+
+    if !changed {
+        return Ok(None);
+    }
+
+    let fields: Fields = row_type
+        .fields()
+        .iter()
+        .map(|field| {
+            Ok(ArrowField::new(
+                field.name(),
+                paimon_type_to_arrow(field.data_type())?,
+                field.data_type().is_nullable(),
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into();
+    if fields.is_empty() {
+        Ok(Some(Arc::new(StructArray::new_empty_fields(
+            input.len(),
+            input.nulls().cloned(),
+        ))))
+    } else {
+        Ok(Some(Arc::new(
+            StructArray::try_new(fields, columns, input.nulls().cloned()).map_err(|e| {
+                Error::UnexpectedError {
+                    message: format!("Failed to build assembled Variant ROW column: {e}"),
+                    source: Some(Box::new(e)),
+                }
+            })?,
+        )))
+    }
+}
+
+fn is_variant_storage_array(array: &dyn Array) -> bool {
+    let ArrowDataType::Struct(fields) = array.data_type() else {
+        return false;
+    };
+    let has_binary = |name: &str| {
+        fields
+            .iter()
+            .any(|field| field.name() == name && field.data_type() == &ArrowDataType::Binary)
+    };
+    has_binary(VARIANT_VALUE_FIELD_NAME)
+        && has_binary(VARIANT_METADATA_FIELD_NAME)
+        && (!is_variant_arrow_fields(fields) || is_shredded_variant_array(array))
+}
+
+fn shredded_rows_to_struct_array(
+    rows: Vec<Option<ShreddedRow>>,
+    row_type: &RowType,
+) -> Result<ArrayRef> {
+    let values = rows
+        .into_iter()
+        .map(|row| row.map(ShreddedValue::Row))
+        .collect::<Vec<_>>();
+    array_from_values(&values, &DataType::Row(row_type.clone()))
+}
+
+fn array_from_values(values: &[Option<ShreddedValue>], data_type: &DataType) -> Result<ArrayRef> {
+    match data_type {
+        DataType::Boolean(_) => Ok(Arc::new(BooleanArray::from(
+            values
+                .iter()
+                .map(|value| match value {
+                    Some(ShreddedValue::Boolean(v)) => Some(*v),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        ))),
+        DataType::TinyInt(_) => Ok(Arc::new(Int8Array::from(
+            values
+                .iter()
+                .map(|value| match value {
+                    Some(ShreddedValue::Int8(v)) => Some(*v),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        ))),
+        DataType::SmallInt(_) => Ok(Arc::new(Int16Array::from(
+            values
+                .iter()
+                .map(|value| match value {
+                    Some(ShreddedValue::Int16(v)) => Some(*v),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        ))),
+        DataType::Int(_) => Ok(Arc::new(Int32Array::from(
+            values
+                .iter()
+                .map(|value| match value {
+                    Some(ShreddedValue::Int32(v)) => Some(*v),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        ))),
+        DataType::BigInt(_) => Ok(Arc::new(Int64Array::from(
+            values
+                .iter()
+                .map(|value| match value {
+                    Some(ShreddedValue::Int64(v)) => Some(*v),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        ))),
+        DataType::Float(_) => Ok(Arc::new(Float32Array::from(
+            values
+                .iter()
+                .map(|value| match value {
+                    Some(ShreddedValue::Float32(v)) => Some(*v),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        ))),
+        DataType::Double(_) => Ok(Arc::new(Float64Array::from(
+            values
+                .iter()
+                .map(|value| match value {
+                    Some(ShreddedValue::Float64(v)) => Some(*v),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        ))),
+        DataType::Decimal(decimal) => {
+            let array = Decimal128Array::from(
+                values
+                    .iter()
+                    .map(|value| match value {
+                        Some(ShreddedValue::Decimal128(v)) => Some(*v),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .with_precision_and_scale(decimal.precision() as u8, decimal.scale() as i8)
+            .map_err(|e| Error::DataInvalid {
+                message: format!("Failed to build Variant decimal typed_value: {e}"),
+                source: Some(Box::new(e)),
+            })?;
+            Ok(Arc::new(array))
+        }
+        DataType::VarChar(_) | DataType::Char(_) => Ok(Arc::new(StringArray::from(
+            values
+                .iter()
+                .map(|value| match value {
+                    Some(ShreddedValue::String(v)) => Some(v.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        ))),
+        DataType::VarBinary(_) | DataType::Binary(_) | DataType::Blob(_) => {
+            let values = values
+                .iter()
+                .map(|value| match value {
+                    Some(ShreddedValue::Binary(v)) => Some(v.as_slice()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            Ok(Arc::new(BinaryArray::from(values)))
+        }
+        DataType::Date(_) => Ok(Arc::new(Date32Array::from(
+            values
+                .iter()
+                .map(|value| match value {
+                    Some(ShreddedValue::Date32(v)) => Some(*v),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+        ))),
+        DataType::Timestamp(ts) => timestamp_array(values, ts.precision(), None),
+        DataType::LocalZonedTimestamp(ts) => timestamp_array(values, ts.precision(), Some("UTC")),
+        DataType::Row(row_type) => struct_array_from_values(values, row_type),
+        DataType::Array(array_type) => list_array_from_values(values, array_type),
+        other => Ok(new_null_array(&paimon_type_to_arrow(other)?, values.len())),
+    }
+}
+
+fn timestamp_array(
+    values: &[Option<ShreddedValue>],
+    precision: u32,
+    tz: Option<&str>,
+) -> Result<ArrayRef> {
+    let values = values
+        .iter()
+        .map(|value| match value {
+            Some(ShreddedValue::Timestamp(v)) => Some(*v),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    Ok(match precision {
+        0..=3 => Arc::new(TimestampMillisecondArray::from(values).with_timezone_opt(tz)),
+        4..=6 => Arc::new(TimestampMicrosecondArray::from(values).with_timezone_opt(tz)),
+        _ => Arc::new(TimestampNanosecondArray::from(values).with_timezone_opt(tz)),
+    })
+}
+
+fn struct_array_from_values(
+    values: &[Option<ShreddedValue>],
+    row_type: &RowType,
+) -> Result<ArrayRef> {
+    let fields: Fields = row_type
+        .fields()
+        .iter()
+        .map(|field| {
+            Ok(ArrowField::new(
+                field.name(),
+                paimon_type_to_arrow(field.data_type())?,
+                field.data_type().is_nullable(),
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into();
+    let validities = values.iter().map(Option::is_some).collect::<Vec<_>>();
+    let columns = row_type
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(field_idx, field)| {
+            let child_values = values
+                .iter()
+                .map(|value| match value {
+                    Some(ShreddedValue::Row(row)) => {
+                        row.fields().get(field_idx).cloned().unwrap_or(None)
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            array_from_values(&child_values, field.data_type())
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let nulls = Some(null_buffer(validities));
+    if fields.is_empty() {
+        Ok(Arc::new(StructArray::new_empty_fields(values.len(), nulls)))
+    } else {
+        Ok(Arc::new(
+            StructArray::try_new(fields, columns, nulls).map_err(|e| Error::UnexpectedError {
+                message: format!("Failed to build Variant shredded StructArray: {e}"),
+                source: Some(Box::new(e)),
+            })?,
+        ))
+    }
+}
+
+fn list_array_from_values(
+    values: &[Option<ShreddedValue>],
+    array_type: &ArrayType,
+) -> Result<ArrayRef> {
+    let element_type = array_type.element_type();
+    let element_arrow_type = paimon_type_to_arrow(element_type)?;
+    let element_field = Arc::new(ArrowField::new(
+        "element",
+        element_arrow_type,
+        element_type.is_nullable(),
+    ));
+    let mut offsets = Vec::with_capacity(values.len() + 1);
+    offsets.push(0i32);
+    let mut validities = Vec::with_capacity(values.len());
+    let mut flattened = Vec::new();
+    for value in values {
+        match value {
+            Some(ShreddedValue::List(rows)) => {
+                validities.push(true);
+                for row in rows {
+                    flattened.push(Some(ShreddedValue::Row(row.clone())));
+                }
+                let next = *offsets.last().unwrap()
+                    + i32::try_from(rows.len()).map_err(|e| Error::DataInvalid {
+                        message: "Variant shredded array has too many elements".to_string(),
+                        source: Some(Box::new(e)),
+                    })?;
+                offsets.push(next);
+            }
+            _ => {
+                validities.push(false);
+                offsets.push(*offsets.last().unwrap());
+            }
+        }
+    }
+    let child = array_from_values(&flattened, element_type)?;
+    Ok(Arc::new(
+        ListArray::try_new(
+            element_field,
+            OffsetBuffer::new(ScalarBuffer::from(offsets)),
+            child,
+            Some(null_buffer(validities)),
+        )
+        .map_err(|e| Error::UnexpectedError {
+            message: format!("Failed to build Variant shredded ListArray: {e}"),
+            source: Some(Box::new(e)),
+        })?,
+    ))
+}
+
+fn struct_row_at(
+    array: &StructArray,
+    row: usize,
+    row_type: &RowType,
+) -> Result<Option<ShreddedRow>> {
+    if array.is_null(row) {
+        return Ok(None);
+    }
+    let mut shredded = ShreddedRow::new(row_type.fields().len());
+    for (field_idx, field) in row_type.fields().iter().enumerate() {
+        if let Some(value) = value_at(array.column(field_idx).as_ref(), row, field.data_type())? {
+            shredded.set(field_idx, value)?;
+        }
+    }
+    Ok(Some(shredded))
+}
+
+fn value_at(array: &dyn Array, row: usize, data_type: &DataType) -> Result<Option<ShreddedValue>> {
+    if array.is_null(row) {
+        return Ok(None);
+    }
+    Ok(match data_type {
+        DataType::Boolean(_) => Some(ShreddedValue::Boolean(
+            downcast_array::<BooleanArray>(array, "Boolean")?.value(row),
+        )),
+        DataType::TinyInt(_) => Some(ShreddedValue::Int8(
+            downcast_array::<Int8Array>(array, "TinyInt")?.value(row),
+        )),
+        DataType::SmallInt(_) => Some(ShreddedValue::Int16(
+            downcast_array::<Int16Array>(array, "SmallInt")?.value(row),
+        )),
+        DataType::Int(_) => Some(ShreddedValue::Int32(
+            downcast_array::<Int32Array>(array, "Int")?.value(row),
+        )),
+        DataType::BigInt(_) => Some(ShreddedValue::Int64(
+            downcast_array::<Int64Array>(array, "BigInt")?.value(row),
+        )),
+        DataType::Float(_) => Some(ShreddedValue::Float32(
+            downcast_array::<Float32Array>(array, "Float")?.value(row),
+        )),
+        DataType::Double(_) => Some(ShreddedValue::Float64(
+            downcast_array::<Float64Array>(array, "Double")?.value(row),
+        )),
+        DataType::Decimal(_) => Some(ShreddedValue::Decimal128(
+            downcast_array::<Decimal128Array>(array, "Decimal")?.value(row),
+        )),
+        DataType::VarChar(_) | DataType::Char(_) => Some(ShreddedValue::String(
+            downcast_array::<StringArray>(array, "String")?
+                .value(row)
+                .to_string(),
+        )),
+        DataType::VarBinary(_) | DataType::Binary(_) | DataType::Blob(_) => {
+            Some(ShreddedValue::Binary(
+                downcast_array::<BinaryArray>(array, "Binary")?
+                    .value(row)
+                    .to_vec(),
+            ))
+        }
+        DataType::Date(_) => Some(ShreddedValue::Date32(
+            downcast_array::<Date32Array>(array, "Date")?.value(row),
+        )),
+        DataType::Timestamp(_) | DataType::LocalZonedTimestamp(_) => {
+            Some(ShreddedValue::Timestamp(timestamp_value_at(array, row)?))
+        }
+        DataType::Row(row_type) => {
+            let struct_array = downcast_array::<StructArray>(array, "Struct")?;
+            struct_row_at(struct_array, row, row_type)?.map(ShreddedValue::Row)
+        }
+        DataType::Array(array_type) => {
+            let list = downcast_array::<ListArray>(array, "List")?;
+            let child = list.value(row);
+            let DataType::Row(element_row_type) = array_type.element_type() else {
+                return Err(Error::DataInvalid {
+                    message: "Variant shredded array element must be ROW".to_string(),
+                    source: None,
+                });
+            };
+            let child_struct = child
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .ok_or_else(|| Error::DataInvalid {
+                    message: "Variant shredded array values must be StructArray".to_string(),
+                    source: None,
+                })?;
+            let mut rows = Vec::with_capacity(child_struct.len());
+            for idx in 0..child_struct.len() {
+                rows.push(
+                    struct_row_at(child_struct, idx, element_row_type)?.ok_or_else(|| {
+                        Error::DataInvalid {
+                            message: "Variant shredded array element row is null".to_string(),
+                            source: None,
+                        }
+                    })?,
+                );
+            }
+            Some(ShreddedValue::List(rows))
+        }
+        _ => None,
+    })
+}
+
+fn timestamp_value_at(array: &dyn Array, row: usize) -> Result<i64> {
+    match array.data_type() {
+        ArrowDataType::Timestamp(TimeUnit::Millisecond, _) => {
+            Ok(downcast_array::<TimestampMillisecondArray>(array, "TimestampMs")?.value(row))
+        }
+        ArrowDataType::Timestamp(TimeUnit::Microsecond, _) => {
+            Ok(downcast_array::<TimestampMicrosecondArray>(array, "TimestampUs")?.value(row))
+        }
+        ArrowDataType::Timestamp(TimeUnit::Nanosecond, _) => {
+            Ok(downcast_array::<TimestampNanosecondArray>(array, "TimestampNs")?.value(row))
+        }
+        other => Err(Error::DataInvalid {
+            message: format!("Unsupported Variant shredded timestamp array: {other:?}"),
+            source: None,
+        }),
+    }
+}
+
+fn downcast_array<'a, T: 'static>(array: &'a dyn Array, name: &str) -> Result<&'a T> {
+    array
+        .as_any()
+        .downcast_ref::<T>()
+        .ok_or_else(|| Error::DataInvalid {
+            message: format!(
+                "Expected Variant shredded {name} array, got {:?}",
+                array.data_type()
+            ),
+            source: None,
+        })
+}
+
+fn variant_array(values: Vec<Option<GenericVariant>>) -> Result<ArrayRef> {
+    let len = values.len();
+    let mut value_items: Vec<Option<&[u8]>> = Vec::with_capacity(len);
+    let mut metadata_items: Vec<Option<&[u8]>> = Vec::with_capacity(len);
+    let mut validities = Vec::with_capacity(len);
+    for value in &values {
+        match value {
+            Some(variant) => {
+                value_items.push(Some(variant.value()));
+                metadata_items.push(Some(variant.metadata()));
+                validities.push(true);
+            }
+            None => {
+                value_items.push(Some(&[]));
+                metadata_items.push(Some(&[]));
+                validities.push(false);
+            }
+        }
+    }
+    Ok(Arc::new(
+        StructArray::try_new(
+            match crate::arrow::variant_arrow_type() {
+                ArrowDataType::Struct(fields) => fields,
+                _ => unreachable!("variant_arrow_type always returns Struct"),
+            },
+            vec![
+                Arc::new(BinaryArray::from(value_items)),
+                Arc::new(BinaryArray::from(metadata_items)),
+            ],
+            Some(null_buffer(validities)),
+        )
+        .map_err(|e| Error::UnexpectedError {
+            message: format!("Failed to build Variant array: {e}"),
+            source: Some(Box::new(e)),
+        })?,
+    ))
+}
+
+fn null_buffer(validities: Vec<bool>) -> NullBuffer {
+    NullBuffer::new(BooleanBuffer::from(validities))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arrow::variant_arrow_type;
+    use crate::spec::{IntType, VariantType};
+
+    fn variant_array_for_test(values: &[GenericVariant]) -> ArrayRef {
+        let value_items = values
+            .iter()
+            .map(|variant| Some(variant.value()))
+            .collect::<Vec<_>>();
+        let metadata_items = values
+            .iter()
+            .map(|variant| Some(variant.metadata()))
+            .collect::<Vec<_>>();
+        let fields = match variant_arrow_type() {
+            ArrowDataType::Struct(fields) => fields,
+            _ => unreachable!("variant_arrow_type is a struct"),
+        };
+        Arc::new(
+            StructArray::try_new(
+                fields,
+                vec![
+                    Arc::new(BinaryArray::from(value_items)),
+                    Arc::new(BinaryArray::from(metadata_items)),
+                ],
+                None,
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn configured_schema_transforms_and_reassembles_variant_batch() {
+        let logical_fields = vec![
+            DataField::new(0, "id".to_string(), DataType::Int(IntType::new())),
+            DataField::new(1, "v".to_string(), DataType::Variant(VariantType::new())),
+        ];
+        let options = HashMap::from([(
+            "parquet.variant.shreddingSchema".to_string(),
+            r#"{"type":"ROW","fields":[{"name":"v","type":{"type":"ROW","fields":[{"name":"age","type":"BIGINT"},{"name":"city","type":"STRING"}]}}]}"#.to_string(),
+        )]);
+        let physical_fields = configured_variant_shredding_fields(&logical_fields, &options)
+            .unwrap()
+            .expect("shredding fields");
+        assert_ne!(logical_fields, physical_fields);
+
+        let variants = vec![
+            GenericVariant::parse_json(r#"{"age":27,"city":"Beijing"}"#).unwrap(),
+            GenericVariant::parse_json(r#"{"city":"Hangzhou","other":"x"}"#).unwrap(),
+            GenericVariant::parse_json(r#"{"age":"old"}"#).unwrap(),
+        ];
+        let batch = RecordBatch::try_new(
+            build_target_arrow_schema(&logical_fields).unwrap(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                variant_array_for_test(&variants),
+            ],
+        )
+        .unwrap();
+
+        let physical =
+            batch_to_shredded_physical(&batch, &logical_fields, &physical_fields).unwrap();
+        assert!(is_shredded_variant_array(physical.column(1).as_ref()));
+
+        let assembled = assemble_shredded_variant_array(physical.column(1).as_ref()).unwrap();
+        let assembled = assembled.as_any().downcast_ref::<StructArray>().unwrap();
+        let values = assembled
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        let metadata = assembled
+            .column_by_name("metadata")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        for (idx, expected) in variants.iter().enumerate() {
+            let actual = GenericVariant::from_parts(
+                values.value(idx).to_vec(),
+                metadata.value(idx).to_vec(),
+            )
+            .unwrap();
+            assert_eq!(actual.to_json().unwrap(), expected.to_json().unwrap());
+        }
+    }
+
+    #[test]
+    fn configured_schema_noops_when_no_variant_field_matches() {
+        let logical_fields = vec![DataField::new(
+            0,
+            "id".to_string(),
+            DataType::Int(IntType::new()),
+        )];
+        let options = HashMap::from([(
+            "variant.shreddingSchema".to_string(),
+            r#"{"type":"ROW","fields":[{"name":"v","type":{"type":"ROW","fields":[{"name":"age","type":"BIGINT"}]}}]}"#.to_string(),
+        )]);
+        assert!(
+            configured_variant_shredding_fields(&logical_fields, &options)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn inferred_schema_transforms_and_reassembles_variant_batch() {
+        let logical_fields = vec![
+            DataField::new(0, "id".to_string(), DataType::Int(IntType::new())),
+            DataField::new(1, "v".to_string(), DataType::Variant(VariantType::new())),
+        ];
+        let variants = vec![
+            GenericVariant::parse_json(r#"{"age":30,"name":"Alice"}"#).unwrap(),
+            GenericVariant::parse_json(r#"{"age":25,"name":"Bob"}"#).unwrap(),
+            GenericVariant::parse_json(r#"{"age":35,"name":"Charlie"}"#).unwrap(),
+        ];
+        let batch = RecordBatch::try_new(
+            build_target_arrow_schema(&logical_fields).unwrap(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                variant_array_for_test(&variants),
+            ],
+        )
+        .unwrap();
+        let options = HashMap::from([(
+            "variant.inferShreddingSchema".to_string(),
+            "true".to_string(),
+        )]);
+
+        let physical_fields =
+            infer_variant_shredding_fields(&logical_fields, std::slice::from_ref(&batch), &options)
+                .unwrap()
+                .expect("inferred shredding fields");
+        let DataType::Row(variant_row) = physical_fields[1].data_type() else {
+            panic!("expected inferred variant field to become ROW");
+        };
+        let typed_value = variant_row
+            .fields()
+            .iter()
+            .find(|field| field.name() == VARIANT_TYPED_VALUE_FIELD_NAME)
+            .expect("typed_value field");
+        let DataType::Row(object_row) = typed_value.data_type() else {
+            panic!("expected typed_value object ROW");
+        };
+        assert_eq!(
+            object_row
+                .fields()
+                .iter()
+                .map(|field| field.name())
+                .collect::<Vec<_>>(),
+            vec!["age", "name"]
+        );
+
+        let physical =
+            batch_to_shredded_physical(&batch, &logical_fields, &physical_fields).unwrap();
+        assert!(is_shredded_variant_array(physical.column(1).as_ref()));
+        let assembled =
+            assemble_shredded_variant_batch(physical, &logical_fields).expect("assembled");
+        let assembled = assembled
+            .column_by_name("v")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let values = assembled
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        let metadata = assembled
+            .column_by_name("metadata")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        for (idx, expected) in variants.iter().enumerate() {
+            let actual = GenericVariant::from_parts(
+                values.value(idx).to_vec(),
+                metadata.value(idx).to_vec(),
+            )
+            .unwrap();
+            assert_eq!(actual.to_json().unwrap(), expected.to_json().unwrap());
+        }
+    }
+
+    #[test]
+    fn inferred_schema_converts_nested_row_variant() {
+        let nested_row = RowType::new(vec![DataField::new(
+            0,
+            "v".to_string(),
+            DataType::Variant(VariantType::new()),
+        )]);
+        let logical_fields = vec![DataField::new(
+            0,
+            "payload".to_string(),
+            DataType::Row(nested_row),
+        )];
+        let variants = vec![
+            GenericVariant::parse_json(r#"{"score":1}"#).unwrap(),
+            GenericVariant::parse_json(r#"{"score":2}"#).unwrap(),
+        ];
+        let row_arrow_type = paimon_type_to_arrow(logical_fields[0].data_type()).unwrap();
+        let ArrowDataType::Struct(row_fields) = row_arrow_type else {
+            panic!("expected ROW arrow type");
+        };
+        let payload =
+            StructArray::try_new(row_fields, vec![variant_array_for_test(&variants)], None)
+                .unwrap();
+        let batch = RecordBatch::try_new(
+            build_target_arrow_schema(&logical_fields).unwrap(),
+            vec![Arc::new(payload)],
+        )
+        .unwrap();
+        let options = HashMap::from([(
+            "variant.inferShreddingSchema".to_string(),
+            "true".to_string(),
+        )]);
+
+        let physical_fields =
+            infer_variant_shredding_fields(&logical_fields, std::slice::from_ref(&batch), &options)
+                .unwrap()
+                .expect("nested inferred shredding fields");
+        let physical =
+            batch_to_shredded_physical(&batch, &logical_fields, &physical_fields).unwrap();
+        let assembled =
+            assemble_shredded_variant_batch(physical, &logical_fields).expect("assembled");
+        assert_eq!(
+            assembled.schema().field(0).data_type(),
+            build_target_arrow_schema(&logical_fields)
+                .unwrap()
+                .field(0)
+                .data_type()
+        );
+    }
+}

--- a/crates/paimon/src/table/blob_file_writer.rs
+++ b/crates/paimon/src/table/blob_file_writer.rs
@@ -21,7 +21,7 @@ use crate::table::data_file_writer::DataFileWriter;
 use crate::Result;
 use arrow_array::builder::BinaryBuilder;
 use arrow_array::{Array, RecordBatch};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 pub(crate) fn is_blob_file_name(file_name: &str) -> bool {
@@ -65,6 +65,7 @@ impl AppendBlobFileWriter {
         file_format: String,
         input_schema: &arrow_schema::Schema,
         table_fields: &[crate::spec::DataField],
+        format_options: &HashMap<String, String>,
         blob_descriptor_fields: &HashSet<String>,
     ) -> Self {
         let mut normal_column_indices = Vec::new();
@@ -90,6 +91,7 @@ impl AppendBlobFileWriter {
                         write_buffer_size,
                         "blob".to_string(),
                         vec![field.clone()],
+                        HashMap::new(),
                         Some(0),
                         None,
                         Some(vec![field.name().to_string()]),
@@ -118,6 +120,7 @@ impl AppendBlobFileWriter {
             write_buffer_size,
             file_format,
             normal_table_fields,
+            format_options.clone(),
             Some(0),
             None,
             None,

--- a/crates/paimon/src/table/cow_writer.rs
+++ b/crates/paimon/src/table/cow_writer.rs
@@ -300,6 +300,7 @@ impl CopyOnWriteMergeWriter {
                         write_buffer_size,
                         file_format.to_string(),
                         write_fields.to_vec(),
+                        schema.options().clone(),
                         Some(0),
                         None,
                         None,

--- a/crates/paimon/src/table/data_evolution_reader.rs
+++ b/crates/paimon/src/table/data_evolution_reader.rs
@@ -2735,9 +2735,10 @@ mod tests {
             )]));
             let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(array)]).unwrap();
             let output = file_io.new_output(&local_file_path(&vector_path)).unwrap();
-            let mut writer = create_format_writer(&output, arrow_schema, "zstd", 1, None, None)
-                .await
-                .unwrap();
+            let mut writer =
+                create_format_writer(&output, arrow_schema, "zstd", 1, None, None, None)
+                    .await
+                    .unwrap();
             writer.write(&batch).await.unwrap();
             writer.close().await.unwrap();
         }

--- a/crates/paimon/src/table/data_evolution_writer.rs
+++ b/crates/paimon/src/table/data_evolution_writer.rs
@@ -907,6 +907,7 @@ pub(crate) struct DataEvolutionPartialWriter {
     file_compression_zstd_level: i32,
     write_buffer_size: i64,
     file_format: String,
+    format_options: HashMap<String, String>,
     write_fields: Vec<DataField>,
     write_columns: Vec<String>,
     /// Writers keyed by (partition_bytes, bucket, first_row_id).
@@ -962,6 +963,7 @@ impl DataEvolutionPartialWriter {
             file_compression_zstd_level: core_options.file_compression_zstd_level(),
             write_buffer_size: core_options.write_parquet_buffer_size(),
             file_format: core_options.file_format().to_string(),
+            format_options: schema.options().clone(),
             write_fields,
             write_columns,
             writers: HashMap::new(),
@@ -1010,6 +1012,7 @@ impl DataEvolutionPartialWriter {
                 self.write_buffer_size,
                 self.file_format.clone(),
                 self.write_fields.clone(),
+                self.format_options.clone(),
                 Some(0), // file_source: APPEND
                 Some(first_row_id),
                 Some(self.write_columns.clone()),

--- a/crates/paimon/src/table/data_file_reader.rs
+++ b/crates/paimon/src/table/data_file_reader.rs
@@ -208,7 +208,8 @@ impl DataFileReader {
 
         Ok(try_stream! {
             let path_to_read = split.data_file_path(&file_meta);
-            let format_reader = create_format_reader(&path_to_read, blob_as_descriptor)?;
+            let format_reader =
+                create_format_reader(&path_to_read, blob_as_descriptor, &format_read_fields)?;
             let input_file = file_io.new_input(&path_to_read)?;
             let file_reader = input_file.reader().await?;
             let local_ranges = row_ranges.as_ref().map(|ranges| {
@@ -614,7 +615,7 @@ mod row_tests {
         let file_name = "part-0.row";
         let file_path = format!("{bucket_path}/{file_name}");
         let output = file_io.new_output(&file_path).unwrap();
-        let mut writer = create_format_writer(&output, schema, "zstd", 1, None, None)
+        let mut writer = create_format_writer(&output, schema, "zstd", 1, None, None, None)
             .await
             .unwrap();
         writer.write(&batch).await.unwrap();

--- a/crates/paimon/src/table/data_file_writer.rs
+++ b/crates/paimon/src/table/data_file_writer.rs
@@ -29,6 +29,7 @@ use crate::spec::{bucket_dir_name, DataField, DataFileMeta, EMPTY_SERIALIZED_ROW
 use crate::Result;
 use arrow_array::RecordBatch;
 use chrono::Utc;
+use std::collections::HashMap;
 use tokio::task::JoinSet;
 
 /// Low-level writer that produces Parquet data files for a single (partition, bucket).
@@ -50,6 +51,7 @@ pub(crate) struct DataFileWriter {
     write_buffer_size: i64,
     file_format: String,
     write_fields: Vec<DataField>,
+    format_options: HashMap<String, String>,
     file_source: Option<i32>,
     first_row_id: Option<i64>,
     write_cols: Option<Vec<String>>,
@@ -76,6 +78,7 @@ impl DataFileWriter {
         write_buffer_size: i64,
         file_format: String,
         write_fields: Vec<DataField>,
+        format_options: HashMap<String, String>,
         file_source: Option<i32>,
         first_row_id: Option<i64>,
         write_cols: Option<Vec<String>>,
@@ -92,6 +95,7 @@ impl DataFileWriter {
             write_buffer_size,
             file_format,
             write_fields,
+            format_options,
             file_source,
             first_row_id,
             write_cols,
@@ -160,6 +164,7 @@ impl DataFileWriter {
             self.file_compression_zstd_level,
             Some(self.file_io.clone()),
             Some(&self.write_fields),
+            Some(&self.format_options),
         )
         .await?;
         self.current_writer = Some(writer);

--- a/crates/paimon/src/table/kv_file_writer.rs
+++ b/crates/paimon/src/table/kv_file_writer.rs
@@ -359,6 +359,7 @@ impl KeyValueFileWriter {
             self.config.file_compression_zstd_level,
             None,
             None,
+            None,
         )
         .await?;
 

--- a/crates/paimon/src/table/postpone_file_writer.rs
+++ b/crates/paimon/src/table/postpone_file_writer.rs
@@ -230,6 +230,7 @@ impl PostponeFileWriter {
             self.config.file_compression_zstd_level,
             None,
             None,
+            None,
         )
         .await?;
         self.current_writer = Some(writer);

--- a/crates/paimon/src/table/table_write.rs
+++ b/crates/paimon/src/table/table_write.rs
@@ -641,6 +641,7 @@ impl TableWrite {
                 self.file_format.clone(),
                 &input_schema,
                 fields,
+                self.table.schema().options(),
                 &self.blob_descriptor_fields,
             )))
         } else {
@@ -656,6 +657,7 @@ impl TableWrite {
                 self.write_buffer_size,
                 self.file_format.clone(),
                 self.table.schema().fields().to_vec(),
+                self.table.schema().options().clone(),
                 Some(0),
                 None,
                 None,
@@ -909,10 +911,10 @@ mod tests {
         file_path: &str,
         file_size: i64,
     ) -> Vec<RecordBatch> {
-        let format_reader = create_format_reader(file_path, false).unwrap();
+        let read_fields = physical_key_value_fields();
+        let format_reader = create_format_reader(file_path, false, &read_fields).unwrap();
         let input = file_io.new_input(file_path).unwrap();
         let file_reader = input.reader().await.unwrap();
-        let read_fields = physical_key_value_fields();
         let stream = format_reader
             .read_batch_stream(
                 Box::new(file_reader),
@@ -1055,7 +1057,8 @@ mod tests {
             bucket_dir_name(messages[0].bucket),
             data_file.file_name
         );
-        let format_reader = create_format_reader(&file_path, false).unwrap();
+        let format_reader =
+            create_format_reader(&file_path, false, table.schema().fields()).unwrap();
         let input = file_io.new_input(&file_path).unwrap();
         let stream = format_reader
             .read_batch_stream(

--- a/crates/paimon/src/variant.rs
+++ b/crates/paimon/src/variant.rs
@@ -19,6 +19,11 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::spec::{
+    ArrayType, BigIntType, BooleanType, DataField, DataType, DateType, DecimalType, DoubleType,
+    FloatType, LocalZonedTimestampType, RowType, TimestampType, VarBinaryType, VarCharType,
+    VariantType,
+};
 use crate::{Error, Result};
 use base64::{engine::general_purpose, Engine as _};
 
@@ -204,6 +209,10 @@ impl<'a> VariantRef<'a> {
         get_decimal(self.value, self.pos)
     }
 
+    pub fn get_binary(&self) -> Result<&'a [u8]> {
+        get_binary(self.value, self.pos)
+    }
+
     pub fn to_json(&self) -> Result<String> {
         let mut out = String::new();
         write_json(self.value, self.metadata, self.pos, &mut out)?;
@@ -276,6 +285,104 @@ impl<'a> VariantRef<'a> {
             layout.offset_size,
         )?;
         VariantRef::new_at(self.value, self.metadata, layout.data_start + offset).map(Some)
+    }
+}
+
+pub(crate) const VARIANT_METADATA_FIELD_NAME: &str = "metadata";
+pub(crate) const VARIANT_VALUE_FIELD_NAME: &str = "value";
+pub(crate) const VARIANT_TYPED_VALUE_FIELD_NAME: &str = "typed_value";
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ShreddedValue {
+    Boolean(bool),
+    Int8(i8),
+    Int16(i16),
+    Int32(i32),
+    Int64(i64),
+    Float32(f32),
+    Float64(f64),
+    Decimal128(i128),
+    String(String),
+    Binary(Vec<u8>),
+    Date32(i32),
+    Timestamp(i64),
+    Row(ShreddedRow),
+    List(Vec<ShreddedRow>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ShreddedRow {
+    fields: Vec<Option<ShreddedValue>>,
+}
+
+impl ShreddedRow {
+    pub(crate) fn new(num_fields: usize) -> Self {
+        Self {
+            fields: vec![None; num_fields],
+        }
+    }
+
+    pub(crate) fn field(&self, idx: usize) -> Option<&ShreddedValue> {
+        self.fields.get(idx)?.as_ref()
+    }
+
+    pub(crate) fn set(&mut self, idx: usize, value: ShreddedValue) -> Result<()> {
+        let Some(slot) = self.fields.get_mut(idx) else {
+            return data_invalid("Invalid Variant shredding row index");
+        };
+        *slot = Some(value);
+        Ok(())
+    }
+
+    pub(crate) fn fields(&self) -> &[Option<ShreddedValue>] {
+        &self.fields
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum VariantScalarSchema {
+    Boolean,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    Float32,
+    Float64,
+    Decimal { precision: u8, scale: i8 },
+    String,
+    Binary,
+    Date32,
+    Timestamp,
+    TimestampNtz,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct VariantObjectField {
+    pub(crate) field_name: String,
+    pub(crate) schema: VariantSchema,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct VariantSchema {
+    pub(crate) typed_idx: Option<usize>,
+    pub(crate) variant_idx: Option<usize>,
+    pub(crate) top_level_metadata_idx: Option<usize>,
+    pub(crate) num_fields: usize,
+    pub(crate) scalar_schema: Option<VariantScalarSchema>,
+    pub(crate) object_schema: Option<Vec<VariantObjectField>>,
+    pub(crate) object_schema_map: HashMap<String, usize>,
+    pub(crate) array_schema: Option<Box<VariantSchema>>,
+}
+
+impl VariantSchema {
+    pub(crate) fn is_unshredded(&self) -> bool {
+        self.top_level_metadata_idx.is_some()
+            && self.variant_idx.is_some()
+            && self.typed_idx.is_none()
+    }
+
+    fn object_field_index(&self, name: &str) -> Option<usize> {
+        self.object_schema_map.get(name).copied()
     }
 }
 
@@ -1267,6 +1374,39 @@ impl VariantBuilder {
         self.value.extend_from_slice(&value.to_bits().to_le_bytes());
     }
 
+    fn append_float(&mut self, value: f32) {
+        self.value.push(primitive_header(FLOAT));
+        self.value.extend_from_slice(&value.to_bits().to_le_bytes());
+    }
+
+    fn append_binary(&mut self, value: &[u8]) {
+        self.value.push(primitive_header(BINARY));
+        let pos = self.value.len();
+        self.value.resize(pos + U32_SIZE, 0);
+        write_le_at(&mut self.value, pos, value.len(), U32_SIZE);
+        self.value.extend_from_slice(value);
+    }
+
+    fn append_date(&mut self, value: i32) {
+        self.value.push(primitive_header(DATE));
+        push_signed_le(&mut self.value, value as i128, 4);
+    }
+
+    fn append_timestamp(&mut self, value: i64) {
+        self.value.push(primitive_header(TIMESTAMP));
+        push_signed_le(&mut self.value, value as i128, 8);
+    }
+
+    fn append_timestamp_ntz(&mut self, value: i64) {
+        self.value.push(primitive_header(TIMESTAMP_NTZ));
+        push_signed_le(&mut self.value, value as i128, 8);
+    }
+
+    fn append_uuid(&mut self, value: uuid::Uuid) {
+        self.value.push(primitive_header(UUID));
+        self.value.extend_from_slice(value.as_bytes());
+    }
+
     fn append_decimal(&mut self, decimal: VariantDecimal) {
         if decimal.scale as u8 <= MAX_DECIMAL4_PRECISION
             && decimal.precision <= MAX_DECIMAL4_PRECISION
@@ -1285,6 +1425,86 @@ impl VariantBuilder {
             self.value.push(decimal.scale as u8);
             self.value
                 .extend_from_slice(&decimal.unscaled.to_le_bytes());
+        }
+    }
+
+    fn write_pos(&self) -> usize {
+        self.value.len()
+    }
+
+    fn append_variant_ref(&mut self, variant: VariantRef<'_>) -> Result<()> {
+        match variant.kind()? {
+            VariantKind::Object => {
+                let start = self.write_pos();
+                let mut fields = Vec::new();
+                for field in variant.object_fields()? {
+                    let id = self.add_key(&field.key);
+                    fields.push(FieldEntry {
+                        key: field.key,
+                        id,
+                        offset: self.write_pos() - start,
+                    });
+                    self.append_variant_ref(field.value)?;
+                }
+                self.finish_object(start, fields)
+            }
+            VariantKind::Array => {
+                let start = self.write_pos();
+                let mut offsets = Vec::new();
+                for element in variant.array_elements()? {
+                    offsets.push(self.write_pos() - start);
+                    self.append_variant_ref(element)?;
+                }
+                self.finish_array(start, offsets)
+            }
+            VariantKind::Null => {
+                self.append_null();
+                Ok(())
+            }
+            VariantKind::Boolean => {
+                self.append_bool(variant.get_boolean()?);
+                Ok(())
+            }
+            VariantKind::Long => {
+                self.append_long(variant.get_long()?);
+                Ok(())
+            }
+            VariantKind::String => {
+                self.append_string(&variant.get_string()?);
+                Ok(())
+            }
+            VariantKind::Double => {
+                self.append_double(variant.get_double()?);
+                Ok(())
+            }
+            VariantKind::Decimal => {
+                self.append_decimal(variant.get_decimal()?);
+                Ok(())
+            }
+            VariantKind::Date => {
+                self.append_date(variant.get_long()? as i32);
+                Ok(())
+            }
+            VariantKind::Timestamp => {
+                self.append_timestamp(variant.get_long()?);
+                Ok(())
+            }
+            VariantKind::TimestampNtz => {
+                self.append_timestamp_ntz(variant.get_long()?);
+                Ok(())
+            }
+            VariantKind::Float => {
+                self.append_float(variant.get_float()?);
+                Ok(())
+            }
+            VariantKind::Binary => {
+                self.append_binary(variant.get_binary()?);
+                Ok(())
+            }
+            VariantKind::Uuid => {
+                self.append_uuid(get_uuid(variant.value, variant.pos)?);
+                Ok(())
+            }
         }
     }
 
@@ -1694,12 +1914,1214 @@ fn java_string_cmp(left: &str, right: &str) -> std::cmp::Ordering {
     left.encode_utf16().cmp(right.encode_utf16())
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct VariantShreddingInferConfig {
+    pub(crate) max_schema_depth: usize,
+    pub(crate) min_field_cardinality_ratio: f64,
+}
+
+pub(crate) fn infer_variant_shredding_schema(
+    variants: &[GenericVariant],
+    config: &VariantShreddingInferConfig,
+    max_fields_remaining: &mut usize,
+) -> Result<DataType> {
+    let mut simple_schema = None;
+    for variant in variants {
+        let schema_of_row = schema_of_variant(variant.as_ref()?, config.max_schema_depth)?;
+        simple_schema = merge_inferred_schema(simple_schema, schema_of_row)?;
+    }
+
+    let min_cardinality =
+        ((variants.len() as f64) * config.min_field_cardinality_ratio).ceil() as u64;
+    finalize_inferred_schema(simple_schema, min_cardinality, max_fields_remaining)
+}
+
+fn schema_of_variant(variant: VariantRef<'_>, max_depth: usize) -> Result<Option<DataType>> {
+    Ok(match variant.kind()? {
+        VariantKind::Object => {
+            if max_depth == 0 {
+                return Ok(Some(inferred_variant_type()));
+            }
+
+            let object_fields = variant.object_fields()?;
+            let mut fields = Vec::with_capacity(object_fields.len());
+            for (idx, field) in object_fields.iter().enumerate() {
+                let field_type = schema_of_variant(field.value, max_depth - 1)?
+                    .unwrap_or_else(inferred_variant_type);
+                fields.push(
+                    DataField::new(idx as i32, field.key.clone(), field_type)
+                        .with_description(Some("1".to_string())),
+                );
+            }
+
+            for idx in 1..fields.len() {
+                if java_string_cmp(fields[idx - 1].name(), fields[idx].name())
+                    != std::cmp::Ordering::Less
+                {
+                    return data_invalid("Variant object fields must be sorted alphabetically");
+                }
+            }
+
+            Some(DataType::Row(RowType::new(fields)))
+        }
+        VariantKind::Array => {
+            if max_depth == 0 {
+                return Ok(Some(inferred_variant_type()));
+            }
+
+            let mut element_type = None;
+            for element in variant.array_elements()? {
+                element_type = merge_inferred_schema(
+                    element_type,
+                    schema_of_variant(element, max_depth - 1)?,
+                )?;
+            }
+            Some(DataType::Array(ArrayType::new(
+                element_type.unwrap_or_else(inferred_variant_type),
+            )))
+        }
+        VariantKind::Null => None,
+        VariantKind::Boolean => Some(DataType::Boolean(BooleanType::new())),
+        VariantKind::Long => {
+            let value = variant.get_long()?;
+            let precision = decimal_precision(value as i128) as u32;
+            if precision <= 18 {
+                Some(DataType::Decimal(DecimalType::new(precision, 0)?))
+            } else {
+                Some(DataType::BigInt(BigIntType::new()))
+            }
+        }
+        VariantKind::String => Some(DataType::VarChar(VarCharType::string_type())),
+        VariantKind::Double => Some(DataType::Double(DoubleType::new())),
+        VariantKind::Decimal => {
+            let decimal = variant.get_decimal()?;
+            if decimal.scale < 0 {
+                Some(inferred_variant_type())
+            } else {
+                let scale = decimal.scale as u32;
+                let mut precision = decimal.precision as u32;
+                if precision < scale {
+                    precision = scale;
+                }
+                if precision == 0 {
+                    precision = 1;
+                }
+                Some(DataType::Decimal(DecimalType::new(precision, scale)?))
+            }
+        }
+        VariantKind::Date => Some(DataType::Date(DateType::new())),
+        VariantKind::Timestamp => Some(DataType::LocalZonedTimestamp(
+            LocalZonedTimestampType::new(LocalZonedTimestampType::DEFAULT_PRECISION)?,
+        )),
+        VariantKind::TimestampNtz => Some(DataType::Timestamp(TimestampType::new(
+            TimestampType::DEFAULT_PRECISION,
+        )?)),
+        VariantKind::Float => Some(DataType::Float(FloatType::new())),
+        VariantKind::Binary => Some(DataType::VarBinary(VarBinaryType::try_new(
+            true,
+            VarBinaryType::MAX_LENGTH,
+        )?)),
+        VariantKind::Uuid => Some(inferred_variant_type()),
+    })
+}
+
+fn merge_inferred_schema(
+    left: Option<DataType>,
+    right: Option<DataType>,
+) -> Result<Option<DataType>> {
+    match (left, right) {
+        (None, right) => Ok(right),
+        (left, None) => Ok(left),
+        (Some(left), Some(right)) => merge_inferred_types(left, right).map(Some),
+    }
+}
+
+fn merge_inferred_types(left: DataType, right: DataType) -> Result<DataType> {
+    Ok(match (&left, &right) {
+        (DataType::Decimal(left), DataType::Decimal(right)) => {
+            merge_inferred_decimals(left, right)?
+        }
+        (DataType::Decimal(decimal), DataType::BigInt(_))
+        | (DataType::BigInt(_), DataType::Decimal(decimal)) => {
+            merge_inferred_decimal_with_long(decimal)?
+        }
+        (DataType::Row(left), DataType::Row(right)) => {
+            DataType::Row(merge_inferred_row_types(left, right)?)
+        }
+        (DataType::Array(left), DataType::Array(right)) => {
+            let element_type = merge_inferred_schema(
+                Some(left.element_type().clone()),
+                Some(right.element_type().clone()),
+            )?
+            .unwrap_or_else(inferred_variant_type);
+            DataType::Array(ArrayType::new(element_type))
+        }
+        _ if left == right => left,
+        _ => inferred_variant_type(),
+    })
+}
+
+fn merge_inferred_decimals(left: &DecimalType, right: &DecimalType) -> Result<DataType> {
+    let scale = left.scale().max(right.scale());
+    let range = (left.precision() - left.scale()).max(right.precision() - right.scale());
+    if range + scale > DecimalType::MAX_PRECISION {
+        Ok(inferred_variant_type())
+    } else {
+        Ok(DataType::Decimal(DecimalType::new(range + scale, scale)?))
+    }
+}
+
+fn merge_inferred_decimal_with_long(decimal: &DecimalType) -> Result<DataType> {
+    if decimal.scale() == 0 && decimal.precision() <= 18 {
+        Ok(DataType::BigInt(BigIntType::new()))
+    } else {
+        merge_inferred_decimals(decimal, &DecimalType::new(19, 0)?)
+    }
+}
+
+fn merge_inferred_row_types(left: &RowType, right: &RowType) -> Result<RowType> {
+    let fields1 = left.fields();
+    let fields2 = right.fields();
+    let mut new_fields = Vec::new();
+    let mut f1_idx = 0;
+    let mut f2_idx = 0;
+    let mut next_field_id = 0;
+    const MAX_ROW_FIELD_SIZE: usize = 1000;
+
+    while f1_idx < fields1.len() && f2_idx < fields2.len() && new_fields.len() < MAX_ROW_FIELD_SIZE
+    {
+        let field1 = &fields1[f1_idx];
+        let field2 = &fields2[f2_idx];
+        match java_string_cmp(field1.name(), field2.name()) {
+            std::cmp::Ordering::Equal => {
+                let data_type =
+                    merge_inferred_types(field1.data_type().clone(), field2.data_type().clone())?;
+                let count = inferred_field_count(field1)? + inferred_field_count(field2)?;
+                new_fields.push(inferred_count_field(
+                    next_field_id,
+                    field1.name(),
+                    data_type,
+                    count,
+                ));
+                next_field_id += 1;
+                f1_idx += 1;
+                f2_idx += 1;
+            }
+            std::cmp::Ordering::Less => {
+                let count = inferred_field_count(field1)?;
+                new_fields.push(inferred_count_field(
+                    next_field_id,
+                    field1.name(),
+                    field1.data_type().clone(),
+                    count,
+                ));
+                next_field_id += 1;
+                f1_idx += 1;
+            }
+            std::cmp::Ordering::Greater => {
+                let count = inferred_field_count(field2)?;
+                new_fields.push(inferred_count_field(
+                    next_field_id,
+                    field2.name(),
+                    field2.data_type().clone(),
+                    count,
+                ));
+                next_field_id += 1;
+                f2_idx += 1;
+            }
+        }
+    }
+
+    while f1_idx < fields1.len() && new_fields.len() < MAX_ROW_FIELD_SIZE {
+        let field = &fields1[f1_idx];
+        let count = inferred_field_count(field)?;
+        new_fields.push(inferred_count_field(
+            next_field_id,
+            field.name(),
+            field.data_type().clone(),
+            count,
+        ));
+        next_field_id += 1;
+        f1_idx += 1;
+    }
+
+    while f2_idx < fields2.len() && new_fields.len() < MAX_ROW_FIELD_SIZE {
+        let field = &fields2[f2_idx];
+        let count = inferred_field_count(field)?;
+        new_fields.push(inferred_count_field(
+            next_field_id,
+            field.name(),
+            field.data_type().clone(),
+            count,
+        ));
+        next_field_id += 1;
+        f2_idx += 1;
+    }
+
+    Ok(RowType::new(new_fields))
+}
+
+fn inferred_field_count(field: &DataField) -> Result<u64> {
+    let Some(description) = field.description() else {
+        return data_invalid("Variant inferred field is missing count");
+    };
+    description.parse::<u64>().map_err(|e| Error::DataInvalid {
+        message: format!("Invalid Variant inferred field count: {description}"),
+        source: Some(Box::new(e)),
+    })
+}
+
+fn inferred_count_field(id: i32, name: &str, data_type: DataType, count: u64) -> DataField {
+    DataField::new(id, name.to_string(), data_type).with_description(Some(count.to_string()))
+}
+
+fn finalize_inferred_schema(
+    data_type: Option<DataType>,
+    min_cardinality: u64,
+    max_fields_remaining: &mut usize,
+) -> Result<DataType> {
+    if *max_fields_remaining == 0 {
+        return Ok(inferred_variant_type());
+    }
+    *max_fields_remaining -= 1;
+    if *max_fields_remaining == 0 {
+        return Ok(inferred_variant_type());
+    }
+
+    let Some(data_type) = data_type else {
+        return Ok(inferred_variant_type());
+    };
+    if matches!(data_type, DataType::Variant(_)) {
+        return Ok(inferred_variant_type());
+    }
+
+    Ok(match data_type {
+        DataType::Row(row_type) => {
+            let mut fields = Vec::new();
+            for field in row_type.fields() {
+                if inferred_field_count(field)? >= min_cardinality && *max_fields_remaining > 0 {
+                    let field_type = finalize_inferred_schema(
+                        Some(field.data_type().clone()),
+                        min_cardinality,
+                        max_fields_remaining,
+                    )?;
+                    fields.push(DataField::new(
+                        fields.len() as i32,
+                        field.name().to_string(),
+                        field_type,
+                    ));
+                }
+            }
+
+            if fields.is_empty() {
+                inferred_variant_type()
+            } else {
+                DataType::Row(RowType::new(fields))
+            }
+        }
+        DataType::Array(array_type) => {
+            let element_type = finalize_inferred_schema(
+                Some(array_type.element_type().clone()),
+                min_cardinality,
+                max_fields_remaining,
+            )?;
+            DataType::Array(ArrayType::new(element_type))
+        }
+        DataType::TinyInt(_) | DataType::SmallInt(_) | DataType::Int(_) | DataType::BigInt(_) => {
+            *max_fields_remaining = (*max_fields_remaining).saturating_sub(1);
+            DataType::BigInt(BigIntType::new())
+        }
+        DataType::Decimal(decimal) => {
+            *max_fields_remaining = (*max_fields_remaining).saturating_sub(1);
+            if decimal.precision() <= 18 && decimal.scale() == 0 {
+                DataType::BigInt(BigIntType::new())
+            } else if decimal.precision() <= 18 {
+                DataType::Decimal(DecimalType::new(18, decimal.scale())?)
+            } else {
+                DataType::Decimal(DecimalType::new(
+                    DecimalType::MAX_PRECISION,
+                    decimal.scale(),
+                )?)
+            }
+        }
+        other => {
+            *max_fields_remaining = (*max_fields_remaining).saturating_sub(1);
+            other
+        }
+    })
+}
+
+fn inferred_variant_type() -> DataType {
+    DataType::Variant(VariantType::new())
+}
+
+pub(crate) fn variant_shredding_type(data_type: &DataType) -> Result<DataType> {
+    Ok(DataType::Row(variant_shredding_row_type(
+        data_type, true, false,
+    )?))
+}
+
+fn variant_shredding_row_type(
+    data_type: &DataType,
+    is_top_level: bool,
+    is_object_field: bool,
+) -> Result<RowType> {
+    let mut fields = Vec::new();
+    if is_top_level {
+        fields.push(DataField::new(
+            0,
+            VARIANT_METADATA_FIELD_NAME.to_string(),
+            variant_binary_type(false)?,
+        ));
+    }
+
+    match data_type {
+        DataType::Array(array_type) => {
+            let element = DataType::Row(variant_shredding_row_type(
+                array_type.element_type(),
+                false,
+                false,
+            )?);
+            fields.push(DataField::new(
+                1,
+                VARIANT_VALUE_FIELD_NAME.to_string(),
+                variant_binary_type(true)?,
+            ));
+            fields.push(DataField::new(
+                2,
+                VARIANT_TYPED_VALUE_FIELD_NAME.to_string(),
+                DataType::Array(ArrayType::with_nullable(data_type.is_nullable(), element)),
+            ));
+        }
+        DataType::Row(row_type) => {
+            let object_fields = row_type
+                .fields()
+                .iter()
+                .map(|field| {
+                    let child =
+                        DataType::Row(variant_shredding_row_type(field.data_type(), false, true)?)
+                            .copy_with_nullable(false)?;
+                    Ok(DataField::new(field.id(), field.name().to_string(), child)
+                        .with_description(field.description().map(ToString::to_string)))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            fields.push(DataField::new(
+                1,
+                VARIANT_VALUE_FIELD_NAME.to_string(),
+                variant_binary_type(true)?,
+            ));
+            fields.push(DataField::new(
+                2,
+                VARIANT_TYPED_VALUE_FIELD_NAME.to_string(),
+                DataType::Row(RowType::new(object_fields)),
+            ));
+        }
+        DataType::Variant(_) => {
+            fields.push(DataField::new(
+                1,
+                VARIANT_VALUE_FIELD_NAME.to_string(),
+                variant_binary_type(is_object_field)?,
+            ));
+        }
+        dt if scalar_schema_for_type(dt)?.is_some() => {
+            fields.push(DataField::new(
+                1,
+                VARIANT_VALUE_FIELD_NAME.to_string(),
+                variant_binary_type(true)?,
+            ));
+            fields.push(DataField::new(
+                2,
+                VARIANT_TYPED_VALUE_FIELD_NAME.to_string(),
+                data_type.clone(),
+            ));
+        }
+        other => return invalid_variant_shredding_schema(format!("{other:?}")),
+    }
+
+    Ok(RowType::new(fields))
+}
+
+fn variant_binary_type(nullable: bool) -> Result<DataType> {
+    Ok(DataType::VarBinary(VarBinaryType::try_new(
+        nullable,
+        VarBinaryType::MAX_LENGTH,
+    )?))
+}
+
+pub(crate) fn build_variant_schema(row_type: &RowType) -> Result<VariantSchema> {
+    build_variant_schema_with_level(row_type, true)
+}
+
+fn build_variant_schema_with_level(row_type: &RowType, top_level: bool) -> Result<VariantSchema> {
+    let fields = row_type.fields();
+    if fields.is_empty() {
+        return invalid_variant_shredding_schema(format!("{row_type:?}"));
+    }
+
+    let mut seen = HashSet::new();
+    let mut typed_idx = None;
+    let mut variant_idx = None;
+    let mut top_level_metadata_idx = None;
+    let mut scalar_schema = None;
+    let mut object_schema = None;
+    let mut array_schema = None;
+
+    for (idx, field) in fields.iter().enumerate() {
+        if !seen.insert(field.name().to_string()) {
+            return invalid_variant_shredding_schema(format!("{row_type:?}"));
+        }
+
+        match field.name() {
+            VARIANT_TYPED_VALUE_FIELD_NAME => {
+                if typed_idx.is_some() {
+                    return invalid_variant_shredding_schema(format!("{row_type:?}"));
+                }
+                typed_idx = Some(idx);
+                match field.data_type() {
+                    DataType::Row(inner) => {
+                        if inner.fields().is_empty() {
+                            return invalid_variant_shredding_schema(format!("{row_type:?}"));
+                        }
+                        let mut object_names = HashSet::new();
+                        let mut object_fields = Vec::with_capacity(inner.fields().len());
+                        for child in inner.fields() {
+                            if !object_names.insert(child.name().to_string()) {
+                                return invalid_variant_shredding_schema(format!("{row_type:?}"));
+                            }
+                            let DataType::Row(child_row) = child.data_type() else {
+                                return invalid_variant_shredding_schema(format!("{row_type:?}"));
+                            };
+                            object_fields.push(VariantObjectField {
+                                field_name: child.name().to_string(),
+                                schema: build_variant_schema_with_level(child_row, false)?,
+                            });
+                        }
+                        object_schema = Some(object_fields);
+                    }
+                    DataType::Array(array_type) => {
+                        let DataType::Row(element_row) = array_type.element_type() else {
+                            return invalid_variant_shredding_schema(format!("{row_type:?}"));
+                        };
+                        array_schema = Some(Box::new(build_variant_schema_with_level(
+                            element_row,
+                            false,
+                        )?));
+                    }
+                    dt => {
+                        scalar_schema = scalar_schema_for_type(dt)?;
+                        if scalar_schema.is_none() {
+                            return invalid_variant_shredding_schema(format!("{row_type:?}"));
+                        }
+                    }
+                }
+            }
+            VARIANT_VALUE_FIELD_NAME => {
+                if variant_idx.is_some() || !is_varbinary_type(field.data_type()) {
+                    return invalid_variant_shredding_schema(format!("{row_type:?}"));
+                }
+                variant_idx = Some(idx);
+            }
+            VARIANT_METADATA_FIELD_NAME => {
+                if top_level_metadata_idx.is_some() || !is_varbinary_type(field.data_type()) {
+                    return invalid_variant_shredding_schema(format!("{row_type:?}"));
+                }
+                top_level_metadata_idx = Some(idx);
+            }
+            _ => return invalid_variant_shredding_schema(format!("{row_type:?}")),
+        }
+    }
+
+    if top_level != top_level_metadata_idx.is_some() {
+        return invalid_variant_shredding_schema(format!("{row_type:?}"));
+    }
+
+    let object_schema_map = object_schema
+        .as_ref()
+        .map(|fields| {
+            fields
+                .iter()
+                .enumerate()
+                .map(|(idx, field)| (field.field_name.clone(), idx))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(VariantSchema {
+        typed_idx,
+        variant_idx,
+        top_level_metadata_idx,
+        num_fields: fields.len(),
+        scalar_schema,
+        object_schema,
+        object_schema_map,
+        array_schema,
+    })
+}
+
+fn is_varbinary_type(data_type: &DataType) -> bool {
+    matches!(data_type, DataType::VarBinary(_) | DataType::Binary(_))
+}
+
+fn scalar_schema_for_type(data_type: &DataType) -> Result<Option<VariantScalarSchema>> {
+    Ok(match data_type {
+        DataType::Boolean(_) => Some(VariantScalarSchema::Boolean),
+        DataType::TinyInt(_) => Some(VariantScalarSchema::Int8),
+        DataType::SmallInt(_) => Some(VariantScalarSchema::Int16),
+        DataType::Int(_) => Some(VariantScalarSchema::Int32),
+        DataType::BigInt(_) => Some(VariantScalarSchema::Int64),
+        DataType::Float(_) => Some(VariantScalarSchema::Float32),
+        DataType::Double(_) => Some(VariantScalarSchema::Float64),
+        DataType::Decimal(decimal) => Some(VariantScalarSchema::Decimal {
+            precision: u8::try_from(decimal.precision()).map_err(|_| Error::DataTypeInvalid {
+                message: "Variant shredding decimal precision exceeds u8".to_string(),
+            })?,
+            scale: i8::try_from(decimal.scale() as i32).map_err(|_| Error::DataTypeInvalid {
+                message: "Variant shredding decimal scale exceeds i8".to_string(),
+            })?,
+        }),
+        DataType::VarChar(_) | DataType::Char(_) => Some(VariantScalarSchema::String),
+        DataType::VarBinary(_) | DataType::Binary(_) | DataType::Blob(_) => {
+            Some(VariantScalarSchema::Binary)
+        }
+        DataType::Date(_) => Some(VariantScalarSchema::Date32),
+        DataType::Timestamp(_) => Some(VariantScalarSchema::TimestampNtz),
+        DataType::LocalZonedTimestamp(_) => Some(VariantScalarSchema::Timestamp),
+        _ => None,
+    })
+}
+
+fn invalid_variant_shredding_schema<T>(data_type: impl Into<String>) -> Result<T> {
+    Err(Error::DataInvalid {
+        message: format!("Invalid variant shredding schema: {}", data_type.into()),
+        source: None,
+    })
+}
+
+pub(crate) fn cast_shredded(
+    variant: &GenericVariant,
+    schema: &VariantSchema,
+) -> Result<ShreddedRow> {
+    let root = variant.as_ref()?;
+    let mut row = cast_shredded_ref(root, schema)?;
+    if let Some(idx) = schema.top_level_metadata_idx {
+        row.set(idx, ShreddedValue::Binary(variant.metadata().to_vec()))?;
+    }
+    Ok(row)
+}
+
+fn cast_shredded_ref(variant: VariantRef<'_>, schema: &VariantSchema) -> Result<ShreddedRow> {
+    let mut row = ShreddedRow::new(schema.num_fields);
+    match variant.kind()? {
+        VariantKind::Array if schema.array_schema.is_some() => {
+            let element_schema = schema.array_schema.as_ref().unwrap();
+            let values = variant
+                .array_elements()?
+                .into_iter()
+                .map(|element| cast_shredded_ref(element, element_schema))
+                .collect::<Result<Vec<_>>>()?;
+            if let Some(idx) = schema.typed_idx {
+                row.set(idx, ShreddedValue::List(values))?;
+            }
+        }
+        VariantKind::Object if schema.object_schema.is_some() => {
+            let object_schema = schema.object_schema.as_ref().unwrap();
+            let mut shredded_values: Vec<Option<ShreddedRow>> = vec![None; object_schema.len()];
+            let mut leftovers = Vec::new();
+
+            for field in variant.object_fields()? {
+                if let Some(field_idx) = schema.object_field_index(&field.key) {
+                    let child_schema = &object_schema[field_idx].schema;
+                    shredded_values[field_idx] =
+                        Some(cast_shredded_ref(field.value, child_schema)?);
+                } else {
+                    leftovers.push(field);
+                }
+            }
+
+            let object_row = ShreddedRow {
+                fields: object_schema
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, field)| {
+                        Some(ShreddedValue::Row(
+                            shredded_values[idx]
+                                .clone()
+                                .unwrap_or_else(|| ShreddedRow::new(field.schema.num_fields)),
+                        ))
+                    })
+                    .collect(),
+            };
+            if let Some(idx) = schema.typed_idx {
+                row.set(idx, ShreddedValue::Row(object_row))?;
+            }
+            if !leftovers.is_empty() {
+                let value = build_object_value_from_fields(leftovers)?;
+                if let Some(idx) = schema.variant_idx {
+                    row.set(idx, ShreddedValue::Binary(value))?;
+                }
+            }
+        }
+        _ if schema.scalar_schema.is_some() => {
+            let scalar = schema.scalar_schema.as_ref().unwrap();
+            if let Some(value) = try_typed_shred(variant, scalar)? {
+                if let Some(idx) = schema.typed_idx {
+                    row.set(idx, value)?;
+                }
+            } else if let Some(idx) = schema.variant_idx {
+                row.set(idx, ShreddedValue::Binary(variant.value_slice()?.to_vec()))?;
+            }
+        }
+        _ => {
+            if let Some(idx) = schema.variant_idx {
+                row.set(idx, ShreddedValue::Binary(variant.value_slice()?.to_vec()))?;
+            }
+        }
+    }
+    Ok(row)
+}
+
+pub(crate) fn rebuild_shredded(
+    row: &ShreddedRow,
+    schema: &VariantSchema,
+) -> Result<GenericVariant> {
+    let Some(metadata_idx) = schema.top_level_metadata_idx else {
+        return data_invalid("Malformed shredded Variant: missing top-level metadata field");
+    };
+    let metadata = match row.field(metadata_idx) {
+        Some(ShreddedValue::Binary(bytes)) => bytes.as_slice(),
+        _ => return data_invalid("Malformed shredded Variant: missing metadata"),
+    };
+    if schema.is_unshredded() {
+        let value = binary_field(row, schema.variant_idx)?;
+        return GenericVariant::from_parts(value.to_vec(), metadata.to_vec());
+    }
+
+    let mut builder = VariantBuilder::new();
+    rebuild_shredded_into(row, metadata, schema, &mut builder)?;
+    builder.result()
+}
+
+fn rebuild_shredded_into(
+    row: &ShreddedRow,
+    metadata: &[u8],
+    schema: &VariantSchema,
+    builder: &mut VariantBuilder,
+) -> Result<()> {
+    if let Some(typed_idx) = schema.typed_idx {
+        if let Some(typed_value) = row.field(typed_idx) {
+            if let Some(scalar) = &schema.scalar_schema {
+                append_scalar_shredded_value(builder, typed_value, scalar)?;
+            } else if let Some(element_schema) = &schema.array_schema {
+                let ShreddedValue::List(elements) = typed_value else {
+                    return data_invalid("Malformed shredded Variant array typed_value");
+                };
+                let start = builder.write_pos();
+                let mut offsets = Vec::with_capacity(elements.len());
+                for element in elements {
+                    offsets.push(builder.write_pos() - start);
+                    rebuild_shredded_into(element, metadata, element_schema, builder)?;
+                }
+                builder.finish_array(start, offsets)?;
+            } else if let Some(object_schema) = &schema.object_schema {
+                let ShreddedValue::Row(object_row) = typed_value else {
+                    return data_invalid("Malformed shredded Variant object typed_value");
+                };
+                let start = builder.write_pos();
+                let mut fields = Vec::new();
+                for (idx, field) in object_schema.iter().enumerate() {
+                    let Some(ShreddedValue::Row(field_row)) = object_row.field(idx) else {
+                        return data_invalid("Malformed shredded Variant object field");
+                    };
+                    if shredded_row_has_value(field_row, &field.schema) {
+                        let id = builder.add_key(&field.field_name);
+                        fields.push(FieldEntry {
+                            key: field.field_name.clone(),
+                            id,
+                            offset: builder.write_pos() - start,
+                        });
+                        rebuild_shredded_into(field_row, metadata, &field.schema, builder)?;
+                    }
+                }
+                if let Some(value) = optional_binary_field(row, schema.variant_idx)? {
+                    let variant = GenericVariant::from_parts(value.to_vec(), metadata.to_vec())?;
+                    let variant_ref = variant.as_ref()?;
+                    if variant_ref.kind()? != VariantKind::Object {
+                        return data_invalid("Malformed shredded Variant object value");
+                    }
+                    for field in variant_ref.object_fields()? {
+                        if schema.object_field_index(&field.key).is_some() {
+                            return data_invalid(
+                                "Malformed shredded Variant duplicate object field",
+                            );
+                        }
+                        let id = builder.add_key(&field.key);
+                        fields.push(FieldEntry {
+                            key: field.key,
+                            id,
+                            offset: builder.write_pos() - start,
+                        });
+                        builder.append_variant_ref(field.value)?;
+                    }
+                }
+                builder.finish_object(start, fields)?;
+            }
+            return Ok(());
+        }
+    }
+
+    if let Some(value) = optional_binary_field(row, schema.variant_idx)? {
+        let variant = GenericVariant::from_parts(value.to_vec(), metadata.to_vec())?;
+        builder.append_variant_ref(variant.as_ref()?)?;
+        Ok(())
+    } else {
+        data_invalid("Malformed shredded Variant: missing value")
+    }
+}
+
+fn shredded_row_has_value(row: &ShreddedRow, schema: &VariantSchema) -> bool {
+    schema.typed_idx.is_some_and(|idx| row.field(idx).is_some())
+        || schema
+            .variant_idx
+            .is_some_and(|idx| row.field(idx).is_some())
+}
+
+fn optional_binary_field(row: &ShreddedRow, idx: Option<usize>) -> Result<Option<&[u8]>> {
+    let Some(idx) = idx else {
+        return Ok(None);
+    };
+    match row.field(idx) {
+        Some(ShreddedValue::Binary(bytes)) => Ok(Some(bytes.as_slice())),
+        Some(_) => data_invalid("Malformed shredded Variant binary field"),
+        None => Ok(None),
+    }
+}
+
+fn binary_field(row: &ShreddedRow, idx: Option<usize>) -> Result<&[u8]> {
+    optional_binary_field(row, idx)?.ok_or_else(|| Error::DataInvalid {
+        message: "Malformed shredded Variant: missing binary field".to_string(),
+        source: None,
+    })
+}
+
+fn append_scalar_shredded_value(
+    builder: &mut VariantBuilder,
+    value: &ShreddedValue,
+    scalar: &VariantScalarSchema,
+) -> Result<()> {
+    match (scalar, value) {
+        (VariantScalarSchema::Boolean, ShreddedValue::Boolean(v)) => builder.append_bool(*v),
+        (VariantScalarSchema::Int8, ShreddedValue::Int8(v)) => builder.append_long(*v as i64),
+        (VariantScalarSchema::Int16, ShreddedValue::Int16(v)) => builder.append_long(*v as i64),
+        (VariantScalarSchema::Int32, ShreddedValue::Int32(v)) => builder.append_long(*v as i64),
+        (VariantScalarSchema::Int64, ShreddedValue::Int64(v)) => builder.append_long(*v),
+        (VariantScalarSchema::Float32, ShreddedValue::Float32(v)) => builder.append_float(*v),
+        (VariantScalarSchema::Float64, ShreddedValue::Float64(v)) => builder.append_double(*v),
+        (
+            VariantScalarSchema::Decimal { precision, scale },
+            ShreddedValue::Decimal128(unscaled),
+        ) => builder.append_decimal(VariantDecimal {
+            unscaled: *unscaled,
+            precision: *precision,
+            scale: *scale,
+        }),
+        (VariantScalarSchema::String, ShreddedValue::String(v)) => builder.append_string(v),
+        (VariantScalarSchema::Binary, ShreddedValue::Binary(v)) => builder.append_binary(v),
+        (VariantScalarSchema::Date32, ShreddedValue::Date32(v)) => builder.append_date(*v),
+        (VariantScalarSchema::Timestamp, ShreddedValue::Timestamp(v)) => {
+            builder.append_timestamp(*v)
+        }
+        (VariantScalarSchema::TimestampNtz, ShreddedValue::Timestamp(v)) => {
+            builder.append_timestamp_ntz(*v)
+        }
+        _ => return data_invalid("Malformed shredded Variant scalar typed_value"),
+    }
+    Ok(())
+}
+
+fn try_typed_shred(
+    variant: VariantRef<'_>,
+    scalar: &VariantScalarSchema,
+) -> Result<Option<ShreddedValue>> {
+    Ok(match (variant.kind()?, scalar) {
+        (VariantKind::Boolean, VariantScalarSchema::Boolean) => {
+            Some(ShreddedValue::Boolean(variant.get_boolean()?))
+        }
+        (VariantKind::Long, VariantScalarSchema::Int8) => {
+            let value = variant.get_long()?;
+            i8::try_from(value).ok().map(ShreddedValue::Int8)
+        }
+        (VariantKind::Long, VariantScalarSchema::Int16) => {
+            let value = variant.get_long()?;
+            i16::try_from(value).ok().map(ShreddedValue::Int16)
+        }
+        (VariantKind::Long, VariantScalarSchema::Int32) => {
+            let value = variant.get_long()?;
+            i32::try_from(value).ok().map(ShreddedValue::Int32)
+        }
+        (VariantKind::Long, VariantScalarSchema::Int64) => {
+            Some(ShreddedValue::Int64(variant.get_long()?))
+        }
+        (VariantKind::Long, VariantScalarSchema::Decimal { precision, scale }) => {
+            let unscaled = rescale_decimal(variant.get_long()? as i128, 0, *scale)?;
+            if decimal_precision(unscaled) <= *precision {
+                Some(ShreddedValue::Decimal128(unscaled))
+            } else {
+                None
+            }
+        }
+        (VariantKind::Decimal, VariantScalarSchema::Decimal { precision, scale }) => {
+            let decimal = variant.get_decimal()?;
+            rescale_decimal_exact(decimal.unscaled, decimal.scale, *scale).and_then(|unscaled| {
+                (decimal_precision(unscaled) <= *precision)
+                    .then_some(ShreddedValue::Decimal128(unscaled))
+            })
+        }
+        (VariantKind::Decimal, VariantScalarSchema::Int8) => {
+            decimal_to_integral(variant, i8::MIN as i128, i8::MAX as i128)?
+                .map(|v| ShreddedValue::Int8(v as i8))
+        }
+        (VariantKind::Decimal, VariantScalarSchema::Int16) => {
+            decimal_to_integral(variant, i16::MIN as i128, i16::MAX as i128)?
+                .map(|v| ShreddedValue::Int16(v as i16))
+        }
+        (VariantKind::Decimal, VariantScalarSchema::Int32) => {
+            decimal_to_integral(variant, i32::MIN as i128, i32::MAX as i128)?
+                .map(|v| ShreddedValue::Int32(v as i32))
+        }
+        (VariantKind::Decimal, VariantScalarSchema::Int64) => {
+            decimal_to_integral(variant, i64::MIN as i128, i64::MAX as i128)?
+                .map(|v| ShreddedValue::Int64(v as i64))
+        }
+        (VariantKind::Float, VariantScalarSchema::Float32) => {
+            Some(ShreddedValue::Float32(variant.get_float()?))
+        }
+        (VariantKind::Double, VariantScalarSchema::Float64) => {
+            Some(ShreddedValue::Float64(variant.get_double()?))
+        }
+        (VariantKind::String, VariantScalarSchema::String) => {
+            Some(ShreddedValue::String(variant.get_string()?))
+        }
+        (VariantKind::Binary, VariantScalarSchema::Binary) => {
+            Some(ShreddedValue::Binary(variant.get_binary()?.to_vec()))
+        }
+        (VariantKind::Date, VariantScalarSchema::Date32) => {
+            let value = variant.get_long()?;
+            i32::try_from(value).ok().map(ShreddedValue::Date32)
+        }
+        (VariantKind::Timestamp, VariantScalarSchema::Timestamp) => {
+            Some(ShreddedValue::Timestamp(variant.get_long()?))
+        }
+        (VariantKind::TimestampNtz, VariantScalarSchema::TimestampNtz) => {
+            Some(ShreddedValue::Timestamp(variant.get_long()?))
+        }
+        _ => None,
+    })
+}
+
+fn rescale_decimal(unscaled: i128, from_scale: i8, to_scale: i8) -> Result<i128> {
+    if to_scale >= from_scale {
+        let factor = 10_i128
+            .checked_pow((to_scale - from_scale) as u32)
+            .ok_or_else(|| Error::DataInvalid {
+                message: "Variant decimal scale overflow".to_string(),
+                source: None,
+            })?;
+        unscaled
+            .checked_mul(factor)
+            .ok_or_else(|| Error::DataInvalid {
+                message: "Variant decimal rescale overflow".to_string(),
+                source: None,
+            })
+    } else {
+        let factor = 10_i128
+            .checked_pow((from_scale - to_scale) as u32)
+            .ok_or_else(|| Error::DataInvalid {
+                message: "Variant decimal scale overflow".to_string(),
+                source: None,
+            })?;
+        Ok(unscaled / factor)
+    }
+}
+
+fn rescale_decimal_exact(unscaled: i128, from_scale: i8, to_scale: i8) -> Option<i128> {
+    if to_scale >= from_scale {
+        rescale_decimal(unscaled, from_scale, to_scale).ok()
+    } else {
+        let factor = 10_i128.checked_pow((from_scale - to_scale) as u32)?;
+        (unscaled % factor == 0).then_some(unscaled / factor)
+    }
+}
+
+fn decimal_to_integral(variant: VariantRef<'_>, min: i128, max: i128) -> Result<Option<i128>> {
+    let decimal = variant.get_decimal()?;
+    let Some(value) = rescale_decimal_exact(decimal.unscaled, decimal.scale, 0) else {
+        return Ok(None);
+    };
+    Ok((value >= min && value <= max).then_some(value))
+}
+
+#[derive(Clone)]
+struct ObjectFieldRef<'a> {
+    key: String,
+    id: usize,
+    value: VariantRef<'a>,
+}
+
+impl<'a> VariantRef<'a> {
+    fn object_fields(&self) -> Result<Vec<ObjectFieldRef<'a>>> {
+        let layout = object_layout(self.value, self.pos)?;
+        let mut fields = Vec::with_capacity(layout.size);
+        for i in 0..layout.size {
+            let id = read_unsigned(
+                self.value,
+                layout.id_start + layout.id_size * i,
+                layout.id_size,
+            )?;
+            let key = get_metadata_key(self.metadata, id)?;
+            let offset = read_unsigned(
+                self.value,
+                layout.offset_start + layout.offset_size * i,
+                layout.offset_size,
+            )?;
+            fields.push(ObjectFieldRef {
+                key,
+                id,
+                value: VariantRef::new_at(self.value, self.metadata, layout.data_start + offset)?,
+            });
+        }
+        Ok(fields)
+    }
+
+    fn array_elements(&self) -> Result<Vec<VariantRef<'a>>> {
+        let layout = array_layout(self.value, self.pos)?;
+        let mut elements = Vec::with_capacity(layout.size);
+        for i in 0..layout.size {
+            let offset = read_unsigned(
+                self.value,
+                layout.offset_start + layout.offset_size * i,
+                layout.offset_size,
+            )?;
+            elements.push(VariantRef::new_at(
+                self.value,
+                self.metadata,
+                layout.data_start + offset,
+            )?);
+        }
+        Ok(elements)
+    }
+}
+
+fn build_object_value_from_fields(fields: Vec<ObjectFieldRef<'_>>) -> Result<Vec<u8>> {
+    let mut entries = Vec::with_capacity(fields.len());
+    let mut data = Vec::new();
+    for field in fields {
+        let offset = data.len();
+        data.extend_from_slice(field.value.value_slice()?);
+        entries.push(FieldEntry {
+            key: field.key,
+            id: field.id,
+            offset,
+        });
+    }
+    build_object_value(entries, data)
+}
+
+fn build_object_value(mut fields: Vec<FieldEntry>, data: Vec<u8>) -> Result<Vec<u8>> {
+    fields.sort_by(|a, b| java_string_cmp(&a.key, &b.key));
+    for pair in fields.windows(2) {
+        if pair[0].key == pair[1].key {
+            return data_invalid("VARIANT_DUPLICATE_KEY");
+        }
+    }
+
+    let data_size = data.len();
+    let size = fields.len();
+    let large_size = size > U8_MAX;
+    let size_bytes = if large_size { U32_SIZE } else { 1 };
+    let max_id = fields.iter().map(|f| f.id).max().unwrap_or(0);
+    let id_size = integer_size(max_id)?;
+    let offset_size = integer_size(data_size)?;
+    let header_size = 1 + size_bytes + size * id_size + (size + 1) * offset_size;
+    let mut value = vec![0u8; header_size];
+    value[0] = object_header(large_size, id_size, offset_size);
+    write_le_at(&mut value, 1, size, size_bytes);
+    let id_start = 1 + size_bytes;
+    let offset_start = id_start + size * id_size;
+    for (i, field) in fields.iter().enumerate() {
+        write_le_at(&mut value, id_start + i * id_size, field.id, id_size);
+        write_le_at(
+            &mut value,
+            offset_start + i * offset_size,
+            field.offset,
+            offset_size,
+        );
+    }
+    write_le_at(
+        &mut value,
+        offset_start + size * offset_size,
+        data_size,
+        offset_size,
+    );
+    value.extend_from_slice(&data);
+    Ok(value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::spec::{BigIntType, BooleanType, TimeType, VarCharType};
 
     fn empty_metadata() -> Vec<u8> {
         vec![VERSION, 0, 0]
+    }
+
+    fn simple_object_shredding_schema() -> VariantSchema {
+        let configured = DataType::Row(RowType::new(vec![
+            DataField::new(7, "age".to_string(), DataType::BigInt(BigIntType::new())),
+            DataField::new(
+                8,
+                "city".to_string(),
+                DataType::VarChar(VarCharType::string_type()),
+            ),
+            DataField::new(
+                9,
+                "active".to_string(),
+                DataType::Boolean(BooleanType::new()),
+            ),
+        ]));
+        let DataType::Row(physical) = variant_shredding_type(&configured).unwrap() else {
+            panic!("expected row shredding type");
+        };
+        build_variant_schema(&physical).unwrap()
+    }
+
+    #[test]
+    fn variant_shredding_schema_matches_java_shape() {
+        let configured = DataType::Row(RowType::new(vec![
+            DataField::new(7, "age".to_string(), DataType::BigInt(BigIntType::new())),
+            DataField::new(
+                8,
+                "city".to_string(),
+                DataType::VarChar(VarCharType::string_type()),
+            ),
+        ]));
+        let DataType::Row(physical) = variant_shredding_type(&configured).unwrap() else {
+            panic!("expected row shredding type");
+        };
+
+        assert_eq!(physical.fields()[0].name(), VARIANT_METADATA_FIELD_NAME);
+        assert_eq!(physical.fields()[1].name(), VARIANT_VALUE_FIELD_NAME);
+        assert_eq!(physical.fields()[2].name(), VARIANT_TYPED_VALUE_FIELD_NAME);
+
+        let DataType::Row(typed_object) = physical.fields()[2].data_type() else {
+            panic!("expected typed_value object row");
+        };
+        assert_eq!(typed_object.fields()[0].name(), "age");
+        assert!(!typed_object.fields()[0].data_type().is_nullable());
+        let DataType::Row(age_shred) = typed_object.fields()[0].data_type() else {
+            panic!("expected shredded scalar row");
+        };
+        assert_eq!(age_shred.fields()[0].name(), VARIANT_VALUE_FIELD_NAME);
+        assert_eq!(age_shred.fields()[1].name(), VARIANT_TYPED_VALUE_FIELD_NAME);
+    }
+
+    #[test]
+    fn variant_shredding_schema_rejects_unsupported_time_type() {
+        let err = variant_shredding_type(&DataType::Time(TimeType::new(3).unwrap())).unwrap_err();
+        assert!(format!("{err:?}").contains("Invalid variant shredding schema"));
+    }
+
+    fn timestamp_variant(value: i64, ntz: bool) -> GenericVariant {
+        let mut builder = VariantBuilder::new();
+        if ntz {
+            builder.append_timestamp_ntz(value);
+        } else {
+            builder.append_timestamp(value);
+        }
+        builder.result().unwrap()
+    }
+
+    #[test]
+    fn cast_and_rebuild_shredded_timestamp_ntz_preserves_kind() {
+        let configured =
+            DataType::Timestamp(TimestampType::new(TimestampType::DEFAULT_PRECISION).unwrap());
+        let DataType::Row(physical) = variant_shredding_type(&configured).unwrap() else {
+            panic!("expected row shredding type");
+        };
+        let schema = build_variant_schema(&physical).unwrap();
+        let variant = timestamp_variant(1_700_000_000_123_456, true);
+
+        let row = cast_shredded(&variant, &schema).unwrap();
+        assert!(matches!(
+            row.field(2),
+            Some(ShreddedValue::Timestamp(1_700_000_000_123_456))
+        ));
+
+        let rebuilt = rebuild_shredded(&row, &schema).unwrap();
+        let rebuilt_ref = rebuilt.as_ref().unwrap();
+        assert_eq!(rebuilt_ref.kind().unwrap(), VariantKind::TimestampNtz);
+        assert_eq!(rebuilt_ref.get_long().unwrap(), 1_700_000_000_123_456);
+    }
+
+    #[test]
+    fn cast_and_rebuild_shredded_object_keeps_leftover_fields() {
+        let schema = simple_object_shredding_schema();
+        let variant = GenericVariant::parse_json(
+            r#"{"age":27,"city":"Beijing","extra":"left","nested":{"x":1}}"#,
+        )
+        .unwrap();
+
+        let row = cast_shredded(&variant, &schema).unwrap();
+        assert!(matches!(row.field(0), Some(ShreddedValue::Binary(_))));
+        assert!(matches!(row.field(1), Some(ShreddedValue::Binary(_))));
+        let Some(ShreddedValue::Row(object)) = row.field(2) else {
+            panic!("expected typed object");
+        };
+        let Some(ShreddedValue::Row(age)) = object.field(0) else {
+            panic!("expected age row");
+        };
+        assert!(matches!(age.field(1), Some(ShreddedValue::Int64(27))));
+        let Some(ShreddedValue::Row(city)) = object.field(1) else {
+            panic!("expected city row");
+        };
+        assert!(matches!(
+            city.field(1),
+            Some(ShreddedValue::String(value)) if value == "Beijing"
+        ));
+
+        let rebuilt = rebuild_shredded(&row, &schema).unwrap();
+        assert_eq!(rebuilt.to_json().unwrap(), variant.to_json().unwrap());
+    }
+
+    #[test]
+    fn cast_shredded_distinguishes_missing_and_untyped_values() {
+        let schema = simple_object_shredding_schema();
+        let variant = GenericVariant::parse_json(r#"{"age":"old","active":true}"#).unwrap();
+
+        let row = cast_shredded(&variant, &schema).unwrap();
+        let Some(ShreddedValue::Row(object)) = row.field(2) else {
+            panic!("expected typed object");
+        };
+        let Some(ShreddedValue::Row(age)) = object.field(0) else {
+            panic!("expected age row");
+        };
+        assert!(matches!(age.field(0), Some(ShreddedValue::Binary(_))));
+        assert!(age.field(1).is_none());
+        let Some(ShreddedValue::Row(city)) = object.field(1) else {
+            panic!("expected city row");
+        };
+        assert!(city.field(0).is_none());
+        assert!(city.field(1).is_none());
+        let Some(ShreddedValue::Row(active)) = object.field(2) else {
+            panic!("expected active row");
+        };
+        assert!(matches!(
+            active.field(1),
+            Some(ShreddedValue::Boolean(true))
+        ));
+
+        let rebuilt = rebuild_shredded(&row, &schema).unwrap();
+        assert_eq!(rebuilt.to_json().unwrap(), variant.to_json().unwrap());
     }
 
     #[test]

--- a/docs/src/sql.md
+++ b/docs/src/sql.md
@@ -208,6 +208,54 @@ SELECT
     is_variant_null(NULL) AS sql_null;
 ```
 
+### Variant Shredding
+
+Variant shredding stores selected fields from a `VARIANT` column as typed
+physical fields in Parquet files while keeping the logical table schema as
+`VARIANT`. Reads are automatic: when a projected `VARIANT` column is stored in
+shredded physical form, Paimon Rust assembles it back into the normal
+value + metadata representation before returning the batch.
+
+Use a configured shredding schema when the hot fields are known in advance:
+
+```sql
+CREATE TABLE paimon.my_db.shredded_events (
+    user_id BIGINT,
+    payload VARIANT
+) WITH (
+    'file.format' = 'parquet',
+    'variant.shreddingSchema' =
+        '{"type":"ROW","fields":[{"name":"payload","type":{"type":"ROW","fields":[{"name":"event","type":"STRING"},{"name":"score","type":"DOUBLE"},{"name":"city","type":"STRING"}]}}]}'
+);
+```
+
+The configured schema is a Paimon `ROW` type encoded as JSON. Field IDs may be
+omitted; Paimon Rust assigns them by position. Each top-level field name must
+match a `VARIANT` column to shred. The field's type describes the typed fields
+to extract from that Variant value; values that do not match the typed field
+still remain in the Variant payload so the logical value can be rebuilt on read.
+
+Use inferred shredding when the hot fields should be discovered from the first
+rows written by each data-file writer:
+
+```sql
+CREATE TABLE paimon.my_db.inferred_events (
+    user_id BIGINT,
+    payload VARIANT
+) WITH (
+    'file.format' = 'parquet',
+    'variant.inferShreddingSchema' = 'true',
+    'variant.shredding.maxInferBufferRow' = '4096',
+    'variant.shredding.maxSchemaDepth' = '50',
+    'variant.shredding.maxSchemaWidth' = '300',
+    'variant.shredding.minFieldCardinalityRatio' = '0.1'
+);
+```
+
+When both configured and inferred shredding are set, the configured schema takes
+precedence. Shredding currently applies to Parquet data-file writes; ordinary
+non-shredded `VARIANT` files continue to read normally.
+
 Current limitations:
 
 - `schema_of_variant`, `schema_of_variant_agg`, `to_variant_object`, `variant_explode`, and `variant_explode_outer` are not implemented yet.
@@ -1164,6 +1212,27 @@ This is not full Java feature parity. Aggregation tables do not support retract
 rows (`DELETE` / `UPDATE_BEFORE`), deletion vectors, cross-partition dynamic
 bucket writes, or advanced aggregation options such as `ignore-retract`,
 `distinct`, `nested-key`, `count-limit`, and sequence groups.
+
+### Variant Shredding Options
+
+Set these as table options when writing `VARIANT` columns to Parquet. The
+logical table schema remains `VARIANT`; the options only affect the physical
+file layout and automatic read-time assembly.
+
+| Option | Default | Description |
+|---|---:|---|
+| `variant.shreddingSchema` | unset | Configured shredding schema as a Paimon `ROW` type JSON string. Top-level field names match `VARIANT` column names, and their nested types describe the typed fields to extract. |
+| `parquet.variant.shreddingSchema` | unset | Parquet-scoped alias for `variant.shreddingSchema`. |
+| `variant.inferShreddingSchema` | `false` | Enables per-writer schema inference for `VARIANT` columns when no configured shredding schema is set. |
+| `parquet.variant.inferShreddingSchema` | `false` | Parquet-scoped alias for `variant.inferShreddingSchema`. |
+| `variant.shredding.maxInferBufferRow` | `4096` | Number of initial rows buffered per data-file writer before inferring the shredding schema. If fewer rows are written, inference runs when the writer is flushed or closed. |
+| `variant.shredding.maxSchemaDepth` | `50` | Maximum nested depth considered by inference. |
+| `variant.shredding.maxSchemaWidth` | `300` | Maximum number of inferred typed fields across inferred Variant schemas. |
+| `variant.shredding.minFieldCardinalityRatio` | `0.1` | Minimum ratio of sampled non-null Variant values that must contain a field before inference keeps it as a typed field. |
+
+Configured shredding takes precedence over inferred shredding. If a table has no
+`VARIANT` columns, or none of these options enable shredding, Paimon Rust writes
+the normal physical format without wrapping the writer.
 
 ### Other Options
 


### PR DESCRIPTION
## Summary

Adds Variant shredding support aligned with Java, including configured and inferred shredding schemas. The format-level shredding read/write logic is kept reusable so future formats can plug in a physical writer factory instead of duplicating the state machine.

## Changes

- Add Variant shredding schema construction, inference, cast, and rebuild utilities.
- Add Arrow helpers for configured/inferred physical fields, logical-to-physical batch conversion, and shredded Variant reassembly on read.
- Add reusable `ShreddingFormatWriter` / `ShreddingFormatReader` plus a physical writer factory abstraction.
- Keep Parquet focused on raw Parquet IO and a `ParquetPhysicalWriterFactory`; route table format options into `DataFileWriter` through its constructor.
- Add Parquet roundtrip coverage for configured and inferred Variant shredding schemas.
- Document Variant shredding usage, configured/inferred modes, and table options.

## Testing

- [x] `cargo clippy --all-targets --workspace --features fulltext,vortex,mosaic -- -D warnings`
- [x] `cargo test -p paimon --lib`
- [x] `cargo check -p paimon --features mosaic,vortex --lib`
- [x] `cargo fmt --check`
- [x] `git diff --check`

## Notes

No migration is required. Existing non-shredded Variant files continue to read through the no-op path unless a shredded physical shape is detected.
