### PR TITLE
docs: mark unreleased storage backends and mosaic feature in getting-started.md

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -44,20 +44,27 @@ Available storage features:
 | `storage-memory` | In-memory        |
 | `storage-s3`     | Amazon S3        |
 | `storage-oss`    | Alibaba Cloud OSS|
-| `storage-cos`    | Tencent Cloud COS|
-| `storage-azdls`  | Azure Data Lake Storage Gen2 |
-| `storage-obs`    | Huawei Cloud OBS |
-| `storage-gcs`    | Google Cloud Storage |
+| `storage-cos`    | Tencent Cloud COS <sup>[1]</sup> |
+| `storage-azdls`  | Azure Data Lake Storage Gen2 <sup>[1]</sup> |
+| `storage-obs`    | Huawei Cloud OBS <sup>[1]</sup> |
+| `storage-gcs`    | Google Cloud Storage <sup>[1]</sup> |
 | `storage-hdfs`   | HDFS             |
 | `storage-all`    | All of the above |
 
-## Optional File Formats
-
-Mosaic data files can be read by enabling the `mosaic` feature:
+<sup>[1]</sup> Not in the latest release yet; available on the `main` branch. To use it now, depend on the git repository instead of a published version:
 
 ```toml
 [dependencies]
-paimon = { version = "0.2.0", features = ["mosaic"] }
+paimon = { git = "https://github.com/apache/paimon-rust", features = ["storage-cos"] }
+```
+
+## Optional File Formats
+
+Mosaic data files can be read by enabling the `mosaic` feature. This feature is not in the latest release yet; it is available on the `main` branch:
+
+```toml
+[dependencies]
+paimon = { git = "https://github.com/apache/paimon-rust", features = ["mosaic"] }
 ```
 
 The current Mosaic support is read-only. Paimon Rust can read existing `.mosaic` data files in a Paimon table, but it does not write Mosaic data files yet.


### PR DESCRIPTION
### Purpose

`getting-started.md` documents the `storage-cos`, `storage-azdls`, `storage-obs`, `storage-gcs`, and `mosaic` Cargo features as available under `paimon = { version = "0.2.0", ... }`. None of these exist in the published `0.2.0` crate — they were added on `main` after the `0.2.0` release.

Reproduced with a scratch crate:

```toml
[dependencies]
paimon = { version = "0.2.0", features = ["mosaic"] }
```

```
error: failed to select a version for `paimon`.
package `paimon-repro` depends on `paimon` with feature `mosaic` but `paimon` does not have that feature.
help: available features: default, fulltext, storage-all, storage-fs, storage-hdfs, storage-memory, storage-oss, storage-s3, tantivy, tempfile, vortex
```

Confirmed by diffing the `v0.2.0` tag's `crates/paimon/Cargo.toml` against `main`: `storage-cos`, `storage-azdls`, `storage-obs`, `storage-gcs`, and `mosaic` only exist on `main`.

Fixes #461

### Changes

- Mark `storage-cos`, `storage-azdls`, `storage-obs`, `storage-gcs`, and `mosaic` in the features table/section as main-branch-only (not yet in a release).
- Replace their `Cargo.toml` example with a `git` dependency instead of a `version = "0.2.0"` pin. Verified this builds cleanly against `main` (`cargo check` succeeds, resolving `paimon v0.3.0` from git).