### PR TITLE
fix(core): correct BTREE_INDEX_TYPE typo breaking the build

### DIFF
--- a/crates/paimon/src/table/btree_global_index_build_builder.rs
+++ b/crates/paimon/src/table/btree_global_index_build_builder.rs
@@ -113,7 +113,7 @@ impl<'a> BTreeGlobalIndexBuildBuilder<'a> {
         let indexed = crate::table::global_index_build_common::indexed_row_ranges(
             self.table,
             snapshot.index_manifest(),
-            BTREE_INDEX_TYPE,
+            BTREE_GLOBAL_INDEX_TYPE,
             index_field.id(),
             None, // single-column build; no extra fields today
         )
@@ -136,7 +136,7 @@ impl<'a> BTreeGlobalIndexBuildBuilder<'a> {
         crate::table::global_index_build_common::validate_existing_index_overlap(
             self.table,
             snapshot.index_manifest(),
-            BTREE_INDEX_TYPE,
+            BTREE_GLOBAL_INDEX_TYPE,
             index_field.id(),
             None,
             &shards
@@ -1359,7 +1359,7 @@ mod tests {
         .unwrap()
         .into_iter()
         .filter(|entry| {
-            entry.kind == FileKind::Add && entry.index_file.index_type == BTREE_INDEX_TYPE
+            entry.kind == FileKind::Add && entry.index_file.index_type == BTREE_GLOBAL_INDEX_TYPE
         })
         .map(|entry| entry.index_file)
         .collect()
@@ -1749,7 +1749,7 @@ mod tests {
         let hole_start = 4;
         let hole_end = 6;
         let synthetic = IndexFileMeta {
-            index_type: BTREE_INDEX_TYPE.to_string(),
+            index_type: BTREE_GLOBAL_INDEX_TYPE.to_string(),
             file_name: "btree-synthetic-hole.index".to_string(),
             file_size: 1,
             row_count: (hole_end - hole_start + 1) as i32,


### PR DESCRIPTION
## What

Commit #479 (`feat(core): incremental global index build for btree, lumina, and vindex`) introduced references to an undefined constant `BTREE_INDEX_TYPE` in `crates/paimon/src/table/btree_global_index_build_builder.rs`, causing a `E0425: cannot find value BTREE_INDEX_TYPE in this scope` compile error.

This broke `main` across all CI jobs (Clippy, build, unit tests, integration).

## Fix

Replace the four `BTREE_INDEX_TYPE` references with `BTREE_GLOBAL_INDEX_TYPE`, the constant already imported in the module from `global_index_types` (value `"btree"`).

## Verification

`cargo clippy -p paimon --all-targets` passes cleanly.