### PR TITLE
fix(index): propagate fallible with_projection in btree index build

### DIFF
--- a/crates/paimon/src/table/btree_global_index_build_builder.rs
+++ b/crates/paimon/src/table/btree_global_index_build_builder.rs
@@ -559,7 +559,7 @@ async fn extract_index_rows(
     let splits = build_read_splits_for_shard(shard)?;
 
     let mut read_builder = table.new_read_builder();
-    read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME]);
+    read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME])?;
     let read = read_builder.new_read()?;
     let batches = read.to_arrow(&splits)?.try_collect::<Vec<_>>().await?;
     extract_index_rows_from_batches(


### PR DESCRIPTION
### Purpose

CI on `main` is red: the `check` job fails clippy with an unused `Result` in `btree_global_index_build_builder.rs:562`. #454 was written before #460 made `ReadBuilder::with_projection` fallible and merged without a rebase check against it. Every open PR's merge CI now fails on the same error regardless of its own changes.

(Hotfix for CI breakage — no linked issue, per the contribution checklist exception.)

### Brief change log

Propagate the `Result` with `?` — `extract_index_rows` already returns `Result`, and a projection failure here (unknown/duplicate column) should abort the index build rather than silently read the full row.

### Tests

`cargo clippy -p paimon --all-targets --features fulltext,vortex,mosaic -- -D warnings`: clean (was failing).
`cargo test -p paimon --lib btree`: 58 passed.

### API and Format

None.

### Documentation

None.
