### PR TITLE
feat(datafusion): implement DROP VIEW functionality in REST Catalog

### DIFF
--- a/crates/integrations/datafusion/README.md
+++ b/crates/integrations/datafusion/README.md
@@ -26,11 +26,11 @@ This crate contains the integration of [Apache DataFusion](https://datafusion.ap
 
 ## REST Catalog views and SQL functions
 
-`SQLContext` can read, execute, and create persistent views and SQL scalar functions in a Paimon
-REST Catalog:
+`SQLContext` can read, execute, create, and drop persistent views and can create SQL scalar functions in a Paimon REST Catalog:
 
 ```sql
 CREATE VIEW [IF NOT EXISTS] view_name [(column_name, ...)] AS query;
+DROP VIEW [IF EXISTS] view_name;
 
 CREATE FUNCTION [IF NOT EXISTS] function_name([parameter_name data_type, ...])
 RETURNS data_type
@@ -45,6 +45,10 @@ RETURN scalar_expression;
   column list overrides names only and must match the query output. Unqualified relations and REST
   SQL functions are planned in the new view's owning catalog and database. `IF NOT EXISTS` is
   handled atomically by the catalog.
+- `DROP VIEW` accepts bare, two-part, and three-part names and sends one direct REST delete request.
+  `IF EXISTS` ignores only a missing view. Multiple targets and `CASCADE`, `RESTRICT`, `PURGE`, or
+  other drop modifiers are not supported. Catalogs without persistent view support may return
+  `Unsupported`.
 - A SQL function can be called as `function(args...)` in the current catalog/database or as
   `catalog.database.function(args...)`. Its `definitions.datafusion` value must be a scalar SQL
   expression, it must be deterministic, and it must declare its input parameters and exactly one
@@ -54,10 +58,10 @@ RETURN scalar_expression;
   inferred and validated from the planned expression before sending the REST create request. Bare,
   two-part, and three-part creation targets are supported; calls remain limited to bare and
   three-part names.
-- `CREATE OR REPLACE VIEW`, materialized/secure views, comments/options, persistent `ALTER VIEW` /
-  `DROP VIEW`, `CREATE OR REPLACE/ALTER/TEMPORARY FUNCTION`, and persistent `ALTER FUNCTION` /
-  `DROP FUNCTION` are not supported. Lambda/file, aggregate/table/multi-return, non-deterministic,
-  Stable/Volatile, and non-SQL functions are also not supported.
+- `CREATE OR REPLACE VIEW`, materialized/secure views, comments/options, persistent `ALTER VIEW`,
+  `CREATE OR REPLACE/ALTER/TEMPORARY FUNCTION`, and persistent `ALTER FUNCTION` / `DROP FUNCTION`
+  are not supported. Lambda/file, aggregate/table/multi-return, non-deterministic, Stable/Volatile,
+  and non-SQL functions are also not supported.
 
 Use `SQLContext::sql` for function expansion:
 

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -31,6 +31,7 @@
 //! - `ALTER TABLE db.t RENAME TO new_name`
 //! - `ALTER TABLE db.t DROP PARTITION (col = val, ...)`
 //! - `CREATE VIEW [IF NOT EXISTS] view [(col, ...)] AS query`
+//! - `DROP VIEW [IF EXISTS] view`
 //! - `CREATE FUNCTION name(args) RETURNS type [LANGUAGE SQL] RETURN expression`
 //! - `TRUNCATE TABLE db.t`
 //! - `TRUNCATE TABLE db.t PARTITION (col = val, ...)`
@@ -466,8 +467,11 @@ impl SQLContext {
                 object_type,
                 if_exists,
                 names,
+                cascade,
+                restrict,
+                purge,
                 temporary,
-                ..
+                table,
             } if matches!(*object_type, ObjectType::Table | ObjectType::View) => {
                 if *temporary {
                     self.handle_drop_temp_table(names, *if_exists)
@@ -482,7 +486,42 @@ impl SQLContext {
                         self.ctx.sql(sql).await
                     }
                 } else {
-                    self.ctx.sql(sql).await
+                    let targets_paimon_catalog = names.iter().any(|name| {
+                        let table_ref: TableReference = name.to_string().as_str().into();
+                        self.is_paimon_catalog_ref(&table_ref)
+                    });
+                    if !targets_paimon_catalog {
+                        return self.ctx.sql(sql).await;
+                    }
+                    let [name] = names.as_slice() else {
+                        return Err(DataFusionError::Plan(
+                            "Persistent DROP VIEW does not support multiple views".to_string(),
+                        ));
+                    };
+                    if *cascade {
+                        return Err(DataFusionError::Plan(
+                            "DROP VIEW CASCADE is not supported".to_string(),
+                        ));
+                    }
+                    if *restrict {
+                        return Err(DataFusionError::Plan(
+                            "DROP VIEW RESTRICT is not supported".to_string(),
+                        ));
+                    }
+                    if *purge {
+                        return Err(DataFusionError::Plan(
+                            "DROP VIEW PURGE is not supported".to_string(),
+                        ));
+                    }
+                    if table.is_some() {
+                        return Err(DataFusionError::Plan(
+                            "DROP VIEW ON clauses are not supported".to_string(),
+                        ));
+                    }
+                    let (catalog, _catalog_name, identifier) =
+                        self.resolve_catalog_and_table(name)?;
+                    self.handle_drop_view(&catalog, &identifier, *if_exists)
+                        .await
                 }
             }
             Statement::Call(func) => {
@@ -937,6 +976,19 @@ impl SQLContext {
                 .await
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
         }
+        ok_result(&self.ctx)
+    }
+
+    async fn handle_drop_view(
+        &self,
+        catalog: &Arc<dyn Catalog>,
+        identifier: &Identifier,
+        if_exists: bool,
+    ) -> DFResult<DataFrame> {
+        catalog
+            .drop_view(identifier, if_exists)
+            .await
+            .map_err(to_datafusion_error)?;
         ok_result(&self.ctx)
     }
 
@@ -3256,6 +3308,7 @@ mod tests {
         existing_table: Mutex<Option<Table>>,
         functions: Mutex<HashMap<Identifier, paimon::catalog::Function>>,
         views: Mutex<HashMap<Identifier, paimon::catalog::View>>,
+        drop_view_supported: bool,
     }
 
     impl MockCatalog {
@@ -3265,6 +3318,14 @@ mod tests {
                 existing_table: Mutex::new(None),
                 functions: Mutex::new(HashMap::new()),
                 views: Mutex::new(HashMap::new()),
+                drop_view_supported: true,
+            }
+        }
+
+        fn without_drop_view_support() -> Self {
+            Self {
+                drop_view_supported: false,
+                ..Self::new()
             }
         }
 
@@ -3455,6 +3516,25 @@ mod tests {
             );
             Ok(())
         }
+
+        async fn drop_view(
+            &self,
+            identifier: &Identifier,
+            ignore_if_not_exists: bool,
+        ) -> paimon::Result<()> {
+            if !self.drop_view_supported {
+                return Err(paimon::Error::Unsupported {
+                    message: "Catalog does not support views".to_string(),
+                });
+            }
+            if self.views.lock().unwrap().remove(identifier).is_some() || ignore_if_not_exists {
+                Ok(())
+            } else {
+                Err(paimon::Error::ViewNotExist {
+                    full_name: identifier.full_name(),
+                })
+            }
+        }
     }
 
     async fn make_sql_context(catalog: Arc<MockCatalog>) -> SQLContext {
@@ -3569,6 +3649,148 @@ mod tests {
             .downcast_ref::<Int64Array>()
             .unwrap();
         assert_eq!(answers.value(0), 42);
+    }
+
+    #[tokio::test]
+    async fn persistent_rest_catalog_view_can_be_dropped() {
+        let catalog = Arc::new(MockCatalog::new());
+        let ctx = make_sql_context(Arc::clone(&catalog)).await;
+        ctx.sql(
+            "CREATE VIEW answer_view AS \
+             SELECT CAST(42 AS BIGINT) AS answer",
+        )
+        .await
+        .unwrap();
+
+        ctx.sql("DROP VIEW answer_view").await.unwrap();
+
+        assert!(matches!(
+            catalog
+                .get_view(&Identifier::new("default", "answer_view"))
+                .await,
+            Err(paimon::Error::ViewNotExist { .. })
+        ));
+        assert!(ctx.sql("SELECT * FROM answer_view").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn persistent_rest_catalog_view_drop_honors_if_exists() {
+        let catalog = Arc::new(MockCatalog::new());
+        let ctx = make_sql_context(catalog).await;
+
+        let error = ctx.sql("DROP VIEW missing_view").await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("View default.missing_view does not exist"),
+            "unexpected error: {error}"
+        );
+        ctx.sql("DROP VIEW IF EXISTS missing_view").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn persistent_rest_catalog_view_drop_resolves_supported_name_forms() {
+        let catalog = Arc::new(MockCatalog::new());
+        add_bigint_view(&catalog, "default", "bare_view", "SELECT 1 AS answer");
+        add_bigint_view(&catalog, "other", "two_part", "SELECT 1 AS answer");
+        add_bigint_view(&catalog, "other", "three_part", "SELECT 1 AS answer");
+        add_bigint_view(&catalog, "default", "Quoted View", "SELECT 1 AS answer");
+        let ctx = make_sql_context(Arc::clone(&catalog)).await;
+
+        ctx.sql("DROP VIEW bare_view").await.unwrap();
+        ctx.sql("DROP VIEW IF EXISTS other.two_part").await.unwrap();
+        ctx.sql("DROP VIEW IF EXISTS paimon.other.three_part")
+            .await
+            .unwrap();
+        ctx.sql("DROP VIEW \"Quoted View\"").await.unwrap();
+
+        for identifier in [
+            Identifier::new("default", "bare_view"),
+            Identifier::new("other", "two_part"),
+            Identifier::new("other", "three_part"),
+            Identifier::new("default", "Quoted View"),
+        ] {
+            assert!(matches!(
+                catalog.get_view(&identifier).await,
+                Err(paimon::Error::ViewNotExist { .. })
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn persistent_rest_catalog_view_drop_rejects_unsupported_modifiers() {
+        let cases = [
+            ("DROP VIEW paimon.default.invalid_view CASCADE", "CASCADE"),
+            ("DROP VIEW paimon.default.invalid_view RESTRICT", "RESTRICT"),
+            ("DROP VIEW paimon.default.invalid_view PURGE", "PURGE"),
+            (
+                "DROP VIEW paimon.default.invalid_view ON default.target",
+                "ON clauses",
+            ),
+        ];
+
+        for (sql, modifier) in cases {
+            let catalog = Arc::new(MockCatalog::new());
+            let ctx = make_sql_context(catalog).await;
+            let error = ctx.sql(sql).await.unwrap_err();
+            assert!(
+                error.to_string().contains(modifier),
+                "expected {modifier} error, got: {error}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn persistent_rest_catalog_view_drop_rejects_multiple_targets_before_deleting() {
+        let catalog = Arc::new(MockCatalog::new());
+        add_bigint_view(&catalog, "default", "first", "SELECT 1 AS answer");
+        let ctx = make_sql_context(Arc::clone(&catalog)).await;
+
+        let error = ctx
+            .sql("DROP VIEW paimon.default.first, datafusion.public.second")
+            .await
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("Persistent DROP VIEW does not support multiple views"));
+        assert!(catalog
+            .get_view(&Identifier::new("default", "first"))
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn persistent_rest_catalog_view_drop_propagates_unsupported_catalog() {
+        let catalog = Arc::new(MockCatalog::without_drop_view_support());
+        add_bigint_view(&catalog, "default", "answer_view", "SELECT 1 AS answer");
+        let ctx = make_sql_context(Arc::clone(&catalog)).await;
+
+        let error = ctx.sql("DROP VIEW answer_view").await.unwrap_err();
+
+        assert!(error.to_string().contains("Catalog does not support views"));
+        assert!(catalog
+            .get_view(&Identifier::new("default", "answer_view"))
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn persistent_rest_catalog_view_drop_delegates_non_paimon_catalog() {
+        let catalog = Arc::new(MockCatalog::new());
+        let ctx = make_sql_context(catalog).await;
+        ctx.sql("CREATE VIEW datafusion.public.delegated_view AS SELECT 1 AS answer")
+            .await
+            .unwrap();
+
+        ctx.sql("DROP VIEW datafusion.public.delegated_view")
+            .await
+            .unwrap();
+
+        assert!(ctx
+            .sql("SELECT * FROM datafusion.public.delegated_view")
+            .await
+            .is_err());
     }
 
     #[tokio::test]

--- a/crates/paimon/src/api/rest_api.rs
+++ b/crates/paimon/src/api/rest_api.rs
@@ -467,6 +467,16 @@ impl RESTApi {
         self.client.get(&path, None::<&[(&str, &str)]>).await
     }
 
+    /// Drop a persistent view.
+    pub async fn drop_view(&self, identifier: &Identifier) -> Result<()> {
+        let database = identifier.database();
+        let view = identifier.object();
+        validate_non_empty_multi(&[(database, "database name"), (view, "view name")])?;
+        let path = self.resource_paths.view(database, view);
+        let _resp: serde_json::Value = self.client.delete(&path, None::<&[(&str, &str)]>).await?;
+        Ok(())
+    }
+
     // ==================== Function Operations ====================
 
     /// Create a persistent function.

--- a/crates/paimon/src/catalog/mod.rs
+++ b/crates/paimon/src/catalog/mod.rs
@@ -389,6 +389,17 @@ pub trait Catalog: Send + Sync {
         })
     }
 
+    /// Drop a persistent view.
+    ///
+    /// # Errors
+    /// * [`crate::Error::ViewNotExist`] - view does not exist when
+    ///   `ignore_if_not_exists` is false.
+    async fn drop_view(&self, _identifier: &Identifier, _ignore_if_not_exists: bool) -> Result<()> {
+        Err(Error::Unsupported {
+            message: "Catalog does not support views".to_string(),
+        })
+    }
+
     /// List persistent view names in a database.
     async fn list_views(&self, _database_name: &str) -> Result<Vec<String>> {
         Err(Error::Unsupported {

--- a/crates/paimon/src/catalog/rest/rest_catalog.rs
+++ b/crates/paimon/src/catalog/rest/rest_catalog.rs
@@ -313,6 +313,17 @@ impl Catalog for RESTCatalog {
         ))
     }
 
+    async fn drop_view(&self, identifier: &Identifier, ignore_if_not_exists: bool) -> Result<()> {
+        let result = self
+            .api
+            .drop_view(identifier)
+            .await
+            .map_err(|error| map_rest_error_for_view(error, identifier));
+        ignore_error_if(result, |error| {
+            ignore_if_not_exists && matches!(error, Error::ViewNotExist { .. })
+        })
+    }
+
     async fn list_functions(&self, database_name: &str) -> Result<Vec<String>> {
         self.api
             .list_functions(database_name)

--- a/crates/paimon/tests/mock_server.rs
+++ b/crates/paimon/tests/mock_server.rs
@@ -49,6 +49,7 @@ struct MockState {
     views: HashMap<String, GetViewResponse>,
     functions: HashMap<String, GetFunctionResponse>,
     view_function_endpoints_unsupported: bool,
+    drop_view_error_status: Option<StatusCode>,
     list_page_size: Option<usize>,
     no_permission_databases: HashSet<String>,
     no_permission_tables: HashSet<String>,
@@ -358,6 +359,44 @@ impl RESTServer {
         let key = format!("{db}.{view}");
         if let Some(response) = s.views.get(&key) {
             (StatusCode::OK, Json(response.clone())).into_response()
+        } else {
+            let err = ErrorResponse::new(
+                Some("view".to_string()),
+                Some(view),
+                Some("Not Found".to_string()),
+                Some(404),
+            );
+            (StatusCode::NOT_FOUND, Json(err)).into_response()
+        }
+    }
+
+    /// Handle DELETE /databases/:db/views/:view - drop a persistent view.
+    pub async fn drop_view(
+        Path((db, view)): Path<(String, String)>,
+        Extension(state): Extension<Arc<RESTServer>>,
+    ) -> impl IntoResponse {
+        let mut s = state.inner.lock().unwrap();
+        if s.view_function_endpoints_unsupported {
+            let err = ErrorResponse::new(
+                Some("view".to_string()),
+                Some(view),
+                Some("Not Implemented".to_string()),
+                Some(501),
+            );
+            return (StatusCode::NOT_IMPLEMENTED, Json(err)).into_response();
+        }
+        if let Some(status) = s.drop_view_error_status {
+            let err = ErrorResponse::new(
+                Some("view".to_string()),
+                Some(view),
+                status.canonical_reason().map(ToString::to_string),
+                Some(status.as_u16() as i32),
+            );
+            return (status, Json(err)).into_response();
+        }
+        let key = format!("{db}.{view}");
+        if s.views.remove(&key).is_some() {
+            (StatusCode::OK, Json(serde_json::json!(""))).into_response()
         } else {
             let err = ErrorResponse::new(
                 Some("view".to_string()),
@@ -886,6 +925,11 @@ impl RESTServer {
             .view_function_endpoints_unsupported = true;
     }
 
+    /// Make the drop-view endpoint return the given status.
+    pub fn set_drop_view_error_status(&self, status: Option<StatusCode>) {
+        self.inner.lock().unwrap().drop_view_error_status = status;
+    }
+
     /// Add a table with schema and path to the server state.
     ///
     /// This is needed for `RESTCatalog::get_table` which requires
@@ -1051,7 +1095,7 @@ pub async fn start_mock_server(
         )
         .route(
             &format!("{prefix}/databases/:db/views/:view"),
-            get(RESTServer::get_view),
+            get(RESTServer::get_view).delete(RESTServer::drop_view),
         )
         .route(
             &format!("{prefix}/databases/:db/functions"),

--- a/crates/paimon/tests/rest_api_test.rs
+++ b/crates/paimon/tests/rest_api_test.rs
@@ -135,6 +135,37 @@ async fn test_create_view() {
 }
 
 #[tokio::test]
+async fn test_drop_view_uses_encoded_individual_view_path() {
+    let database = "db+%";
+    let view = "active+?#%";
+    let ctx = setup_test_server(vec![database]).await;
+    let schema = ViewSchema::new(
+        Vec::new(),
+        "SELECT 1".to_string(),
+        HashMap::new(),
+        None,
+        HashMap::new(),
+    );
+    let identifier = Identifier::new(database, view);
+    ctx.api.create_view(&identifier, schema).await.unwrap();
+
+    ctx.api.drop_view(&identifier).await.unwrap();
+
+    assert!(matches!(
+        ctx.api.get_view(&identifier).await.unwrap_err(),
+        paimon::Error::RestApi {
+            source: paimon::api::RestError::NoSuchResource { .. }
+        }
+    ));
+    assert!(matches!(
+        ctx.api.drop_view(&identifier).await.unwrap_err(),
+        paimon::Error::RestApi {
+            source: paimon::api::RestError::NoSuchResource { .. }
+        }
+    ));
+}
+
+#[tokio::test]
 async fn test_list_views() {
     let ctx = setup_test_server(vec!["default"]).await;
     ctx.server.set_list_page_size(1);

--- a/crates/paimon/tests/rest_catalog_test.rs
+++ b/crates/paimon/tests/rest_catalog_test.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 
 use arrow_array::{Array, BinaryArray, Int32Array, Int64Array, RecordBatch, StringArray};
 use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+use axum::http::StatusCode;
 use futures::TryStreamExt;
 use paimon::api::ConfigResponse;
 use paimon::catalog::{Catalog, Function, FunctionDefinition, Identifier, RESTCatalog, ViewSchema};
@@ -1053,6 +1054,70 @@ async fn test_catalog_create_view() {
 }
 
 #[tokio::test]
+async fn test_catalog_drop_view() {
+    let ctx = setup_catalog(vec!["default"]).await;
+    let identifier = Identifier::new("default", "active_ids");
+    ctx.catalog
+        .create_view(
+            &identifier,
+            ViewSchema::new(
+                Vec::new(),
+                "SELECT 1".to_string(),
+                HashMap::new(),
+                None,
+                HashMap::new(),
+            ),
+            false,
+        )
+        .await
+        .unwrap();
+
+    ctx.catalog.drop_view(&identifier, false).await.unwrap();
+
+    assert!(ctx.catalog.list_views("default").await.unwrap().is_empty());
+    assert!(matches!(
+        ctx.catalog.get_view(&identifier).await.unwrap_err(),
+        paimon::Error::ViewNotExist { full_name } if full_name == "default.active_ids"
+    ));
+}
+
+#[tokio::test]
+async fn test_catalog_drop_missing_view_honors_ignore_if_not_exists() {
+    let ctx = setup_catalog(vec!["default"]).await;
+    let identifier = Identifier::new("default", "missing");
+
+    assert!(matches!(
+        ctx.catalog.drop_view(&identifier, false).await.unwrap_err(),
+        paimon::Error::ViewNotExist { full_name } if full_name == "default.missing"
+    ));
+    ctx.catalog.drop_view(&identifier, true).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_catalog_drop_view_if_exists_does_not_hide_other_errors() {
+    let ctx = setup_catalog(vec!["default"]).await;
+    let identifier = Identifier::new("default", "active_ids");
+
+    ctx.server
+        .set_drop_view_error_status(Some(StatusCode::FORBIDDEN));
+    assert!(matches!(
+        ctx.catalog.drop_view(&identifier, true).await.unwrap_err(),
+        paimon::Error::RestApi {
+            source: paimon::api::RestError::Forbidden { .. }
+        }
+    ));
+
+    ctx.server
+        .set_drop_view_error_status(Some(StatusCode::INTERNAL_SERVER_ERROR));
+    assert!(matches!(
+        ctx.catalog.drop_view(&identifier, true).await.unwrap_err(),
+        paimon::Error::RestApi {
+            source: paimon::api::RestError::ServiceFailure { .. }
+        }
+    ));
+}
+
+#[tokio::test]
 async fn test_catalog_create_view_missing_database() {
     let ctx = setup_catalog(vec!["default"]).await;
     let identifier = Identifier::new("missing_db", "active_ids");
@@ -1395,6 +1460,13 @@ async fn test_catalog_maps_unsupported_view_and_function_endpoints() {
     assert!(matches!(
         ctx.catalog
             .get_view(&Identifier::new("default", "view"))
+            .await
+            .unwrap_err(),
+        paimon::Error::Unsupported { .. }
+    ));
+    assert!(matches!(
+        ctx.catalog
+            .drop_view(&Identifier::new("default", "view"), true)
             .await
             .unwrap_err(),
         paimon::Error::Unsupported { .. }

--- a/docs/src/sql.md
+++ b/docs/src/sql.md
@@ -40,7 +40,7 @@ Mosaic support is always available and currently read-only. SQL queries can read
 SQL support has two layers:
 
 - DataFusion provides the parser, query planner, optimizer, execution engine, expressions, scalar functions, aggregate functions, and window functions. SQL statements that `SQLContext` does not intercept are delegated to DataFusion. This includes the DataFusion SQL surface for `SELECT` queries, CTEs (including recursive CTEs), subqueries, joins including `LATERAL` joins, SQL lambda functions, grouping, `HAVING`, window clauses, `QUALIFY`, set operations, `ORDER BY`, `LIMIT`/`OFFSET`, `EXPLAIN`, information-schema commands such as `SHOW TABLES`, `DESCRIBE`, `COPY`, and ordinary `INSERT`.
-- Paimon-specific table management and row-level writes are implemented by `SQLContext`. This includes Paimon `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, `CREATE TEMPORARY TABLE`, `CREATE TEMPORARY VIEW`, REST Catalog persistent `CREATE VIEW` and `CREATE FUNCTION`, `DROP TEMPORARY TABLE` / `VIEW`, `INSERT OVERWRITE ... PARTITION`, `UPDATE`, `DELETE`, `MERGE INTO`, `TRUNCATE TABLE`, `ALTER TABLE ... DROP PARTITION`, `CALL sys.*`, Paimon time travel, and `SET` / `RESET 'paimon.*'`.
+- Paimon-specific table management and row-level writes are implemented by `SQLContext`. This includes Paimon `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, `CREATE TEMPORARY TABLE`, `CREATE TEMPORARY VIEW`, REST Catalog persistent `CREATE VIEW`, `DROP VIEW`, and `CREATE FUNCTION`, `DROP TEMPORARY TABLE` / `VIEW`, `INSERT OVERWRITE ... PARTITION`, `UPDATE`, `DELETE`, `MERGE INTO`, `TRUNCATE TABLE`, `ALTER TABLE ... DROP PARTITION`, `CALL sys.*`, Paimon time travel, and `SET` / `RESET 'paimon.*'`.
 
 Not every DataFusion DDL/DML statement maps to a Paimon table operation. For Paimon catalogs, `CREATE EXTERNAL TABLE`, `LOCATION`, `CREATE MATERIALIZED VIEW`, and persistent `CREATE TABLE AS SELECT` are rejected or not implemented. Persistent `CREATE FUNCTION` is supported only for the REST Catalog SQL scalar form documented below. DataFusion `COPY` can export query results to files; it does not create or commit Paimon table files.
 
@@ -78,13 +78,18 @@ internally for `SET`/`RESET` support.
 
 ### REST Catalog Views and SQL Functions
 
-When the registered catalog is a Paimon REST Catalog, `SQLContext` can read,
-execute, and create persistent views and SQL scalar functions.
+When the registered catalog is a Paimon REST Catalog, `SQLContext` can read, execute, create, and drop persistent views and can create SQL scalar functions.
 
 Create a persistent view with this syntax:
 
 ```sql
 CREATE VIEW [IF NOT EXISTS] view_name [(column_name, ...)] AS query;
+```
+
+Drop a persistent view with this syntax:
+
+```sql
+DROP VIEW [IF EXISTS] view_name;
 ```
 
 For example:
@@ -107,10 +112,14 @@ the new view's owning catalog and database, not the session's current database.
 The canonical query is stored as both the default query and the `datafusion`
 dialect definition.
 
-Persistent `CREATE VIEW` is currently implemented by REST Catalog. Other
-catalog implementations may return `Unsupported`. `CREATE OR REPLACE VIEW`,
-materialized/secure views, view comments or options, vendor-specific modifiers,
-and persistent `ALTER VIEW` / `DROP VIEW` are not supported.
+Persistent `CREATE VIEW` and `DROP VIEW` are currently implemented by REST
+Catalog. `DROP VIEW` sends a direct delete request; `IF EXISTS` ignores only a
+missing-view response. Bare, two-part, and three-part names are supported, but
+only one target may be dropped per statement. Other catalog implementations may
+return `Unsupported`. `CREATE OR REPLACE VIEW`, materialized/secure views, view
+comments or options, vendor-specific create modifiers, persistent `ALTER VIEW`,
+and `DROP VIEW` modifiers such as `CASCADE`, `RESTRICT`, or `PURGE` are not
+supported.
 
 Persistent views resolve through the normal DataFusion catalog path, so they
 can be queried wherever a table can be used:
@@ -587,6 +596,18 @@ CREATE TABLE paimon.my_db.complex_types (
 DROP TABLE paimon.my_db.users;
 DROP TABLE IF EXISTS paimon.my_db.users;
 ```
+
+### DROP VIEW
+
+Drop one persistent view from a REST Catalog:
+
+```sql
+DROP VIEW active_users;
+DROP VIEW IF EXISTS my_db.active_users;
+DROP VIEW IF EXISTS paimon.my_db.active_users;
+```
+
+`IF EXISTS` ignores only a missing view; authorization, server, and network errors are still returned. Only one persistent view target is supported per statement. `CASCADE`, `RESTRICT`, `PURGE`, and other drop modifiers are rejected. Catalog implementations without persistent view support return `Unsupported`.
 
 ### CREATE TEMPORARY TABLE
 


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Persistent `DROP VIEW` was delegated to DataFusion, whose Paimon catalog deregistration path only handles tables. As a result, REST Catalog views could not be dropped through `SQLContext`.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - Add `drop_view` support to the Catalog and REST API layers.
  - Handle persistent Paimon `DROP VIEW [IF EXISTS]` in `SQLContext`.
  - Preserve DataFusion delegation for non-Paimon catalogs.
  - Validate unsupported modifiers and normalize SQL identifiers.
  - Add REST, catalog, SQL, and error-handling tests.

### Tests

<!-- List unit tests or integration cases to verify this change -->

  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --workspace --features fulltext,vortex -- -D warnings`
  - `cargo test -p paimon --all-targets --features fulltext,vortex`
  - Focused REST Catalog and DataFusion `DROP VIEW` tests

### API and Format

<!-- Does this change affect API or storage format -->

Adds `Catalog::drop_view`. No storage format changes.

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->

Updates the DataFusion README and SQL documentation.
