### PR TITLE
fix(datafusion): keep dynamic options out of show create

### DIFF
--- a/crates/integrations/datafusion/src/catalog.rs
+++ b/crates/integrations/datafusion/src/catalog.rs
@@ -382,6 +382,7 @@ impl SchemaProvider for PaimonSchemaProvider {
         await_with_runtime(async move {
             match catalog.get_table(&identifier).await {
                 Ok(table) => {
+                    let table_definition = crate::table::build_table_definition(&table)?;
                     let opts = dynamic_options.read().unwrap().clone();
                     let table = if opts.is_empty() {
                         table
@@ -394,8 +395,9 @@ impl SchemaProvider for PaimonSchemaProvider {
                             .await
                             .map_err(to_datafusion_error)?
                     };
-                    let provider = PaimonTableProvider::try_new_with_blob_reader_registry(
+                    let provider = PaimonTableProvider::try_new_with_persisted_table_definition(
                         table,
+                        table_definition,
                         blob_reader_registry,
                     )?;
                     Ok(Some(Arc::new(provider) as Arc<dyn TableProvider>))

--- a/crates/integrations/datafusion/src/catalog.rs
+++ b/crates/integrations/datafusion/src/catalog.rs
@@ -395,10 +395,11 @@ impl SchemaProvider for PaimonSchemaProvider {
                             .await
                             .map_err(to_datafusion_error)?
                     };
+                    blob_reader_registry
+                        .register_if_absent(table.location().to_string(), table.file_io().clone());
                     let provider = PaimonTableProvider::try_new_with_persisted_table_definition(
                         table,
                         table_definition,
-                        blob_reader_registry,
                     )?;
                     Ok(Some(Arc::new(provider) as Arc<dyn TableProvider>))
                 }

--- a/crates/integrations/datafusion/src/catalog.rs
+++ b/crates/integrations/datafusion/src/catalog.rs
@@ -382,25 +382,27 @@ impl SchemaProvider for PaimonSchemaProvider {
         await_with_runtime(async move {
             match catalog.get_table(&identifier).await {
                 Ok(table) => {
-                    let table_definition = crate::table::build_table_definition(&table)?;
                     let opts = dynamic_options.read().unwrap().clone();
-                    let table = if opts.is_empty() {
-                        table
+                    let provider = if opts.is_empty() {
+                        PaimonTableProvider::try_new_with_blob_reader_registry(
+                            table,
+                            blob_reader_registry,
+                        )?
                     } else {
+                        let table_definition = crate::table::build_table_definition(&table).ok();
                         // Dynamic options may select a historical snapshot
                         // (e.g. `SET 'paimon.scan.version'`); switch to its
                         // schema so planning sees the snapshot's columns.
-                        table
+                        let table = table
                             .copy_with_time_travel(opts)
                             .await
-                            .map_err(to_datafusion_error)?
-                    };
-                    let provider =
+                            .map_err(to_datafusion_error)?;
                         PaimonTableProvider::try_new_with_blob_reader_registry_and_definition(
                             table,
                             blob_reader_registry,
-                            Some(table_definition),
-                        )?;
+                            table_definition,
+                        )?
+                    };
                     Ok(Some(Arc::new(provider) as Arc<dyn TableProvider>))
                 }
                 Err(paimon::Error::TableNotExist { .. }) => Ok(None),

--- a/crates/integrations/datafusion/src/catalog.rs
+++ b/crates/integrations/datafusion/src/catalog.rs
@@ -395,12 +395,12 @@ impl SchemaProvider for PaimonSchemaProvider {
                             .await
                             .map_err(to_datafusion_error)?
                     };
-                    blob_reader_registry
-                        .register_if_absent(table.location().to_string(), table.file_io().clone());
-                    let provider = PaimonTableProvider::try_new_with_persisted_table_definition(
-                        table,
-                        table_definition,
-                    )?;
+                    let provider =
+                        PaimonTableProvider::try_new_with_blob_reader_registry_and_definition(
+                            table,
+                            blob_reader_registry,
+                            Some(table_definition),
+                        )?;
                     Ok(Some(Arc::new(provider) as Arc<dyn TableProvider>))
                 }
                 Err(paimon::Error::TableNotExist { .. }) => Ok(None),

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -51,8 +51,8 @@ use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion::sql::sqlparser::ast::{
     AlterTableOperation, BinaryLength, CharacterLength, ColumnDef, CreateTable, CreateTableOptions,
     CreateView, Delete, Expr as SqlExpr, FromTable, Insert, Merge, ObjectName, ObjectType,
-    RenameTableNameKind, Reset, ResetStatement, Set, SqlOption, Statement, TableFactor,
-    TableObject, Truncate, Update, Value as SqlValue,
+    RenameTableNameKind, Reset, ResetStatement, Set, ShowCreateObject, SqlOption, Statement,
+    TableFactor, TableObject, Truncate, Update, Value as SqlValue,
 };
 use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
@@ -368,6 +368,10 @@ impl SQLContext {
                         .await
                 }
             }
+            Statement::ShowCreate {
+                obj_type: ShowCreateObject::Table,
+                obj_name,
+            } => self.handle_show_create_table(sql, obj_name).await,
             Statement::AlterTable(alter_table) => {
                 let (catalog, _catalog_name, _) =
                     self.resolve_catalog_and_table(&alter_table.name)?;
@@ -859,6 +863,33 @@ impl SQLContext {
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
         }
         ok_result(&self.ctx)
+    }
+
+    async fn handle_show_create_table(&self, sql: &str, name: &ObjectName) -> DFResult<DataFrame> {
+        let (catalog, catalog_name, identifier) = self.resolve_catalog_and_table(name)?;
+        let table = match catalog.get_table(&identifier).await {
+            Ok(table) => table,
+            Err(paimon::Error::TableNotExist { .. }) => return self.ctx.sql(sql).await,
+            Err(e) => return Err(to_datafusion_error(e)),
+        };
+        let definition = crate::table::build_table_definition(&table)?;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("table_catalog", ArrowDataType::Utf8, false),
+            Field::new("table_schema", ArrowDataType::Utf8, false),
+            Field::new("table_name", ArrowDataType::Utf8, false),
+            Field::new("definition", ArrowDataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![catalog_name])),
+                Arc::new(StringArray::from(vec![identifier.database().to_string()])),
+                Arc::new(StringArray::from(vec![identifier.object().to_string()])),
+                Arc::new(StringArray::from(vec![definition])),
+            ],
+        )?;
+        self.ctx.read_batch(batch)
     }
 
     async fn handle_alter_table(

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -97,6 +97,23 @@ impl PaimonTableProvider {
         Self::try_new(table)
     }
 
+    pub(crate) fn try_new_with_persisted_table_definition(
+        table: Table,
+        table_definition: String,
+        blob_reader_registry: BlobReaderRegistry,
+    ) -> DFResult<Self> {
+        blob_reader_registry
+            .register_if_absent(table.location().to_string(), table.file_io().clone());
+        let fields = datafusion_read_fields(&table);
+        let schema =
+            paimon::arrow::build_target_arrow_schema(&fields).map_err(to_datafusion_error)?;
+        Ok(Self {
+            table,
+            schema,
+            table_definition,
+        })
+    }
+
     pub fn table(&self) -> &Table {
         &self.table
     }
@@ -106,7 +123,7 @@ impl PaimonTableProvider {
 ///
 /// Mirrors the syntax accepted by `SQLContext::handle_create_table`:
 /// `CREATE TABLE <db>.<table> (<col> <type>, ..., PRIMARY KEY (...)) [PARTITIONED BY (...)] [WITH ('k'='v', ...)]`.
-fn build_table_definition(table: &Table) -> DFResult<String> {
+pub(crate) fn build_table_definition(table: &Table) -> DFResult<String> {
     let identifier = table.identifier();
     let schema = table.schema();
     let mut ddl = String::new();

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -69,7 +69,7 @@ pub(crate) fn datafusion_read_fields(table: &Table) -> Vec<DataField> {
 pub struct PaimonTableProvider {
     table: Table,
     schema: ArrowSchemaRef,
-    table_definition: String,
+    table_definition: Option<String>,
 }
 
 impl PaimonTableProvider {
@@ -77,10 +77,17 @@ impl PaimonTableProvider {
     ///
     /// Loads the table schema and converts it to Arrow for DataFusion.
     pub fn try_new(table: Table) -> DFResult<Self> {
+        let table_definition = build_table_definition(&table)?;
+        Self::try_new_with_table_definition(table, Some(table_definition))
+    }
+
+    fn try_new_with_table_definition(
+        table: Table,
+        table_definition: Option<String>,
+    ) -> DFResult<Self> {
         let fields = datafusion_read_fields(&table);
         let schema =
             paimon::arrow::build_target_arrow_schema(&fields).map_err(to_datafusion_error)?;
-        let table_definition = build_table_definition(&table)?;
         Ok(Self {
             table,
             schema,
@@ -92,7 +99,9 @@ impl PaimonTableProvider {
         table: Table,
         blob_reader_registry: BlobReaderRegistry,
     ) -> DFResult<Self> {
-        Self::try_new_with_blob_reader_registry_and_definition(table, blob_reader_registry, None)
+        blob_reader_registry
+            .register_if_absent(table.location().to_string(), table.file_io().clone());
+        Self::try_new(table)
     }
 
     pub(crate) fn try_new_with_blob_reader_registry_and_definition(
@@ -102,11 +111,7 @@ impl PaimonTableProvider {
     ) -> DFResult<Self> {
         blob_reader_registry
             .register_if_absent(table.location().to_string(), table.file_io().clone());
-        let mut provider = Self::try_new(table)?;
-        if let Some(table_definition) = table_definition {
-            provider.table_definition = table_definition;
-        }
-        Ok(provider)
+        Self::try_new_with_table_definition(table, table_definition)
     }
 
     pub fn table(&self) -> &Table {
@@ -334,7 +339,7 @@ impl TableProvider for PaimonTableProvider {
     }
 
     fn get_table_definition(&self) -> Option<&str> {
-        Some(&self.table_definition)
+        self.table_definition.as_deref()
     }
 
     async fn scan(

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -100,10 +100,7 @@ impl PaimonTableProvider {
     pub(crate) fn try_new_with_persisted_table_definition(
         table: Table,
         table_definition: String,
-        blob_reader_registry: BlobReaderRegistry,
     ) -> DFResult<Self> {
-        blob_reader_registry
-            .register_if_absent(table.location().to_string(), table.file_io().clone());
         let fields = datafusion_read_fields(&table);
         let schema =
             paimon::arrow::build_target_arrow_schema(&fields).map_err(to_datafusion_error)?;

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -92,23 +92,21 @@ impl PaimonTableProvider {
         table: Table,
         blob_reader_registry: BlobReaderRegistry,
     ) -> DFResult<Self> {
-        blob_reader_registry
-            .register_if_absent(table.location().to_string(), table.file_io().clone());
-        Self::try_new(table)
+        Self::try_new_with_blob_reader_registry_and_definition(table, blob_reader_registry, None)
     }
 
-    pub(crate) fn try_new_with_persisted_table_definition(
+    pub(crate) fn try_new_with_blob_reader_registry_and_definition(
         table: Table,
-        table_definition: String,
+        blob_reader_registry: BlobReaderRegistry,
+        table_definition: Option<String>,
     ) -> DFResult<Self> {
-        let fields = datafusion_read_fields(&table);
-        let schema =
-            paimon::arrow::build_target_arrow_schema(&fields).map_err(to_datafusion_error)?;
-        Ok(Self {
-            table,
-            schema,
-            table_definition,
-        })
+        blob_reader_registry
+            .register_if_absent(table.location().to_string(), table.file_io().clone());
+        let mut provider = Self::try_new(table)?;
+        if let Some(table_definition) = table_definition {
+            provider.table_definition = table_definition;
+        }
+        Ok(provider)
     }
 
     pub fn table(&self) -> &Table {

--- a/crates/integrations/datafusion/tests/sql_context_tests.rs
+++ b/crates/integrations/datafusion/tests/sql_context_tests.rs
@@ -1381,6 +1381,44 @@ async fn test_show_create_table_with_partition_and_options() {
 }
 
 #[tokio::test]
+async fn test_show_create_table_excludes_session_dynamic_options() {
+    let (_tmp, catalog) = create_test_env();
+    let sql_context = create_sql_context(catalog).await;
+
+    sql_context
+        .sql("CREATE SCHEMA paimon.test_db")
+        .await
+        .expect("CREATE SCHEMA should succeed");
+    sql_context
+        .sql(
+            "CREATE TABLE paimon.test_db.t (id INT, name VARCHAR, pt INT) \
+             PARTITIONED BY (pt) WITH ('bucket' = '4')",
+        )
+        .await
+        .expect("CREATE TABLE should succeed");
+    sql_context
+        .sql("SET 'paimon.scan.version' = '1'")
+        .await
+        .expect("SET scan.version should succeed");
+    sql_context
+        .sql("SET 'paimon.blob-as-descriptor' = 'true'")
+        .await
+        .expect("SET blob-as-descriptor should succeed");
+
+    let definition = collect_definition(&sql_context, "paimon.test_db.t").await;
+    assert!(
+        definition.contains("'bucket' = '4'"),
+        "definition should keep persisted table options, got: {definition}"
+    );
+    for dynamic_option in ["scan.version", "blob-as-descriptor"] {
+        assert!(
+            !definition.contains(dynamic_option),
+            "definition should not contain session dynamic option {dynamic_option}, got: {definition}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_show_create_table_various_types() {
     let (_tmp, catalog) = create_test_env();
     let sql_context = create_sql_context(catalog).await;

--- a/crates/integrations/datafusion/tests/sql_context_tests.rs
+++ b/crates/integrations/datafusion/tests/sql_context_tests.rs
@@ -24,8 +24,8 @@ use datafusion::datasource::MemTable;
 use paimon::catalog::Identifier;
 use paimon::spec::{
     ArrayType, BinaryType, BlobType, CharType, DataType, FloatType, IntType,
-    LocalZonedTimestampType, MapType, MultisetType, TimeType, VarBinaryType, VarCharType,
-    VectorType,
+    LocalZonedTimestampType, MapType, MultisetType, SchemaChange, TimeType, VarBinaryType,
+    VarCharType, VectorType,
 };
 use paimon::{Catalog, CatalogOptions, FileSystemCatalog, Options};
 use paimon_datafusion::{PaimonCatalogProvider, SQLContext};
@@ -1416,6 +1416,60 @@ async fn test_show_create_table_excludes_session_dynamic_options() {
             "definition should not contain session dynamic option {dynamic_option}, got: {definition}"
         );
     }
+}
+
+#[tokio::test]
+async fn test_dynamic_scan_ignores_current_show_create_unsupported_type() {
+    let (_tmp, catalog) = create_test_env();
+    let sql_context = create_sql_context(catalog.clone()).await;
+
+    sql_context
+        .sql("CREATE SCHEMA paimon.test_db")
+        .await
+        .expect("CREATE SCHEMA should succeed");
+    sql_context
+        .sql("CREATE TABLE paimon.test_db.t (id INT)")
+        .await
+        .expect("CREATE TABLE should succeed");
+    sql_context
+        .sql("INSERT INTO paimon.test_db.t VALUES (1)")
+        .await
+        .expect("INSERT should plan")
+        .collect()
+        .await
+        .expect("INSERT should execute");
+    sql_context
+        .sql("CALL sys.create_tag(table => 'test_db.t', tag => 'before_time')")
+        .await
+        .expect("CREATE TAG should succeed");
+
+    let identifier = Identifier::new("test_db", "t");
+    catalog
+        .alter_table(
+            &identifier,
+            vec![SchemaChange::add_column(
+                "unsupported_col".to_string(),
+                DataType::Time(TimeType::new(3).unwrap()),
+            )],
+            false,
+        )
+        .await
+        .expect("ALTER TABLE should add unsupported SHOW CREATE type");
+
+    sql_context
+        .sql("SET 'paimon.scan.version' = 'before_time'")
+        .await
+        .expect("SET scan.version should succeed");
+
+    let rows = sql_context
+        .sql("SELECT id FROM paimon.test_db.t")
+        .await
+        .expect("dynamic scan should plan with historical schema")
+        .collect()
+        .await
+        .expect("dynamic scan should execute");
+    let row_count: usize = rows.iter().map(|batch| batch.num_rows()).sum();
+    assert_eq!(row_count, 1);
 }
 
 #[tokio::test]

--- a/crates/integrations/datafusion/tests/sql_context_tests.rs
+++ b/crates/integrations/datafusion/tests/sql_context_tests.rs
@@ -1392,12 +1392,27 @@ async fn test_show_create_table_excludes_session_dynamic_options() {
     sql_context
         .sql(
             "CREATE TABLE paimon.test_db.t (id INT, name VARCHAR, pt INT) \
-             PARTITIONED BY (pt) WITH ('bucket' = '4')",
+             PARTITIONED BY (pt) WITH ('file.format' = 'parquet')",
         )
         .await
         .expect("CREATE TABLE should succeed");
     sql_context
-        .sql("SET 'paimon.scan.version' = '1'")
+        .sql("INSERT INTO paimon.test_db.t VALUES (1, 'one', 1)")
+        .await
+        .expect("INSERT should plan")
+        .collect()
+        .await
+        .expect("INSERT should execute");
+    sql_context
+        .sql("CALL sys.create_tag(table => 'test_db.t', tag => 'before_age')")
+        .await
+        .expect("CREATE TAG should succeed");
+    sql_context
+        .sql("ALTER TABLE paimon.test_db.t ADD COLUMN age INT")
+        .await
+        .expect("ALTER TABLE should succeed");
+    sql_context
+        .sql("SET 'paimon.scan.version' = 'before_age'")
         .await
         .expect("SET scan.version should succeed");
     sql_context
@@ -1407,8 +1422,12 @@ async fn test_show_create_table_excludes_session_dynamic_options() {
 
     let definition = collect_definition(&sql_context, "paimon.test_db.t").await;
     assert!(
-        definition.contains("'bucket' = '4'"),
+        definition.contains("'file.format' = 'parquet'"),
         "definition should keep persisted table options, got: {definition}"
+    );
+    assert!(
+        definition.contains("\"age\" INT"),
+        "definition should use current persisted schema, got: {definition}"
     );
     for dynamic_option in ["scan.version", "blob-as-descriptor"] {
         assert!(
@@ -1462,12 +1481,14 @@ async fn test_dynamic_scan_ignores_current_show_create_unsupported_type() {
         .expect("SET scan.version should succeed");
 
     let rows = sql_context
-        .sql("SELECT id FROM paimon.test_db.t")
+        .sql("SELECT * FROM paimon.test_db.t")
         .await
         .expect("dynamic scan should plan with historical schema")
         .collect()
         .await
         .expect("dynamic scan should execute");
+    assert_eq!(rows[0].schema().fields().len(), 1);
+    assert_eq!(rows[0].schema().field(0).name(), "id");
     let row_count: usize = rows.iter().map(|batch| batch.num_rows()).sum();
     assert_eq!(row_count, 1);
 }
@@ -1795,6 +1816,11 @@ async fn test_show_create_table_rejects_non_round_trippable_types() {
             .create_table(&identifier, schema, false)
             .await
             .expect("table should be created");
+
+        sql_context
+            .sql("SET 'paimon.blob-as-descriptor' = 'true'")
+            .await
+            .expect("SET blob-as-descriptor should succeed");
 
         let err = sql_context
             .sql(&format!("SHOW CREATE TABLE paimon.test_db.{table_name}"))


### PR DESCRIPTION
## Summary
- Follow up on #444 by building `SHOW CREATE TABLE` definitions from persisted table metadata before session dynamic options are merged for planning/scans
- Keep the existing blob reader registry helper path and only add an optional persisted definition override for the catalog provider path
- Add regression coverage for multiple session dynamic options (`scan.version` and `blob-as-descriptor`) while ensuring persisted table options remain in the output

## Validation
- cargo test -p paimon-datafusion --test sql_context_tests test_show_create_table_excludes_session_dynamic_options
- cargo test -p paimon-datafusion --test sql_context_tests
- cargo test -p paimon-datafusion --test blob_tests
