### PR TITLE
[table] Support query-auth row filters and column masking at read time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4607,6 +4607,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "async-trait",
+ "axum",
  "bytes",
  "chrono",
  "constant_time_eq",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4745,6 +4745,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "async-trait",
+ "axum",
  "bytes",
  "chrono",
  "constant_time_eq",

--- a/crates/integrations/datafusion/Cargo.toml
+++ b/crates/integrations/datafusion/Cargo.toml
@@ -50,6 +50,8 @@ uuid = { version = "1", features = ["v4"] }
 [dev-dependencies]
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
+# for the shared REST catalog mock (crates/paimon/tests/mock_server.rs)
+axum = { version = "0.7", features = ["macros", "tokio", "http1", "http2"] }
 bytes = "1.7.1"
 flate2 = "1"
 paimon-ftindex-core = "0.1.0"

--- a/crates/integrations/datafusion/src/merge_into.rs
+++ b/crates/integrations/datafusion/src/merge_into.rs
@@ -1233,12 +1233,14 @@ pub(crate) async fn register_cow_target_table(
         return Ok((false, table_name));
     }
 
-    // Read all files in parallel
-    let read_futures: Vec<_> = file_index
-        .iter()
-        .enumerate()
-        .map(|(file_idx, file_info)| async move {
-            let single_split = DataSplitBuilder::new()
+    // This read rewrites the target files, so it must see raw rows: authorize an
+    // unrestricted grant once and stamp it on every split. Stamping the scan
+    // plan's grant instead would shift the positional row offsets the writer
+    // replays under a row filter, rewriting the wrong rows.
+    let mut splits = Vec::with_capacity(file_index.len());
+    for file_info in file_index.iter() {
+        splits.push(
+            DataSplitBuilder::new()
                 .with_snapshot(file_info.snapshot_id)
                 .with_partition(
                     paimon::spec::BinaryRow::from_serialized_bytes(&file_info.partition)
@@ -1249,8 +1251,19 @@ pub(crate) async fn register_cow_target_table(
                 .with_total_buckets(file_info.total_buckets)
                 .with_data_files(vec![file_info.file_meta.clone()])
                 .build()
-                .map_err(to_datafusion_error)?;
+                .map_err(to_datafusion_error)?,
+        );
+    }
+    let splits = table
+        .authorize_rewrite_splits(splits)
+        .await
+        .map_err(to_datafusion_error)?;
 
+    // Read all files in parallel
+    let read_futures: Vec<_> = splits
+        .into_iter()
+        .enumerate()
+        .map(|(file_idx, single_split)| async move {
             let read = table
                 .new_read_builder()
                 .new_read()

--- a/crates/integrations/datafusion/src/merge_into.rs
+++ b/crates/integrations/datafusion/src/merge_into.rs
@@ -1233,10 +1233,9 @@ pub(crate) async fn register_cow_target_table(
         return Ok((false, table_name));
     }
 
-    // This read rewrites the target files, so it must see raw rows: authorize an
-    // unrestricted grant once and stamp it on every split. Stamping the scan
-    // plan's grant instead would shift the positional row offsets the writer
-    // replays under a row filter, rewriting the wrong rows.
+    // This read rewrites the target files, so it must see raw rows. The scan
+    // plan's grant would shift the positional row offsets the writer replays,
+    // rewriting the wrong rows.
     let mut splits = Vec::with_capacity(file_index.len());
     for file_info in file_index.iter() {
         splits.push(

--- a/crates/integrations/datafusion/src/merge_into.rs
+++ b/crates/integrations/datafusion/src/merge_into.rs
@@ -1314,10 +1314,9 @@ pub(crate) async fn register_cow_target_table(
         return Ok((false, table_name));
     }
 
-    // This read rewrites the target files, so it must see raw rows: authorize an
-    // unrestricted grant once and stamp it on every split. Stamping the scan
-    // plan's grant instead would shift the positional row offsets the writer
-    // replays under a row filter, rewriting the wrong rows.
+    // This read rewrites the target files, so it must see raw rows. The scan
+    // plan's grant would shift the positional row offsets the writer replays,
+    // rewriting the wrong rows.
     let mut splits = Vec::with_capacity(file_index.len());
     for file_info in file_index.iter() {
         splits.push(

--- a/crates/integrations/datafusion/src/merge_into.rs
+++ b/crates/integrations/datafusion/src/merge_into.rs
@@ -1314,12 +1314,14 @@ pub(crate) async fn register_cow_target_table(
         return Ok((false, table_name));
     }
 
-    // Read all files in parallel
-    let read_futures: Vec<_> = file_index
-        .iter()
-        .enumerate()
-        .map(|(file_idx, file_info)| async move {
-            let single_split = DataSplitBuilder::new()
+    // This read rewrites the target files, so it must see raw rows: authorize an
+    // unrestricted grant once and stamp it on every split. Stamping the scan
+    // plan's grant instead would shift the positional row offsets the writer
+    // replays under a row filter, rewriting the wrong rows.
+    let mut splits = Vec::with_capacity(file_index.len());
+    for file_info in file_index.iter() {
+        splits.push(
+            DataSplitBuilder::new()
                 .with_snapshot(file_info.snapshot_id)
                 .with_partition(
                     paimon::spec::BinaryRow::from_serialized_bytes(&file_info.partition)
@@ -1330,8 +1332,19 @@ pub(crate) async fn register_cow_target_table(
                 .with_total_buckets(file_info.total_buckets)
                 .with_data_files(vec![file_info.file_meta.clone()])
                 .build()
-                .map_err(to_datafusion_error)?;
+                .map_err(to_datafusion_error)?,
+        );
+    }
+    let splits = table
+        .authorize_rewrite_splits(splits)
+        .await
+        .map_err(to_datafusion_error)?;
 
+    // Read all files in parallel
+    let read_futures: Vec<_> = splits
+        .into_iter()
+        .enumerate()
+        .map(|(file_idx, single_split)| async move {
             let read = table
                 .new_read_builder()
                 .new_read()

--- a/crates/integrations/datafusion/src/physical_plan/scan.rs
+++ b/crates/integrations/datafusion/src/physical_plan/scan.rs
@@ -768,6 +768,10 @@ pub struct PaimonTableScan {
     /// Column-name case sensitivity carried from planning to execution so the
     /// read path resolves names the same way the scan was planned.
     case_sensitive: bool,
+    /// Set from [`paimon::table::Plan::planned_under_restricted_grant`]. Kept
+    /// on the plan rather than inferred from the splits, so a fully pruned scan
+    /// still suppresses its metadata.
+    query_auth_restricted: bool,
     /// Physical filters retained from DataFusion's runtime filter-pushdown pass.
     /// They are evaluated exactly by this scan.
     runtime_filters: Vec<Arc<dyn PhysicalExpr>>,
@@ -778,6 +782,22 @@ pub struct PaimonTableScan {
 }
 
 impl PaimonTableScan {
+    /// Record that this scan was planned under a row filter or column masking.
+    pub(crate) fn with_query_auth_restricted(mut self, restricted: bool) -> Self {
+        self.query_auth_restricted = restricted;
+        self
+    }
+
+    /// Whether this scan runs under a row filter or column masking.
+    fn is_query_auth_restricted(&self) -> bool {
+        self.query_auth_restricted
+            || self
+                .planned_partitions
+                .iter()
+                .flat_map(|splits| splits.iter())
+                .any(paimon::DataSplit::has_restricted_query_auth_grant)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         schema: ArrowSchemaRef,
@@ -808,6 +828,7 @@ impl PaimonTableScan {
             scan_trace,
             pushed_variants,
             case_sensitive,
+            query_auth_restricted: false,
             runtime_filters: Vec::new(),
             decoder_filters: Vec::new(),
         }
@@ -851,10 +872,8 @@ impl PaimonTableScan {
             return Statistics::unknown_column(&self.schema());
         }
 
-        // Manifest stats describe the data BEFORE query-auth enforcement: the
-        // bounds of a masked column are the raw values the mask hides, and null
-        // counts cover rows the row filter drops. Publishing them (e.g. via
-        // EXPLAIN, or to the optimizer) would leak exactly what enforcement hides.
+        // Manifest stats precede enforcement: a masked column's bounds are the
+        // raw values it hides, and null counts cover filtered-out rows.
         if partitions
             .iter()
             .flat_map(|splits| splits.iter())
@@ -1078,10 +1097,8 @@ impl ExecutionPlan for PaimonTableScan {
             None => &self.planned_partitions,
         };
 
-        // Under a restricted grant the manifest row count is the count BEFORE
-        // the row filter runs, so publishing it (EXPLAIN, the optimizer) would
-        // disclose how much data the filter hides — the same reason the column
-        // statistics are suppressed. Report the whole thing as unknown.
+        // The manifest row count precedes the filter, so it would disclose how
+        // much data is hidden. Report the whole thing as unknown.
         if partitions
             .iter()
             .flat_map(|splits| splits.iter())
@@ -1132,6 +1149,19 @@ impl DisplayAs for PaimonTableScan {
         f: &mut std::fmt::Formatter,
     ) -> std::fmt::Result {
         write!(f, "PaimonTableScan: table={}", self.table.identifier())?;
+
+        // These counts and the trace precede the filter/masking that run in
+        // `TableRead`, so EXPLAIN would disclose what enforcement hides — the
+        // same reason the statistics are suppressed.
+        if self.is_query_auth_restricted() {
+            write!(f, ", query-auth=restricted")?;
+            let columns = self
+                .read_type
+                .iter()
+                .map(|f| f.name().to_string())
+                .collect::<Vec<_>>();
+            return write!(f, ", projection=[{}]", columns.join(", "));
+        }
 
         let total_splits: usize = self.planned_partitions.iter().map(|p| p.len()).sum();
         let total_files: usize = self

--- a/crates/integrations/datafusion/src/physical_plan/scan.rs
+++ b/crates/integrations/datafusion/src/physical_plan/scan.rs
@@ -851,6 +851,18 @@ impl PaimonTableScan {
             return Statistics::unknown_column(&self.schema());
         }
 
+        // Manifest stats describe the data BEFORE query-auth enforcement: the
+        // bounds of a masked column are the raw values the mask hides, and null
+        // counts cover rows the row filter drops. Publishing them (e.g. via
+        // EXPLAIN, or to the optimizer) would leak exactly what enforcement hides.
+        if partitions
+            .iter()
+            .flat_map(|splits| splits.iter())
+            .any(DataSplit::has_restricted_query_auth_grant)
+        {
+            return Statistics::unknown_column(&self.schema());
+        }
+
         let Ok(merge_engine) = self.table.schema().core_options().merge_engine() else {
             return Statistics::unknown_column(&self.schema());
         };
@@ -1065,6 +1077,18 @@ impl ExecutionPlan for PaimonTableScan {
             Some(idx) => std::slice::from_ref(&self.planned_partitions[idx]),
             None => &self.planned_partitions,
         };
+
+        // Under a restricted grant the manifest row count is the count BEFORE
+        // the row filter runs, so publishing it (EXPLAIN, the optimizer) would
+        // disclose how much data the filter hides — the same reason the column
+        // statistics are suppressed. Report the whole thing as unknown.
+        if partitions
+            .iter()
+            .flat_map(|splits| splits.iter())
+            .any(DataSplit::has_restricted_query_auth_grant)
+        {
+            return Ok(Arc::new(Statistics::new_unknown(&self.schema())));
+        }
 
         let mut total_rows: usize = 0;
         let mut all_row_counts_known = true;

--- a/crates/integrations/datafusion/src/physical_plan/scan.rs
+++ b/crates/integrations/datafusion/src/physical_plan/scan.rs
@@ -952,6 +952,18 @@ impl PaimonTableScan {
             return Statistics::unknown_column(&self.schema());
         }
 
+        // Manifest stats describe the data BEFORE query-auth enforcement: the
+        // bounds of a masked column are the raw values the mask hides, and null
+        // counts cover rows the row filter drops. Publishing them (e.g. via
+        // EXPLAIN, or to the optimizer) would leak exactly what enforcement hides.
+        if partitions
+            .iter()
+            .flat_map(|splits| splits.iter())
+            .any(DataSplit::has_restricted_query_auth_grant)
+        {
+            return Statistics::unknown_column(&self.schema());
+        }
+
         let Ok(merge_engine) = self.table.schema().core_options().merge_engine() else {
             return Statistics::unknown_column(&self.schema());
         };
@@ -1172,6 +1184,18 @@ impl ExecutionPlan for PaimonTableScan {
             Some(idx) => std::slice::from_ref(&self.planned_partitions[idx]),
             None => &self.planned_partitions,
         };
+
+        // Under a restricted grant the manifest row count is the count BEFORE
+        // the row filter runs, so publishing it (EXPLAIN, the optimizer) would
+        // disclose how much data the filter hides — the same reason the column
+        // statistics are suppressed. Report the whole thing as unknown.
+        if partitions
+            .iter()
+            .flat_map(|splits| splits.iter())
+            .any(DataSplit::has_restricted_query_auth_grant)
+        {
+            return Ok(Arc::new(Statistics::new_unknown(&self.schema())));
+        }
 
         let mut total_rows: usize = 0;
         let mut all_row_counts_known = true;

--- a/crates/integrations/datafusion/src/physical_plan/scan.rs
+++ b/crates/integrations/datafusion/src/physical_plan/scan.rs
@@ -796,6 +796,10 @@ pub struct PaimonTableScan {
     /// Column-name case sensitivity carried from planning to execution so the
     /// read path resolves names the same way the scan was planned.
     case_sensitive: bool,
+    /// Set from [`paimon::table::Plan::planned_under_restricted_grant`]. Kept
+    /// on the plan rather than inferred from the splits, so a fully pruned scan
+    /// still suppresses its metadata.
+    query_auth_restricted: bool,
     /// Physical filters retained from DataFusion's runtime filter-pushdown pass.
     /// They are evaluated exactly by this scan.
     runtime_filters: Vec<Arc<dyn PhysicalExpr>>,
@@ -808,6 +812,22 @@ pub struct PaimonTableScan {
 }
 
 impl PaimonTableScan {
+    /// Record that this scan was planned under a row filter or column masking.
+    pub(crate) fn with_query_auth_restricted(mut self, restricted: bool) -> Self {
+        self.query_auth_restricted = restricted;
+        self
+    }
+
+    /// Whether this scan runs under a row filter or column masking.
+    fn is_query_auth_restricted(&self) -> bool {
+        self.query_auth_restricted
+            || self
+                .planned_partitions
+                .iter()
+                .flat_map(|splits| splits.iter())
+                .any(paimon::DataSplit::has_restricted_query_auth_grant)
+    }
+
     #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -908,6 +928,7 @@ impl PaimonTableScan {
             scan_trace,
             pushed_variants,
             case_sensitive,
+            query_auth_restricted: false,
             runtime_filters: Vec::new(),
             decoder_filters: Vec::new(),
             parquet_read_budget,
@@ -952,10 +973,8 @@ impl PaimonTableScan {
             return Statistics::unknown_column(&self.schema());
         }
 
-        // Manifest stats describe the data BEFORE query-auth enforcement: the
-        // bounds of a masked column are the raw values the mask hides, and null
-        // counts cover rows the row filter drops. Publishing them (e.g. via
-        // EXPLAIN, or to the optimizer) would leak exactly what enforcement hides.
+        // Manifest stats precede enforcement: a masked column's bounds are the
+        // raw values it hides, and null counts cover filtered-out rows.
         if partitions
             .iter()
             .flat_map(|splits| splits.iter())
@@ -1185,10 +1204,8 @@ impl ExecutionPlan for PaimonTableScan {
             None => &self.planned_partitions,
         };
 
-        // Under a restricted grant the manifest row count is the count BEFORE
-        // the row filter runs, so publishing it (EXPLAIN, the optimizer) would
-        // disclose how much data the filter hides — the same reason the column
-        // statistics are suppressed. Report the whole thing as unknown.
+        // The manifest row count precedes the filter, so it would disclose how
+        // much data is hidden. Report the whole thing as unknown.
         if partitions
             .iter()
             .flat_map(|splits| splits.iter())
@@ -1239,6 +1256,19 @@ impl DisplayAs for PaimonTableScan {
         f: &mut std::fmt::Formatter,
     ) -> std::fmt::Result {
         write!(f, "PaimonTableScan: table={}", self.table.identifier())?;
+
+        // These counts and the trace precede the filter/masking that run in
+        // `TableRead`, so EXPLAIN would disclose what enforcement hides — the
+        // same reason the statistics are suppressed.
+        if self.is_query_auth_restricted() {
+            write!(f, ", query-auth=restricted")?;
+            let columns = self
+                .read_type
+                .iter()
+                .map(|f| f.name().to_string())
+                .collect::<Vec<_>>();
+            return write!(f, ", projection=[{}]", columns.join(", "));
+        }
 
         let total_splits: usize = self.planned_partitions.iter().map(|p| p.len()).sum();
         let total_files: usize = self

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -450,7 +450,11 @@ impl TableProvider for PaimonTableProvider {
             .map_err(to_datafusion_error)?;
 
         let target = state.config_options().execution.target_partitions;
+        // Inexact plan row counts (a query-auth row filter drops rows inside
+        // `TableRead`) would let DataFusion's aggregate-statistics rule answer
+        // COUNT(*) with the unfiltered count without ever invoking the read.
         let filter_exact = !filter_analysis.requires_residual
+            && plan.row_counts_exact()
             && filter_analysis
                 .pushed_predicate
                 .as_ref()

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -372,18 +372,24 @@ impl PaimonScanBuilder<'_> {
                 .collect()
         };
 
-        Ok(Arc::new(PaimonTableScan::new(
-            projected_schema,
-            self.table.clone(),
-            read_type,
-            self.pushed_predicate,
-            planned_partitions,
-            self.limit,
-            self.filter_exact,
-            self.scan_trace,
-            None,
-            self.case_sensitive,
-        )))
+        // From the plan, not its splits: a fully pruned plan carries no split
+        // to stamp, but its scan metadata is just as pre-enforcement.
+        let restricted = self.plan.planned_under_restricted_grant();
+        Ok(Arc::new(
+            PaimonTableScan::new(
+                projected_schema,
+                self.table.clone(),
+                read_type,
+                self.pushed_predicate,
+                planned_partitions,
+                self.limit,
+                self.filter_exact,
+                self.scan_trace,
+                None,
+                self.case_sensitive,
+            )
+            .with_query_auth_restricted(restricted),
+        ))
     }
 }
 

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -459,7 +459,11 @@ impl TableProvider for PaimonTableProvider {
             .map_err(to_datafusion_error)?;
 
         let target = state.config_options().execution.target_partitions;
+        // Inexact plan row counts (a query-auth row filter drops rows inside
+        // `TableRead`) would let DataFusion's aggregate-statistics rule answer
+        // COUNT(*) with the unfiltered count without ever invoking the read.
         let filter_exact = !filter_analysis.requires_residual
+            && plan.row_counts_exact()
             && filter_analysis
                 .pushed_predicate
                 .as_ref()

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -370,6 +370,10 @@ impl PaimonScanBuilder<'_> {
             (self.schema.clone(), read_fields)
         };
 
+        // Read before `into_splits` consumes the plan. From the plan, not its
+        // splits: a fully pruned plan carries no split to stamp, but its scan
+        // metadata is just as pre-enforcement.
+        let restricted = self.plan.planned_under_restricted_grant();
         let splits = self.plan.into_splits();
         let planned_partitions: Vec<Arc<[_]>> = if splits.is_empty() {
             vec![Arc::from(Vec::new())]
@@ -381,18 +385,21 @@ impl PaimonScanBuilder<'_> {
                 .collect()
         };
 
-        Ok(Arc::new(PaimonTableScan::try_new(
-            projected_schema,
-            self.table.clone(),
-            read_type,
-            self.pushed_predicate,
-            planned_partitions,
-            self.limit,
-            self.filter_exact,
-            self.scan_trace,
-            None,
-            self.case_sensitive,
-        )?))
+        Ok(Arc::new(
+            PaimonTableScan::try_new(
+                projected_schema,
+                self.table.clone(),
+                read_type,
+                self.pushed_predicate,
+                planned_partitions,
+                self.limit,
+                self.filter_exact,
+                self.scan_trace,
+                None,
+                self.case_sensitive,
+            )?
+            .with_query_auth_restricted(restricted),
+        ))
     }
 }
 

--- a/crates/integrations/datafusion/src/variant_pushdown.rs
+++ b/crates/integrations/datafusion/src/variant_pushdown.rs
@@ -249,18 +249,24 @@ impl ExtensionPlanner for VariantExtractionExtensionPlanner {
                 .as_ref()
                 .is_none_or(|p| read_builder.is_exact_filter_pushdown(p));
 
-        Ok(Some(Arc::new(PaimonTableScan::new(
-            Arc::clone(&node.arrow_schema),
-            node.table.clone(),
-            node.read_type.clone(),
-            filter_analysis.pushed_predicate,
-            planned_partitions,
-            pushed_limit,
-            filter_exact,
-            Some(scan_trace),
-            Some(node.pushed_variants.clone()),
-            case_sensitive,
-        ))))
+        // From the plan, not its splits: a fully pruned plan carries no split to
+        // stamp, but its scan metadata is just as pre-enforcement.
+        let restricted = plan.planned_under_restricted_grant();
+        Ok(Some(Arc::new(
+            PaimonTableScan::new(
+                Arc::clone(&node.arrow_schema),
+                node.table.clone(),
+                node.read_type.clone(),
+                filter_analysis.pushed_predicate,
+                planned_partitions,
+                pushed_limit,
+                filter_exact,
+                Some(scan_trace),
+                Some(node.pushed_variants.clone()),
+                case_sensitive,
+            )
+            .with_query_auth_restricted(restricted),
+        )))
     }
 }
 

--- a/crates/integrations/datafusion/src/variant_pushdown.rs
+++ b/crates/integrations/datafusion/src/variant_pushdown.rs
@@ -243,6 +243,7 @@ impl ExtensionPlanner for VariantExtractionExtensionPlanner {
                 .collect()
         };
         let filter_exact = !filter_analysis.requires_residual
+            && plan.row_counts_exact()
             && filter_analysis
                 .pushed_predicate
                 .as_ref()

--- a/crates/integrations/datafusion/src/variant_pushdown.rs
+++ b/crates/integrations/datafusion/src/variant_pushdown.rs
@@ -231,6 +231,11 @@ impl ExtensionPlanner for VariantExtractionExtensionPlanner {
             .await
             .map_err(to_datafusion_error)?;
 
+        // Read before `into_splits` consumes the plan. From the plan, not its
+        // splits: a fully pruned plan carries no split to stamp, but its scan
+        // metadata is just as pre-enforcement.
+        let restricted = plan.planned_under_restricted_grant();
+        let row_counts_exact = plan.row_counts_exact();
         let splits = plan.into_splits();
         let target = session_state.config_options().execution.target_partitions;
         let planned_partitions: Vec<Arc<[_]>> = if splits.is_empty() {
@@ -243,24 +248,27 @@ impl ExtensionPlanner for VariantExtractionExtensionPlanner {
                 .collect()
         };
         let filter_exact = !filter_analysis.requires_residual
-            && plan.row_counts_exact()
+            && row_counts_exact
             && filter_analysis
                 .pushed_predicate
                 .as_ref()
                 .is_none_or(|p| read_builder.is_exact_filter_pushdown(p));
 
-        Ok(Some(Arc::new(PaimonTableScan::try_new(
-            Arc::clone(&node.arrow_schema),
-            node.table.clone(),
-            node.read_type.clone(),
-            filter_analysis.pushed_predicate,
-            planned_partitions,
-            pushed_limit,
-            filter_exact,
-            Some(scan_trace),
-            Some(node.pushed_variants.clone()),
-            case_sensitive,
-        )?)))
+        Ok(Some(Arc::new(
+            PaimonTableScan::try_new(
+                Arc::clone(&node.arrow_schema),
+                node.table.clone(),
+                node.read_type.clone(),
+                filter_analysis.pushed_predicate,
+                planned_partitions,
+                pushed_limit,
+                filter_exact,
+                Some(scan_trace),
+                Some(node.pushed_variants.clone()),
+                case_sensitive,
+            )?
+            .with_query_auth_restricted(restricted),
+        )))
     }
 }
 

--- a/crates/integrations/datafusion/tests/query_auth.rs
+++ b/crates/integrations/datafusion/tests/query_auth.rs
@@ -1,0 +1,212 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Query-auth enforcement through the DataFusion provider: SQL over a REST
+//! catalog table with `query-auth.enabled` must apply the per-user grant
+//! (row filter + column masking) fetched at scan-plan time, and COUNT(*)
+//! must not shortcut to unfiltered statistics.
+//!
+//! This is the same provider path the Python binding
+//! (`pypaimon_rust.datafusion`) drives via FFI.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, Int32Array, Int64Array, StringArray};
+use datafusion::arrow::compute::cast;
+use datafusion::arrow::datatypes::{
+    DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+};
+use datafusion::arrow::record_batch::RecordBatch;
+use paimon::api::{AuthTableQueryResponse, ConfigResponse};
+use paimon::catalog::{Identifier, RESTCatalog};
+use paimon::spec::{BigIntType, DataType, IntType, Schema, VarCharType};
+use paimon::{Catalog, CatalogOptions, FileSystemCatalog, Options, Table};
+use paimon_datafusion::SQLContext;
+
+// Shared REST catalog mock (same source the paimon crate's integration tests
+// use); only a subset of its helpers is exercised here.
+#[allow(dead_code)]
+#[path = "../../../paimon/tests/mock_server.rs"]
+mod mock_server;
+use mock_server::start_mock_server;
+
+async fn write_batch(table: &Table, batch: RecordBatch, commit_user: &str) {
+    let write_builder = table
+        .new_write_builder()
+        .with_commit_user(commit_user)
+        .expect("valid commit user");
+    let mut write = write_builder.new_write().expect("create writer");
+    write.write_arrow_batch(&batch).await.expect("write batch");
+    let messages = write.prepare_commit().await.expect("prepare commit");
+    write_builder
+        .new_commit()
+        .commit(messages)
+        .await
+        .expect("commit batch");
+}
+
+// Multi-threaded: the provider's `block_on_with_runtime` bridges park the
+// current thread, which must not be the only thread serving the mock server.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_query_auth_grant_enforced_via_sql() {
+    let tmp = tempfile::tempdir().unwrap();
+    let warehouse = format!("file://{}", tmp.path().display());
+
+    // Write demo_employees (id, name, salary) through a plain FileSystemCatalog.
+    let mut fs_options = Options::new();
+    fs_options.set(CatalogOptions::WAREHOUSE, &warehouse);
+    let fs_catalog = FileSystemCatalog::new(fs_options).expect("create filesystem catalog");
+    fs_catalog
+        .create_database("default", true, HashMap::new())
+        .await
+        .unwrap();
+    let columns = || {
+        Schema::builder()
+            .column("id", DataType::Int(IntType::new()))
+            .column("name", DataType::VarChar(VarCharType::new(255).unwrap()))
+            .column("salary", DataType::BigInt(BigIntType::new()))
+            .option("bucket", "1")
+            .option("bucket-key", "id")
+    };
+    let identifier = Identifier::new("default", "qa_emp");
+    fs_catalog
+        .create_table(&identifier, columns().build().unwrap(), false)
+        .await
+        .unwrap();
+    let writer = fs_catalog.get_table(&identifier).await.unwrap();
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", ArrowDataType::Int32, true),
+        ArrowField::new("name", ArrowDataType::Utf8, true),
+        ArrowField::new("salary", ArrowDataType::Int64, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+            Arc::new(StringArray::from(vec![
+                "alice", "bob", "charlie", "diana", "eve",
+            ])),
+            Arc::new(Int64Array::from(vec![120000, 85000, 95000, 70000, 99000])),
+        ],
+    )
+    .unwrap();
+    write_batch(&writer, batch, "u1").await;
+
+    // Serve the same files through a mock REST catalog whose grant applies a
+    // row filter (salary >= 90000) and masks name -> UPPER(name).
+    let mut defaults = HashMap::new();
+    defaults.insert("prefix".to_string(), "mock-test".to_string());
+    let server = start_mock_server(
+        "test_warehouse".to_string(),
+        "/tmp/test_warehouse".to_string(),
+        ConfigResponse::new(defaults),
+        vec!["default".to_string()],
+    )
+    .await;
+    server.add_table_with_schema(
+        "default",
+        "qa_emp",
+        columns()
+            .option("query-auth.enabled", "true")
+            .build()
+            .unwrap(),
+        &format!("{warehouse}/default.db/qa_emp"),
+    );
+    server.set_auth_response(
+        "default",
+        "qa_emp",
+        AuthTableQueryResponse {
+            filter: Some(vec![
+                r#"{"kind":"LEAF","transform":{"name":"FIELD_REF","fieldRef":{"index":2,"name":"salary","type":"BIGINT"}},"function":"GREATER_OR_EQUAL","literals":[90000]}"#
+                    .to_string(),
+            ]),
+            column_masking: Some(HashMap::from([(
+                "name".to_string(),
+                r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#
+                    .to_string(),
+            )])),
+        },
+    );
+
+    let mut rest_options = Options::new();
+    rest_options.set("uri", server.url().expect("server url"));
+    rest_options.set("warehouse", "test_warehouse");
+    rest_options.set("token.provider", "bear");
+    rest_options.set("token", "test_token");
+    let rest_catalog = RESTCatalog::new(rest_options, true)
+        .await
+        .expect("create REST catalog");
+
+    // Sanity: the mock-served table must resolve through the Catalog trait.
+    rest_catalog
+        .get_table(&identifier)
+        .await
+        .expect("REST get_table(default.qa_emp)");
+
+    let mut ctx = SQLContext::new();
+    ctx.register_catalog("paimon", Arc::new(rest_catalog))
+        .await
+        .expect("register catalog");
+
+    // Row filter + masking must both be applied on the SQL result.
+    let batches = ctx
+        .sql("SELECT id, name, salary FROM paimon.default.qa_emp ORDER BY id")
+        .await
+        .expect("plan select")
+        .collect()
+        .await
+        .expect("execute select");
+    let mut rows = Vec::new();
+    for b in &batches {
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        // DataFusion may hand back Utf8View for string columns; normalize.
+        let names = cast(b.column(1), &ArrowDataType::Utf8).expect("cast name to Utf8");
+        let names = names.as_any().downcast_ref::<StringArray>().unwrap();
+        let sal = b.column(2).as_any().downcast_ref::<Int64Array>().unwrap();
+        for r in 0..b.num_rows() {
+            rows.push((ids.value(r), names.value(r).to_string(), sal.value(r)));
+        }
+    }
+    assert_eq!(
+        rows,
+        vec![
+            (1, "ALICE".to_string(), 120000),
+            (3, "CHARLIE".to_string(), 95000),
+            (5, "EVE".to_string(), 99000),
+        ],
+        "grant must drop salary<90000 rows and uppercase name"
+    );
+
+    // COUNT(*) must reflect the filtered row count, not unfiltered statistics
+    // (the aggregate-statistics optimization must be disabled by the inexact
+    // plan row counts).
+    let batches = ctx
+        .sql("SELECT COUNT(*) FROM paimon.default.qa_emp")
+        .await
+        .expect("plan count")
+        .collect()
+        .await
+        .expect("execute count");
+    let count = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0);
+    assert_eq!(count, 3, "COUNT(*) must not use unfiltered statistics");
+}

--- a/crates/paimon/src/arrow/residual.rs
+++ b/crates/paimon/src/arrow/residual.rs
@@ -696,7 +696,7 @@ fn set_membership_hash_mask(
     }
 }
 
-fn evaluate_column_predicate(
+pub(crate) fn evaluate_column_predicate(
     column: &ArrayRef,
     scalar: &Scalar<ArrayRef>,
     op: PredicateOperator,
@@ -855,7 +855,7 @@ fn combine_filter_masks(left: &BooleanArray, right: &BooleanArray, use_or: bool)
     BooleanArray::new(values, None)
 }
 
-fn boolean_mask_from_predicate(
+pub(crate) fn boolean_mask_from_predicate(
     len: usize,
     mut predicate: impl FnMut(usize) -> bool,
 ) -> BooleanArray {

--- a/crates/paimon/src/arrow/residual.rs
+++ b/crates/paimon/src/arrow/residual.rs
@@ -368,7 +368,7 @@ pub(crate) fn evaluate_exact_leaf_predicate(
 /// operator, including finer-scale literals that cannot be represented at the
 /// column scale (e.g. `d > 1.05` on a DECIMAL(_,1) column is exactly `d >= 1.1`).
 /// NULL rows stay NULL in the mask (collapsed to `false` by the caller).
-fn evaluate_decimal_leaf(
+pub(crate) fn evaluate_decimal_leaf(
     array: &ArrayRef,
     op: PredicateOperator,
     literals: &[Datum],

--- a/crates/paimon/src/arrow/residual.rs
+++ b/crates/paimon/src/arrow/residual.rs
@@ -565,7 +565,7 @@ fn evaluate_array_element_equality(
 /// operator, including finer-scale literals that cannot be represented at the
 /// column scale (e.g. `d > 1.05` on a DECIMAL(_,1) column is exactly `d >= 1.1`).
 /// NULL rows stay NULL in the mask (collapsed to `false` by the caller).
-fn evaluate_decimal_leaf(
+pub(crate) fn evaluate_decimal_leaf(
     array: &ArrayRef,
     op: PredicateOperator,
     literals: &[Datum],

--- a/crates/paimon/src/arrow/residual.rs
+++ b/crates/paimon/src/arrow/residual.rs
@@ -891,7 +891,7 @@ fn set_membership_hash_mask(
     }
 }
 
-fn evaluate_column_predicate(
+pub(crate) fn evaluate_column_predicate(
     column: &ArrayRef,
     scalar: &Scalar<ArrayRef>,
     op: PredicateOperator,
@@ -988,7 +988,7 @@ fn combine_filter_masks(left: &BooleanArray, right: &BooleanArray, use_or: bool)
     BooleanArray::new(values, None)
 }
 
-fn boolean_mask_from_predicate(
+pub(crate) fn boolean_mask_from_predicate(
     len: usize,
     mut predicate: impl FnMut(usize) -> bool,
 ) -> BooleanArray {

--- a/crates/paimon/src/catalog/partition_listing.rs
+++ b/crates/paimon/src/catalog/partition_listing.rs
@@ -32,9 +32,8 @@ use crate::Result;
 /// Scan a table's manifest entries and aggregate them into [`Partition`] rows,
 /// matching the shape catalogs would otherwise return from a metastore.
 pub async fn list_partitions_from_file_system(table: &Table) -> Result<Vec<Partition>> {
-    // Same disclosure as `Table::partition_stats`: per-partition record counts
-    // and key values come from the raw manifests, so a row filter would not
-    // apply to them. Require an unrestricted grant.
+    // Like `Table::partition_stats`: record counts and key values come from raw
+    // manifests, which a row filter would not touch.
     table.authorize_unrestricted_read().await?;
     let file_io = table.file_io();
     let snapshot_sm = table.snapshot_manager();

--- a/crates/paimon/src/catalog/partition_listing.rs
+++ b/crates/paimon/src/catalog/partition_listing.rs
@@ -32,6 +32,10 @@ use crate::Result;
 /// Scan a table's manifest entries and aggregate them into [`Partition`] rows,
 /// matching the shape catalogs would otherwise return from a metastore.
 pub async fn list_partitions_from_file_system(table: &Table) -> Result<Vec<Partition>> {
+    // Same disclosure as `Table::partition_stats`: per-partition record counts
+    // and key values come from the raw manifests, so a row filter would not
+    // apply to them. Require an unrestricted grant.
+    table.authorize_unrestricted_read().await?;
     let file_io = table.file_io();
     let snapshot_sm = table.snapshot_manager();
     let manifest_sm = SnapshotManager::new(file_io.clone(), table.location().to_string());

--- a/crates/paimon/src/catalog/partition_listing.rs
+++ b/crates/paimon/src/catalog/partition_listing.rs
@@ -32,8 +32,10 @@ use crate::Result;
 /// Scan a table's manifest entries and aggregate them into [`Partition`] rows,
 /// matching the shape catalogs would otherwise return from a metastore.
 pub async fn list_partitions_from_file_system(table: &Table) -> Result<Vec<Partition>> {
-    // Manifests carry partition values and per-column stats.
-    crate::spec::CoreOptions::new(table.schema().options()).ensure_read_authorized()?;
+    // Same disclosure as `Table::partition_stats`: per-partition record counts
+    // and key values come from the raw manifests, so a row filter would not
+    // apply to them. Require an unrestricted grant.
+    table.authorize_unrestricted_read().await?;
     let file_io = table.file_io();
     let snapshot_sm = table.snapshot_manager();
     let manifest_sm = SnapshotManager::new(file_io.clone(), table.location().to_string());

--- a/crates/paimon/src/spec/core_options.rs
+++ b/crates/paimon/src/spec/core_options.rs
@@ -416,8 +416,9 @@ impl<'a> CoreOptions<'a> {
 
     /// Whether `query-auth.enabled` is set.
     ///
-    /// When set, the server enforces a per-user row filter / column masking that this client
-    /// can't yet apply, so read paths fail closed (see `ensure_read_authorized`).
+    /// When set, every read must first be authorized against the REST server,
+    /// which returns a per-user row filter / column masking to apply. Paths that
+    /// cannot do so fail closed (see `ensure_read_authorized`).
     pub fn query_auth_enabled(&self) -> bool {
         self.options
             .get(QUERY_AUTH_ENABLED_OPTION)
@@ -431,9 +432,9 @@ impl<'a> CoreOptions<'a> {
     pub fn ensure_read_authorized(&self) -> crate::Result<()> {
         if self.query_auth_enabled() {
             return Err(crate::Error::Unsupported {
-                message: "reading a table with 'query-auth.enabled' = true is not supported: \
-                          the Rust client cannot yet enforce its row-level auth filter / column \
-                          masking, so it refuses to read to avoid returning unfiltered data"
+                message: "reading a table with 'query-auth.enabled' = true is not supported on \
+                          this path: it cannot obtain or apply the server's per-user row filter / \
+                          column masking, so it refuses to read to avoid returning raw data"
                     .to_string(),
             });
         }

--- a/crates/paimon/src/spec/core_options.rs
+++ b/crates/paimon/src/spec/core_options.rs
@@ -515,8 +515,9 @@ impl<'a> CoreOptions<'a> {
 
     /// Whether `query-auth.enabled` is set.
     ///
-    /// When set, the server enforces a per-user row filter / column masking that this client
-    /// can't yet apply, so read paths fail closed (see `ensure_read_authorized`).
+    /// When set, every read must first be authorized against the REST server,
+    /// which returns a per-user row filter / column masking to apply. Paths that
+    /// cannot do so fail closed (see `ensure_read_authorized`).
     pub fn query_auth_enabled(&self) -> bool {
         self.options
             .get(QUERY_AUTH_ENABLED_OPTION)
@@ -559,9 +560,9 @@ impl<'a> CoreOptions<'a> {
     fn ensure_query_auth_absent(&self) -> crate::Result<()> {
         if self.query_auth_enabled() {
             return Err(crate::Error::Unsupported {
-                message: "reading a table with 'query-auth.enabled' = true is not supported: \
-                          the Rust client cannot yet enforce its row-level auth filter / column \
-                          masking, so it refuses to read to avoid returning unfiltered data"
+                message: "reading a table with 'query-auth.enabled' = true is not supported on \
+                          this path: it cannot obtain or apply the server's per-user row filter / \
+                          column masking, so it refuses to read to avoid returning raw data"
                     .to_string(),
             });
         }

--- a/crates/paimon/src/spec/predicate.rs
+++ b/crates/paimon/src/spec/predicate.rs
@@ -631,6 +631,45 @@ impl Predicate {
             Predicate::AlwaysTrue | Predicate::AlwaysFalse => {}
         }
     }
+
+    /// Like [`Self::collect_leaf_field_indices`], but skipping leaves that name
+    /// a reserved system column. Their index is a placeholder (`_ROW_ID` uses
+    /// 0), so treating it as a table-schema index would point at an unrelated
+    /// column; callers track those leaves by name instead.
+    pub fn collect_user_leaf_field_indices(&self, out: &mut std::collections::HashSet<usize>) {
+        match self {
+            Predicate::Leaf { index, column, .. } => {
+                if !crate::table::query_auth::is_reserved_system_field_name(column) {
+                    out.insert(*index);
+                }
+            }
+            Predicate::And(children) | Predicate::Or(children) => {
+                children
+                    .iter()
+                    .for_each(|c| c.collect_user_leaf_field_indices(out));
+            }
+            Predicate::Not(inner) => inner.collect_user_leaf_field_indices(out),
+            Predicate::AlwaysTrue | Predicate::AlwaysFalse => {}
+        }
+    }
+
+    /// Column names referenced by every leaf. Unlike
+    /// [`Self::collect_leaf_field_indices`] this surfaces system columns too,
+    /// whose positional index is not a table-schema index.
+    pub fn collect_leaf_column_names(&self, out: &mut std::collections::HashSet<String>) {
+        match self {
+            Predicate::Leaf { column, .. } => {
+                out.insert(column.clone());
+            }
+            Predicate::And(children) | Predicate::Or(children) => {
+                children
+                    .iter()
+                    .for_each(|c| c.collect_leaf_column_names(out));
+            }
+            Predicate::Not(inner) => inner.collect_leaf_column_names(out),
+            Predicate::AlwaysTrue | Predicate::AlwaysFalse => {}
+        }
+    }
 }
 
 fn rest_json_err(detail: impl fmt::Display) -> Error {
@@ -2190,6 +2229,28 @@ mod tests {
     }
 
     // ======================== Decimal equivalence ========================
+
+    #[test]
+    fn test_user_leaf_indices_skip_system_columns() {
+        use std::collections::HashSet;
+        // A `_ROW_ID` leaf carries a placeholder index (0). Treating it as a
+        // table-schema index would drag an unrelated column into the auth
+        // request and the scope checks.
+        let row_id = Predicate::Leaf {
+            index: 0,
+            column: crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            data_type: DataType::BigInt(BigIntType::new()),
+            op: PredicateOperator::GtEq,
+            literals: vec![Datum::Long(5)],
+        };
+        let mut all = HashSet::new();
+        row_id.collect_leaf_field_indices(&mut all);
+        assert_eq!(all, HashSet::from([0]), "placeholder index is present");
+
+        let mut user = HashSet::new();
+        row_id.collect_user_leaf_field_indices(&mut user);
+        assert!(user.is_empty(), "system leaf must not contribute an index");
+    }
 
     #[test]
     fn test_decimal_eq_same_scale() {

--- a/crates/paimon/src/spec/predicate.rs
+++ b/crates/paimon/src/spec/predicate.rs
@@ -672,6 +672,23 @@ impl Predicate {
             Predicate::AlwaysTrue | Predicate::AlwaysFalse => {}
         }
     }
+    /// Column names referenced by every leaf. Unlike
+    /// [`Self::collect_leaf_field_indices`] this surfaces system columns too,
+    /// whose positional index is not a table-schema index.
+    pub fn collect_leaf_column_names(&self, out: &mut std::collections::HashSet<String>) {
+        match self {
+            Predicate::Leaf { column, .. } => {
+                out.insert(column.clone());
+            }
+            Predicate::And(children) | Predicate::Or(children) => {
+                children
+                    .iter()
+                    .for_each(|c| c.collect_leaf_column_names(out));
+            }
+            Predicate::Not(inner) => inner.collect_leaf_column_names(out),
+            Predicate::AlwaysTrue | Predicate::AlwaysFalse => {}
+        }
+    }
 
     /// Serialize this predicate in the REST catalog wire format, the inverse of
     /// [`Self::from_rest_json`].
@@ -2489,6 +2506,31 @@ mod tests {
     }
 
     // ======================== Decimal equivalence ========================
+
+    #[test]
+    fn test_user_leaf_indices_skip_system_columns() {
+        use std::collections::HashSet;
+        // A `_ROW_ID` leaf carries a placeholder index (0). Treating it as a
+        // table-schema index would drag an unrelated column into the auth
+        // request and the scope checks.
+        let row_id = Predicate::Leaf {
+            index: 0,
+            column: crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            data_type: DataType::BigInt(BigIntType::new()),
+            op: PredicateOperator::GtEq,
+            literals: vec![Datum::Long(5)],
+        };
+        let mut all = HashSet::new();
+        row_id.collect_leaf_field_indices(&mut all);
+        assert_eq!(all, HashSet::from([0]), "placeholder index is present");
+
+        let mut names = HashSet::new();
+        row_id.collect_leaf_column_names(&mut names);
+        assert_eq!(
+            names,
+            HashSet::from([crate::spec::ROW_ID_FIELD_NAME.to_string()])
+        );
+    }
 
     #[test]
     fn test_decimal_eq_same_scale() {

--- a/crates/paimon/src/spec/schema.rs
+++ b/crates/paimon/src/spec/schema.rs
@@ -255,6 +255,19 @@ impl TableSchema {
         Ok(())
     }
 
+    /// Force `query-auth.enabled = true` on this schema.
+    ///
+    /// Used when a copy must inherit the flag from a table whose schema carries
+    /// it (the REST catalog delivers it on the table response, so an on-disk
+    /// schema — e.g. a branch's — need not have it).
+    pub(crate) fn copy_with_query_auth_enabled(&self) -> Self {
+        let mut new_schema = self.clone();
+        new_schema
+            .options
+            .insert(QUERY_AUTH_ENABLED_OPTION.to_string(), "true".to_string());
+        new_schema
+    }
+
     /// Apply a list of schema changes and return a new schema with incremented ID.
     ///
     /// Column-level changes operate on **top-level** columns only: a

--- a/crates/paimon/src/spec/schema.rs
+++ b/crates/paimon/src/spec/schema.rs
@@ -255,11 +255,9 @@ impl TableSchema {
         Ok(())
     }
 
-    /// Force `query-auth.enabled = true` on this schema.
-    ///
-    /// Used when a copy must inherit the flag from a table whose schema carries
-    /// it (the REST catalog delivers it on the table response, so an on-disk
-    /// schema — e.g. a branch's — need not have it).
+    /// Force `query-auth.enabled = true`. The REST catalog delivers the flag on
+    /// the table response, so a copy built from an on-disk schema (a branch's)
+    /// must re-assert it.
     pub(crate) fn copy_with_query_auth_enabled(&self) -> Self {
         let mut new_schema = self.clone();
         new_schema

--- a/crates/paimon/src/spec/schema.rs
+++ b/crates/paimon/src/spec/schema.rs
@@ -266,11 +266,9 @@ impl TableSchema {
         Ok(())
     }
 
-    /// Force `query-auth.enabled = true` on this schema.
-    ///
-    /// Used when a copy must inherit the flag from a table whose schema carries
-    /// it (the REST catalog delivers it on the table response, so an on-disk
-    /// schema — e.g. a branch's — need not have it).
+    /// Force `query-auth.enabled = true`. The REST catalog delivers the flag on
+    /// the table response, so a copy built from an on-disk schema (a branch's)
+    /// must re-assert it.
     pub(crate) fn copy_with_query_auth_enabled(&self) -> Self {
         let mut new_schema = self.clone();
         new_schema

--- a/crates/paimon/src/spec/schema.rs
+++ b/crates/paimon/src/spec/schema.rs
@@ -266,6 +266,19 @@ impl TableSchema {
         Ok(())
     }
 
+    /// Force `query-auth.enabled = true` on this schema.
+    ///
+    /// Used when a copy must inherit the flag from a table whose schema carries
+    /// it (the REST catalog delivers it on the table response, so an on-disk
+    /// schema — e.g. a branch's — need not have it).
+    pub(crate) fn copy_with_query_auth_enabled(&self) -> Self {
+        let mut new_schema = self.clone();
+        new_schema
+            .options
+            .insert(QUERY_AUTH_ENABLED_OPTION.to_string(), "true".to_string());
+        new_schema
+    }
+
     /// Apply a list of schema changes and return a new schema with incremented ID.
     ///
     /// Column-level changes operate on **top-level** columns only: a

--- a/crates/paimon/src/table/audit_log_table.rs
+++ b/crates/paimon/src/table/audit_log_table.rs
@@ -77,7 +77,11 @@ impl AuditLogTable {
         start_exclusive: i64,
         end_inclusive: i64,
     ) -> IncrementalScan<'_> {
+        // The audit read prepends `rowkind` (and `_SEQUENCE_NUMBER` when
+        // enabled) to its output; declare them at planning time so the server
+        // sees them in `select` and the grant's system scope covers them.
         IncrementalScan::for_table(&self.wrapped, mode, start_exclusive, end_inclusive)
+            .with_audit_system_fields()
     }
 
     pub fn to_arrow(&self, plan: &IncrementalPlan) -> crate::Result<ArrowRecordBatchStream> {

--- a/crates/paimon/src/table/btree_global_index_build_builder.rs
+++ b/crates/paimon/src/table/btree_global_index_build_builder.rs
@@ -84,6 +84,11 @@ impl<'a> BTreeGlobalIndexBuildBuilder<'a> {
 
     pub async fn execute(&self) -> Result<usize> {
         self.table.ensure_not_branch_reference_for_write()?;
+        // Authorize before reading any manifest or index metadata, and once for
+        // the whole build: doing it per shard both skipped the early-return
+        // paths and issued one REST round-trip per shard.
+        let build_grant = self.table.authorize_unrestricted_read().await?;
+        let grant = build_grant.as_ref();
 
         let index_type = normalize_sorted_global_index_type(&self.index_type).ok_or_else(|| {
             Error::Unsupported {
@@ -167,7 +172,7 @@ impl<'a> BTreeGlobalIndexBuildBuilder<'a> {
         let mut messages = Vec::with_capacity(shard_count);
         for shard in shards {
             let index_file = self
-                .build_index_file(&shard, index_field, index_column)
+                .build_index_file(&shard, index_field, index_column, grant)
                 .await?;
             let mut message =
                 CommitMessage::new(shard.partition_bytes.clone(), shard.source_bucket, vec![]);
@@ -194,6 +199,7 @@ impl<'a> BTreeGlobalIndexBuildBuilder<'a> {
         shard: &BTreeGlobalIndexShard,
         index_field: &DataField,
         index_column: &str,
+        grant: Option<&std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>,
     ) -> Result<IndexFileMeta> {
         let index_type = normalize_sorted_global_index_type(&self.index_type).ok_or_else(|| {
             Error::Unsupported {
@@ -205,8 +211,15 @@ impl<'a> BTreeGlobalIndexBuildBuilder<'a> {
         })?;
         let row_count = checked_row_count(shard.row_range_start, shard.row_range_end)?;
         let (cmp, serialize_key) = make_index_key_codec(index_type, index_field.data_type());
-        let mut rows =
-            extract_index_rows(self.table, shard, index_column, index_field, serialize_key).await?;
+        let mut rows = extract_index_rows(
+            self.table,
+            shard,
+            index_column,
+            index_field,
+            serialize_key,
+            grant,
+        )
+        .await?;
         sort_index_rows(&mut rows, &cmp);
 
         self.table
@@ -613,15 +626,11 @@ async fn extract_index_rows(
     index_column: &str,
     index_field: &DataField,
     serialize_key: SerializeKeyFn,
+    grant: Option<&std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>,
 ) -> Result<Vec<BTreeKeyRow>> {
-    // Building the global index reads the indexed column across the shard. Under
-    // a restricted query-auth grant that read would drop/mask rows, so the index
-    // would be built over a filtered view. Require an unrestricted grant and read
-    // raw (stamp the returned grant on each split).
-    let write_grant = table.authorize_unrestricted_read().await?;
     let splits: Vec<crate::table::DataSplit> = build_read_splits_for_shard(shard)?
         .into_iter()
-        .map(|s| s.with_query_auth_grant(write_grant.clone()))
+        .map(|s| s.with_query_auth_grant(grant.cloned()))
         .collect();
 
     let mut read_builder = table.new_read_builder();

--- a/crates/paimon/src/table/btree_global_index_build_builder.rs
+++ b/crates/paimon/src/table/btree_global_index_build_builder.rs
@@ -614,7 +614,15 @@ async fn extract_index_rows(
     index_field: &DataField,
     serialize_key: SerializeKeyFn,
 ) -> Result<Vec<BTreeKeyRow>> {
-    let splits = build_read_splits_for_shard(shard)?;
+    // Building the global index reads the indexed column across the shard. Under
+    // a restricted query-auth grant that read would drop/mask rows, so the index
+    // would be built over a filtered view. Require an unrestricted grant and read
+    // raw (stamp the returned grant on each split).
+    let write_grant = table.authorize_unrestricted_read().await?;
+    let splits: Vec<crate::table::DataSplit> = build_read_splits_for_shard(shard)?
+        .into_iter()
+        .map(|s| s.with_query_auth_grant(write_grant.clone()))
+        .collect();
 
     let mut read_builder = table.new_read_builder();
     read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME])?;

--- a/crates/paimon/src/table/bucket_assigner_cross.rs
+++ b/crates/paimon/src/table/bucket_assigner_cross.rs
@@ -85,6 +85,13 @@ impl GlobalPartitionIndex {
             .collect();
         let projected_pk_indices: Vec<usize> = (0..pk_fields.len()).collect();
 
+        // Building the cross-partition PK index reads every primary key. Under a
+        // restricted query-auth grant the planned splits would filter rows, so
+        // the index would miss hidden keys and produce duplicate PKs / lost
+        // updates on upsert. Require a fully unrestricted grant (the plan then
+        // stamps that unrestricted grant on its splits, so the reads run raw).
+        table.authorize_unrestricted_read().await?;
+
         let mut rb = table.new_read_builder();
         rb.with_projection(&pk_field_names)?;
         let scan = rb.new_scan().with_scan_all_files();

--- a/crates/paimon/src/table/bucket_assigner_cross.rs
+++ b/crates/paimon/src/table/bucket_assigner_cross.rs
@@ -85,11 +85,9 @@ impl GlobalPartitionIndex {
             .collect();
         let projected_pk_indices: Vec<usize> = (0..pk_fields.len()).collect();
 
-        // Building the cross-partition PK index reads every primary key. Under a
-        // restricted query-auth grant the planned splits would filter rows, so
-        // the index would miss hidden keys and produce duplicate PKs / lost
-        // updates on upsert. Require a fully unrestricted grant (the plan then
-        // stamps that unrestricted grant on its splits, so the reads run raw).
+        // The cross-partition PK index reads every primary key; under a
+        // restricted grant it would miss hidden keys and produce duplicate PKs
+        // or lost updates on upsert.
         table.authorize_unrestricted_read().await?;
 
         let mut rb = table.new_read_builder();

--- a/crates/paimon/src/table/bucket_assigner_cross.rs
+++ b/crates/paimon/src/table/bucket_assigner_cross.rs
@@ -88,11 +88,9 @@ impl GlobalPartitionIndex {
             .collect();
         let projected_pk_indices: Vec<usize> = (0..pk_fields.len()).collect();
 
-        // Building the cross-partition PK index reads every primary key. Under a
-        // restricted query-auth grant the planned splits would filter rows, so
-        // the index would miss hidden keys and produce duplicate PKs / lost
-        // updates on upsert. Require a fully unrestricted grant (the plan then
-        // stamps that unrestricted grant on its splits, so the reads run raw).
+        // The cross-partition PK index reads every primary key; under a
+        // restricted grant it would miss hidden keys and produce duplicate PKs
+        // or lost updates on upsert.
         table.authorize_unrestricted_read().await?;
 
         let mut rb = table.new_read_builder();

--- a/crates/paimon/src/table/bucket_assigner_cross.rs
+++ b/crates/paimon/src/table/bucket_assigner_cross.rs
@@ -88,6 +88,13 @@ impl GlobalPartitionIndex {
             .collect();
         let projected_pk_indices: Vec<usize> = (0..pk_fields.len()).collect();
 
+        // Building the cross-partition PK index reads every primary key. Under a
+        // restricted query-auth grant the planned splits would filter rows, so
+        // the index would miss hidden keys and produce duplicate PKs / lost
+        // updates on upsert. Require a fully unrestricted grant (the plan then
+        // stamps that unrestricted grant on its splits, so the reads run raw).
+        table.authorize_unrestricted_read().await?;
+
         let mut rb = table.new_read_builder();
         rb.with_projection(&pk_field_names)?;
         let scan = rb.new_scan().with_scan_all_files();

--- a/crates/paimon/src/table/cow_writer.rs
+++ b/crates/paimon/src/table/cow_writer.rs
@@ -210,6 +210,14 @@ impl CopyOnWriteMergeWriter {
             return Ok(Vec::new());
         }
 
+        // A copy-on-write rewrite reads each affected file and rewrites it in
+        // place. Under a restricted query-auth grant that read would filter and
+        // mask rows, silently deleting hidden rows and persisting masked values
+        // on commit — so require a fully unrestricted grant and read raw. The
+        // returned grant (unrestricted, or `None` for a non-query-auth table) is
+        // stamped on each split so `to_arrow` reads raw instead of failing closed.
+        let write_grant = self.table.authorize_unrestricted_read().await?;
+
         let schema = self.table.schema();
         let core_options = CoreOptions::new(schema.options());
         let partition_keys: Vec<String> = schema.partition_keys().to_vec();
@@ -232,6 +240,7 @@ impl CopyOnWriteMergeWriter {
         let update_batches = &self.update_batches;
         let file_index = &self.file_index;
         let table = &self.table;
+        let write_grant = &write_grant;
         let partition_keys = &partition_keys;
         let partition_computer = &partition_computer;
         let write_fields = &write_fields;
@@ -253,7 +262,8 @@ impl CopyOnWriteMergeWriter {
                     .with_bucket_path(file_info.bucket_path.clone())
                     .with_total_buckets(file_info.total_buckets)
                     .with_data_files(vec![file_info.file_meta.clone()])
-                    .build()?;
+                    .build()?
+                    .with_query_auth_grant(write_grant.clone());
 
                 let read = table.new_read_builder().new_read()?;
                 let original_batches: Vec<RecordBatch> =

--- a/crates/paimon/src/table/cow_writer.rs
+++ b/crates/paimon/src/table/cow_writer.rs
@@ -211,11 +211,9 @@ impl CopyOnWriteMergeWriter {
         }
 
         // A copy-on-write rewrite reads each affected file and rewrites it in
-        // place. Under a restricted query-auth grant that read would filter and
-        // mask rows, silently deleting hidden rows and persisting masked values
-        // on commit — so require a fully unrestricted grant and read raw. The
-        // returned grant (unrestricted, or `None` for a non-query-auth table) is
-        // stamped on each split so `to_arrow` reads raw instead of failing closed.
+        // place, so under a restricted grant it would silently delete hidden
+        // rows and persist masked values. Require an unrestricted grant and
+        // stamp it on each split, so `to_arrow` reads raw.
         let write_grant = self.table.authorize_unrestricted_read().await?;
 
         let schema = self.table.schema();

--- a/crates/paimon/src/table/cow_writer.rs
+++ b/crates/paimon/src/table/cow_writer.rs
@@ -214,11 +214,9 @@ impl CopyOnWriteMergeWriter {
         }
 
         // A copy-on-write rewrite reads each affected file and rewrites it in
-        // place. Under a restricted query-auth grant that read would filter and
-        // mask rows, silently deleting hidden rows and persisting masked values
-        // on commit — so require a fully unrestricted grant and read raw. The
-        // returned grant (unrestricted, or `None` for a non-query-auth table) is
-        // stamped on each split so `to_arrow` reads raw instead of failing closed.
+        // place, so under a restricted grant it would silently delete hidden
+        // rows and persist masked values. Require an unrestricted grant and
+        // stamp it on each split, so `to_arrow` reads raw.
         let write_grant = self.table.authorize_unrestricted_read().await?;
 
         let schema = self.table.schema();

--- a/crates/paimon/src/table/cow_writer.rs
+++ b/crates/paimon/src/table/cow_writer.rs
@@ -213,6 +213,14 @@ impl CopyOnWriteMergeWriter {
             return Ok(Vec::new());
         }
 
+        // A copy-on-write rewrite reads each affected file and rewrites it in
+        // place. Under a restricted query-auth grant that read would filter and
+        // mask rows, silently deleting hidden rows and persisting masked values
+        // on commit — so require a fully unrestricted grant and read raw. The
+        // returned grant (unrestricted, or `None` for a non-query-auth table) is
+        // stamped on each split so `to_arrow` reads raw instead of failing closed.
+        let write_grant = self.table.authorize_unrestricted_read().await?;
+
         let schema = self.table.schema();
         let core_options = CoreOptions::new(schema.options());
         let partition_keys: Vec<String> = schema.partition_keys().to_vec();
@@ -235,6 +243,7 @@ impl CopyOnWriteMergeWriter {
         let update_batches = &self.update_batches;
         let file_index = &self.file_index;
         let table = &self.table;
+        let write_grant = &write_grant;
         let partition_keys = &partition_keys;
         let partition_computer = &partition_computer;
         let write_fields = &write_fields;
@@ -256,7 +265,8 @@ impl CopyOnWriteMergeWriter {
                     .with_bucket_path(file_info.bucket_path.clone())
                     .with_total_buckets(file_info.total_buckets)
                     .with_data_files(vec![file_info.file_meta.clone()])
-                    .build()?;
+                    .build()?
+                    .with_query_auth_grant(write_grant.clone());
 
                 let read = table.new_read_builder().new_read()?;
                 let original_batches: Vec<RecordBatch> =

--- a/crates/paimon/src/table/data_evolution_writer.rs
+++ b/crates/paimon/src/table/data_evolution_writer.rs
@@ -164,6 +164,12 @@ impl DataEvolutionWriter {
             return Ok(Vec::new());
         }
 
+        // This rewrite reads each affected file's original columns and rewrites
+        // it; under a restricted query-auth grant that read would filter/mask
+        // rows into the committed result. Require an unrestricted grant and read
+        // raw (stamp the returned grant on each split).
+        let write_grant = self.table.authorize_unrestricted_read().await?;
+
         // 1. Scan file metadata and build row_id -> file group index.
         //    In data-evolution tables, multiple files can share the same first_row_id
         //    (base file + partial-column files). We must group them so the reader
@@ -248,7 +254,8 @@ impl DataEvolutionWriter {
                 .with_total_buckets(file_range.total_buckets)
                 .with_data_files(file_range.files.clone())
                 .with_raw_convertible(file_range.files.len() == 1)
-                .build()?;
+                .build()?
+                .with_query_auth_grant(write_grant.clone());
 
             let stream = read.to_arrow(&[split])?;
             let original_batches: Vec<RecordBatch> = stream.try_collect().await?;
@@ -459,6 +466,12 @@ impl DataEvolutionDeleteWriter {
         if self.row_ids.is_empty() {
             return Ok(Vec::new());
         }
+
+        // The row ids to delete come from a read the caller performed; under a
+        // restricted grant that read hid rows, so the committed deletion vectors
+        // would encode a delete set derived from a filtered view. Require an
+        // unrestricted grant, like `DataEvolutionWriter::prepare_commit`.
+        self.table.authorize_unrestricted_read().await?;
 
         let scan = self
             .table

--- a/crates/paimon/src/table/data_evolution_writer.rs
+++ b/crates/paimon/src/table/data_evolution_writer.rs
@@ -164,10 +164,8 @@ impl DataEvolutionWriter {
             return Ok(Vec::new());
         }
 
-        // This rewrite reads each affected file's original columns and rewrites
-        // it; under a restricted query-auth grant that read would filter/mask
-        // rows into the committed result. Require an unrestricted grant and read
-        // raw (stamp the returned grant on each split).
+        // This rewrite reads each affected file's original columns, so a
+        // restricted grant would filter/mask rows into the committed result.
         let write_grant = self.table.authorize_unrestricted_read().await?;
 
         // 1. Scan file metadata and build row_id -> file group index.
@@ -467,10 +465,8 @@ impl DataEvolutionDeleteWriter {
             return Ok(Vec::new());
         }
 
-        // The row ids to delete come from a read the caller performed; under a
-        // restricted grant that read hid rows, so the committed deletion vectors
-        // would encode a delete set derived from a filtered view. Require an
-        // unrestricted grant, like `DataEvolutionWriter::prepare_commit`.
+        // The row ids come from a read the caller performed; under a restricted
+        // grant the deletion vectors would encode a filtered view.
         self.table.authorize_unrestricted_read().await?;
 
         let scan = self

--- a/crates/paimon/src/table/data_evolution_writer.rs
+++ b/crates/paimon/src/table/data_evolution_writer.rs
@@ -167,10 +167,8 @@ impl DataEvolutionWriter {
             return Ok(Vec::new());
         }
 
-        // This rewrite reads each affected file's original columns and rewrites
-        // it; under a restricted query-auth grant that read would filter/mask
-        // rows into the committed result. Require an unrestricted grant and read
-        // raw (stamp the returned grant on each split).
+        // This rewrite reads each affected file's original columns, so a
+        // restricted grant would filter/mask rows into the committed result.
         let write_grant = self.table.authorize_unrestricted_read().await?;
 
         // 1. Scan file metadata and build row_id -> file group index.
@@ -492,10 +490,8 @@ impl DataEvolutionDeleteWriter {
             return Ok(Vec::new());
         }
 
-        // The row ids to delete come from a read the caller performed; under a
-        // restricted grant that read hid rows, so the committed deletion vectors
-        // would encode a delete set derived from a filtered view. Require an
-        // unrestricted grant, like `DataEvolutionWriter::prepare_commit`.
+        // The row ids come from a read the caller performed; under a restricted
+        // grant the deletion vectors would encode a filtered view.
         self.table.authorize_unrestricted_read().await?;
 
         let scan = self

--- a/crates/paimon/src/table/data_evolution_writer.rs
+++ b/crates/paimon/src/table/data_evolution_writer.rs
@@ -167,6 +167,12 @@ impl DataEvolutionWriter {
             return Ok(Vec::new());
         }
 
+        // This rewrite reads each affected file's original columns and rewrites
+        // it; under a restricted query-auth grant that read would filter/mask
+        // rows into the committed result. Require an unrestricted grant and read
+        // raw (stamp the returned grant on each split).
+        let write_grant = self.table.authorize_unrestricted_read().await?;
+
         // 1. Scan file metadata and build row_id -> file group index.
         //    In data-evolution tables, multiple files can share the same first_row_id
         //    (base file + partial-column files). We must group them so the reader
@@ -251,7 +257,8 @@ impl DataEvolutionWriter {
                 .with_total_buckets(file_range.total_buckets)
                 .with_data_files(file_range.files.clone())
                 .with_raw_convertible(file_range.files.len() == 1)
-                .build()?;
+                .build()?
+                .with_query_auth_grant(write_grant.clone());
 
             let stream = read.to_arrow(&[split])?;
             let original_batches: Vec<RecordBatch> = stream.try_collect().await?;
@@ -484,6 +491,12 @@ impl DataEvolutionDeleteWriter {
         if self.row_ids.is_empty() {
             return Ok(Vec::new());
         }
+
+        // The row ids to delete come from a read the caller performed; under a
+        // restricted grant that read hid rows, so the committed deletion vectors
+        // would encode a delete set derived from a filtered view. Require an
+        // unrestricted grant, like `DataEvolutionWriter::prepare_commit`.
+        self.table.authorize_unrestricted_read().await?;
 
         let scan = self
             .table

--- a/crates/paimon/src/table/format_read_builder.rs
+++ b/crates/paimon/src/table/format_read_builder.rs
@@ -118,10 +118,30 @@ impl<'a> FormatReadBuilder<'a> {
             self.limit,
             None,
         )
-        .with_query_auth_scope(self.filter_columns.clone(), self.projected_schema_indices())
+        .with_query_auth_scope(
+            self.filter_columns.clone(),
+            self.projected_schema_indices(),
+            self.projected_system_field_names(),
+        )
     }
 
     /// Table-schema indices of the projected columns (`None` = all).
+    /// Projected system fields (`_ROW_ID`, …). `projected_schema_indices` drops
+    /// them for lack of an index, but Java's `select` includes them.
+    fn projected_system_field_names(&self) -> Vec<String> {
+        self.resolve_read_type()
+            .ok()
+            .flatten()
+            .map(|fields| {
+                fields
+                    .iter()
+                    .filter(|f| crate::table::query_auth::is_reserved_system_field(f))
+                    .map(|f| f.name().to_string())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     fn projected_schema_indices(&self) -> Option<Vec<usize>> {
         // Resolve names too (see `PaimonReadBuilder::projected_schema_indices`).
         self.resolve_read_type().ok().flatten().map(|fields| {

--- a/crates/paimon/src/table/format_read_builder.rs
+++ b/crates/paimon/src/table/format_read_builder.rs
@@ -129,17 +129,13 @@ impl<'a> FormatReadBuilder<'a> {
     /// Projected system fields (`_ROW_ID`, …). `projected_schema_indices` drops
     /// them for lack of an index, but Java's `select` includes them.
     fn projected_system_field_names(&self) -> Vec<String> {
-        self.resolve_read_type()
-            .ok()
-            .flatten()
-            .map(|fields| {
-                fields
-                    .iter()
-                    .filter(|f| crate::table::query_auth::is_reserved_system_field(f))
-                    .map(|f| f.name().to_string())
-                    .collect()
-            })
-            .unwrap_or_default()
+        // Format tables have no row-id extraction (`with_row_ranges` is inert),
+        // so the read type is the only source.
+        crate::table::query_auth::projected_system_field_names(
+            self.resolve_read_type().ok().flatten().as_deref(),
+            &std::collections::HashSet::new(),
+            false,
+        )
     }
 
     fn projected_schema_indices(&self) -> Option<Vec<usize>> {

--- a/crates/paimon/src/table/format_read_builder.rs
+++ b/crates/paimon/src/table/format_read_builder.rs
@@ -24,6 +24,7 @@ use super::{Table, TableRead, TableScan};
 use crate::spec::{DataField, Predicate};
 use crate::table::source::RowRange;
 use crate::Result;
+use std::collections::HashSet;
 
 #[derive(Debug, Clone)]
 pub(crate) struct FormatReadBuilder<'a> {
@@ -37,6 +38,7 @@ pub(crate) struct FormatReadBuilder<'a> {
     data_predicates: Vec<Predicate>,
     limit: Option<usize>,
     case_sensitive: bool,
+    filter_columns: HashSet<usize>,
 }
 
 impl<'a> FormatReadBuilder<'a> {
@@ -49,6 +51,7 @@ impl<'a> FormatReadBuilder<'a> {
             data_predicates: Vec::new(),
             limit: None,
             case_sensitive: true,
+            filter_columns: HashSet::new(),
         }
     }
 
@@ -81,6 +84,10 @@ impl<'a> FormatReadBuilder<'a> {
     }
 
     pub(crate) fn with_filter(&mut self, filter: Predicate) -> &mut Self {
+        // Capture the full predicate's columns before it is split, so masked and
+        // out-of-scope partition keys can't prune on their raw value.
+        self.filter_columns.clear();
+        filter.collect_leaf_field_indices(&mut self.filter_columns);
         let (partition_predicate, data_predicates) = split_scan_predicates(self.table, filter);
         self.partition_filter = partition_predicate.map(|pred| {
             PartitionFilter::from_predicate(pred, &self.table.schema().partition_fields())
@@ -111,11 +118,30 @@ impl<'a> FormatReadBuilder<'a> {
             self.limit,
             None,
         )
+        .with_query_auth_scope(self.filter_columns.clone(), self.projected_schema_indices())
+    }
+
+    /// Table-schema indices of the projected columns (`None` = all).
+    fn projected_schema_indices(&self) -> Option<Vec<usize>> {
+        // Resolve names too (see `PaimonReadBuilder::projected_schema_indices`).
+        self.resolve_read_type().ok().flatten().map(|fields| {
+            fields
+                .iter()
+                .filter_map(|f| {
+                    self.table
+                        .schema()
+                        .fields()
+                        .iter()
+                        .position(|s| s.id() == f.id())
+                })
+                .collect()
+        })
     }
 
     pub(crate) fn new_read(&self) -> Result<TableRead<'a>> {
-        let core_options = self.table.schema().core_options();
-        core_options.ensure_read_authorized()?;
+        // Query-auth is enforced in `TableRead::to_arrow` off the grant stamped
+        // on the splits by planning; no gate needed here (see the Paimon
+        // `PaimonReadBuilder::new_read`).
         let read_type = match self.resolve_read_type()? {
             None => self.table.schema().fields().to_vec(),
             Some(fields) => fields,

--- a/crates/paimon/src/table/format_read_builder.rs
+++ b/crates/paimon/src/table/format_read_builder.rs
@@ -26,6 +26,7 @@ use crate::arrow::ParquetReadBudget;
 use crate::spec::{DataField, Predicate};
 use crate::table::source::RowRange;
 use crate::Result;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -42,6 +43,7 @@ pub(crate) struct FormatReadBuilder<'a> {
     row_ranges: Option<Vec<RowRange>>,
     case_sensitive: bool,
     parquet_read_budget: Option<Arc<ParquetReadBudget>>,
+    filter_columns: HashSet<usize>,
 }
 
 impl<'a> FormatReadBuilder<'a> {
@@ -56,6 +58,7 @@ impl<'a> FormatReadBuilder<'a> {
             row_ranges: None,
             case_sensitive: true,
             parquet_read_budget: None,
+            filter_columns: HashSet::new(),
         }
     }
 
@@ -88,6 +91,10 @@ impl<'a> FormatReadBuilder<'a> {
     }
 
     pub(crate) fn with_filter(&mut self, filter: Predicate) -> &mut Self {
+        // Capture the full predicate's columns before it is split, so masked and
+        // out-of-scope partition keys can't prune on their raw value.
+        self.filter_columns.clear();
+        filter.collect_leaf_field_indices(&mut self.filter_columns);
         let (partition_predicate, data_predicates) = split_scan_predicates(self.table, filter);
         self.partition_filter = partition_predicate.map(|pred| {
             PartitionFilter::from_predicate(pred, &self.table.schema().partition_fields())
@@ -124,6 +131,24 @@ impl<'a> FormatReadBuilder<'a> {
             self.limit,
             self.row_ranges.clone(),
         )
+        .with_query_auth_scope(self.filter_columns.clone(), self.projected_schema_indices())
+    }
+
+    /// Table-schema indices of the projected columns (`None` = all).
+    fn projected_schema_indices(&self) -> Option<Vec<usize>> {
+        // Resolve names too (see `PaimonReadBuilder::projected_schema_indices`).
+        self.resolve_read_type().ok().flatten().map(|fields| {
+            fields
+                .iter()
+                .filter_map(|f| {
+                    self.table
+                        .schema()
+                        .fields()
+                        .iter()
+                        .position(|s| s.id() == f.id())
+                })
+                .collect()
+        })
     }
 
     pub(crate) fn new_read(&self) -> Result<TableRead<'a>> {
@@ -134,8 +159,9 @@ impl<'a> FormatReadBuilder<'a> {
                 message: "Row ranges are not supported for format tables".to_string(),
             });
         }
-        let core_options = self.table.schema().core_options();
-        core_options.ensure_read_authorized()?;
+        // Query-auth is enforced in `TableRead::to_arrow` off the grant stamped
+        // on the splits by planning; no gate needed here (see the Paimon
+        // `PaimonReadBuilder::new_read`).
         let read_type = match self.resolve_read_type()? {
             None => self.table.schema().fields().to_vec(),
             Some(fields) => fields,

--- a/crates/paimon/src/table/format_read_builder.rs
+++ b/crates/paimon/src/table/format_read_builder.rs
@@ -131,10 +131,30 @@ impl<'a> FormatReadBuilder<'a> {
             self.limit,
             self.row_ranges.clone(),
         )
-        .with_query_auth_scope(self.filter_columns.clone(), self.projected_schema_indices())
+        .with_query_auth_scope(
+            self.filter_columns.clone(),
+            self.projected_schema_indices(),
+            self.projected_system_field_names(),
+        )
     }
 
     /// Table-schema indices of the projected columns (`None` = all).
+    /// Projected system fields (`_ROW_ID`, …). `projected_schema_indices` drops
+    /// them for lack of an index, but Java's `select` includes them.
+    fn projected_system_field_names(&self) -> Vec<String> {
+        self.resolve_read_type()
+            .ok()
+            .flatten()
+            .map(|fields| {
+                fields
+                    .iter()
+                    .filter(|f| crate::table::query_auth::is_reserved_system_field(f))
+                    .map(|f| f.name().to_string())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     fn projected_schema_indices(&self) -> Option<Vec<usize>> {
         // Resolve names too (see `PaimonReadBuilder::projected_schema_indices`).
         self.resolve_read_type().ok().flatten().map(|fields| {

--- a/crates/paimon/src/table/format_read_builder.rs
+++ b/crates/paimon/src/table/format_read_builder.rs
@@ -142,17 +142,13 @@ impl<'a> FormatReadBuilder<'a> {
     /// Projected system fields (`_ROW_ID`, …). `projected_schema_indices` drops
     /// them for lack of an index, but Java's `select` includes them.
     fn projected_system_field_names(&self) -> Vec<String> {
-        self.resolve_read_type()
-            .ok()
-            .flatten()
-            .map(|fields| {
-                fields
-                    .iter()
-                    .filter(|f| crate::table::query_auth::is_reserved_system_field(f))
-                    .map(|f| f.name().to_string())
-                    .collect()
-            })
-            .unwrap_or_default()
+        // Format tables have no row-id extraction (`with_row_ranges` is inert),
+        // so the read type is the only source.
+        crate::table::query_auth::projected_system_field_names(
+            self.resolve_read_type().ok().flatten().as_deref(),
+            &std::collections::HashSet::new(),
+            false,
+        )
     }
 
     fn projected_schema_indices(&self) -> Option<Vec<usize>> {

--- a/crates/paimon/src/table/format_table_read.rs
+++ b/crates/paimon/src/table/format_table_read.rs
@@ -70,6 +70,10 @@ impl<'a> FormatTableRead<'a> {
         self.table
     }
 
+    pub(crate) fn limit(&self) -> Option<usize> {
+        self.limit
+    }
+
     pub(crate) fn with_filter(mut self, filter: Predicate) -> Self {
         self.data_predicates = split_scan_predicates(self.table, filter).1;
         self
@@ -87,8 +91,9 @@ impl<'a> FormatTableRead<'a> {
         &self,
         data_splits: &[DataSplit],
     ) -> crate::Result<ArrowRecordBatchStream> {
-        let core_options = self.table.schema().core_options();
-        core_options.ensure_read_authorized()?;
+        // Query-auth (fail-closed + row filter + masking) is enforced by the
+        // outer `TableRead::to_arrow` off the grant stamped on the splits.
+        let core_options = self.table.schema.core_options();
         let read_type = self.read_type.clone();
         let output_schema = build_target_arrow_schema(&read_type)?;
         let partition_keys = self.table.schema().partition_keys().to_vec();

--- a/crates/paimon/src/table/format_table_read.rs
+++ b/crates/paimon/src/table/format_table_read.rs
@@ -90,6 +90,10 @@ impl<'a> FormatTableRead<'a> {
         self
     }
 
+    pub(super) fn explicit_parquet_read_budget(&self) -> Option<Arc<ParquetReadBudget>> {
+        self.parquet_read_budget.clone()
+    }
+
     pub(crate) fn with_parquet_read_budget(mut self, budget: Arc<ParquetReadBudget>) -> Self {
         self.parquet_read_budget = Some(budget);
         self

--- a/crates/paimon/src/table/format_table_read.rs
+++ b/crates/paimon/src/table/format_table_read.rs
@@ -73,6 +73,10 @@ impl<'a> FormatTableRead<'a> {
         self.table
     }
 
+    pub(crate) fn limit(&self) -> Option<usize> {
+        self.limit
+    }
+
     pub(crate) fn with_filter(mut self, filter: Predicate) -> Self {
         self.data_predicates = split_scan_predicates(self.table, filter).1;
         self
@@ -102,8 +106,9 @@ impl<'a> FormatTableRead<'a> {
         &self,
         data_splits: &[DataSplit],
     ) -> crate::Result<ArrowRecordBatchStream> {
+        // Query-auth (fail-closed + row filter + masking) is enforced by the
+        // outer `TableRead::to_arrow` off the grant stamped on the splits.
         let core_options = self.table.schema().core_options();
-        core_options.ensure_read_authorized()?;
         // Mapping the conjunct onto the data fields drops it, so the read would
         // silently ignore the filter. Guard on the read path, not the builder:
         // `TableRead` is public and can be constructed and filtered directly.

--- a/crates/paimon/src/table/format_table_scan.rs
+++ b/crates/paimon/src/table/format_table_scan.rs
@@ -32,6 +32,8 @@ pub(crate) struct FormatTableScan<'a> {
     table: &'a Table,
     partition_filter: Option<PartitionFilter>,
     limit: Option<usize>,
+    query_auth_filter_columns: std::collections::HashSet<usize>,
+    query_auth_projected: Option<Vec<usize>>,
 }
 
 impl<'a> FormatTableScan<'a> {
@@ -44,26 +46,87 @@ impl<'a> FormatTableScan<'a> {
             table,
             partition_filter,
             limit,
+            query_auth_filter_columns: std::collections::HashSet::new(),
+            query_auth_projected: None,
         }
     }
 
+    pub(super) fn with_query_auth_scope(
+        mut self,
+        filter_columns: std::collections::HashSet<usize>,
+        projected: Option<Vec<usize>>,
+    ) -> Self {
+        self.query_auth_filter_columns = filter_columns;
+        self.query_auth_projected = projected;
+        self
+    }
+
     pub(crate) async fn plan(&self) -> crate::Result<Plan> {
-        self.ensure_query_auth_allowed()?;
-        self.plan_inner(None).await
+        let grant = self.ensure_query_auth_allowed().await?;
+        let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
+        self.plan_inner(None, has_row_filter)
+            .await
+            .map(|plan| self.finalize_plan(plan, grant.as_ref()))
     }
 
     pub(crate) async fn plan_with_trace(&self) -> crate::Result<(Plan, ScanTrace)> {
-        self.ensure_query_auth_allowed()?;
+        let grant = self.ensure_query_auth_allowed().await?;
+        let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
         let mut trace = ScanTrace::default();
-        let plan = self.plan_inner(Some(&mut trace)).await?;
-        Ok((plan, trace))
+        let plan = self.plan_inner(Some(&mut trace), has_row_filter).await?;
+        Ok((self.finalize_plan(plan, grant.as_ref()), trace))
     }
 
-    fn ensure_query_auth_allowed(&self) -> crate::Result<()> {
-        CoreOptions::new(self.table.schema().options()).ensure_read_authorized()
+    /// Stamp the grant onto every split (so `TableRead::to_arrow` enforces it)
+    /// and mark row counts inexact when it carries a row filter.
+    fn finalize_plan(
+        &self,
+        plan: Plan,
+        grant: Option<&std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>,
+    ) -> Plan {
+        // Any restricted grant invalidates the plan's statistics (see the
+        // Paimon `TableScan::finalize_plan`).
+        let restricted = grant.is_some_and(|g| g.has_server_restrictions());
+        let plan = plan.stamp_query_auth_grant(grant.cloned());
+        if restricted {
+            plan.with_inexact_row_counts()
+        } else {
+            plan
+        }
     }
 
-    async fn plan_inner(&self, trace: Option<&mut ScanTrace>) -> crate::Result<Plan> {
+    async fn ensure_query_auth_allowed(
+        &self,
+    ) -> crate::Result<Option<std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>> {
+        // Fetch/refresh the grant at plan time (Java parity), then guard
+        // against pruning on masked or out-of-scope columns.
+        let select = self.query_auth_projected.as_ref().map(|projected| {
+            projected
+                .iter()
+                .copied()
+                .chain(self.query_auth_filter_columns.iter().copied())
+                .collect::<std::collections::HashSet<usize>>()
+        });
+        let grant = self
+            .table
+            .verify_query_auth_for_read(select.as_ref())
+            .await?;
+        if let Some(grant) = &grant {
+            crate::table::query_auth::scope_check(
+                grant,
+                self.table.schema().fields(),
+                &self.query_auth_filter_columns,
+                self.query_auth_projected.clone(),
+            )?;
+        }
+        Ok(grant)
+    }
+
+    async fn plan_inner(
+        &self,
+        trace: Option<&mut ScanTrace>,
+        query_auth_row_filter: bool,
+    ) -> crate::Result<Plan> {
         let core_options = CoreOptions::new(self.table.schema().options());
         let format_extension = supported_format_table_extension(core_options.file_format())?;
         let schema_id = self.table.schema().id();
@@ -103,7 +166,7 @@ impl<'a> FormatTableScan<'a> {
                     .cmp(&right.data_files()[0].file_name)
             })
         });
-        splits = self.apply_limit_pushdown(splits);
+        splits = self.apply_limit_pushdown(splits, query_auth_row_filter);
 
         if let Some(trace) = trace {
             trace.record_final_plan(splits.len(), splits.len(), splits.len());
@@ -275,7 +338,13 @@ impl<'a> FormatTableScan<'a> {
     pub(crate) fn apply_limit_pushdown(
         &self,
         splits: Vec<crate::DataSplit>,
+        query_auth_row_filter: bool,
     ) -> Vec<crate::DataSplit> {
+        // A query-auth row filter runs as a residual pass at read time, so the
+        // scan must not cap files by an unfiltered limit before that.
+        if query_auth_row_filter {
+            return splits;
+        }
         match self.limit {
             Some(0) => Vec::new(),
             Some(limit) if splits.len() > limit => splits.into_iter().take(limit).collect(),

--- a/crates/paimon/src/table/format_table_scan.rs
+++ b/crates/paimon/src/table/format_table_scan.rs
@@ -34,6 +34,8 @@ pub(crate) struct FormatTableScan<'a> {
     limit: Option<usize>,
     query_auth_filter_columns: std::collections::HashSet<usize>,
     query_auth_projected: Option<Vec<usize>>,
+    /// Sent in `select`, but has no index to scope.
+    query_auth_system_select: Vec<String>,
 }
 
 impl<'a> FormatTableScan<'a> {
@@ -48,6 +50,7 @@ impl<'a> FormatTableScan<'a> {
             limit,
             query_auth_filter_columns: std::collections::HashSet::new(),
             query_auth_projected: None,
+            query_auth_system_select: Vec::new(),
         }
     }
 
@@ -55,9 +58,11 @@ impl<'a> FormatTableScan<'a> {
         mut self,
         filter_columns: std::collections::HashSet<usize>,
         projected: Option<Vec<usize>>,
+        system_select: Vec<String>,
     ) -> Self {
         self.query_auth_filter_columns = filter_columns;
         self.query_auth_projected = projected;
+        self.query_auth_system_select = system_select;
         self
     }
 
@@ -109,7 +114,7 @@ impl<'a> FormatTableScan<'a> {
         });
         let grant = self
             .table
-            .verify_query_auth_for_read(select.as_ref())
+            .verify_query_auth_for_read(select.as_ref(), &self.query_auth_system_select)
             .await?;
         if let Some(grant) = &grant {
             crate::table::query_auth::scope_check(

--- a/crates/paimon/src/table/format_table_scan.rs
+++ b/crates/paimon/src/table/format_table_scan.rs
@@ -114,9 +114,23 @@ impl<'a> FormatTableScan<'a> {
         });
         let grant = self
             .table
-            .verify_query_auth_for_read(select.as_ref(), &self.query_auth_system_select)
+            .verify_query_auth_for_read(select.as_ref(), Some(&self.query_auth_system_select))
             .await?;
         if let Some(grant) = &grant {
+            // The grant authorizes the catalog table, but `plan_inner` reads
+            // from `CoreOptions::path`. An override could point the scan at
+            // another directory and have those splits stamped with this grant.
+            let core = CoreOptions::new(self.table.schema().options());
+            if core.path().is_some_and(|p| {
+                p.trim_end_matches('/') != self.table.location().trim_end_matches('/')
+            }) {
+                return Err(crate::Error::Unsupported {
+                    message: "a 'path' override cannot be used on a \
+                              'query-auth.enabled' table: the grant authorizes the \
+                              catalog table's location, not the overridden one"
+                        .to_string(),
+                });
+            }
             crate::table::query_auth::scope_check(
                 grant,
                 self.table.schema().fields(),

--- a/crates/paimon/src/table/format_table_scan.rs
+++ b/crates/paimon/src/table/format_table_scan.rs
@@ -34,6 +34,8 @@ pub(crate) struct FormatTableScan<'a> {
     partition_filter: Option<PartitionFilter>,
     limit: Option<usize>,
     row_ranges: Option<Vec<RowRange>>,
+    query_auth_filter_columns: std::collections::HashSet<usize>,
+    query_auth_projected: Option<Vec<usize>>,
 }
 
 impl<'a> FormatTableScan<'a> {
@@ -48,6 +50,8 @@ impl<'a> FormatTableScan<'a> {
             partition_filter,
             limit,
             row_ranges,
+            query_auth_filter_columns: std::collections::HashSet::new(),
+            query_auth_projected: None,
         }
     }
 
@@ -56,24 +60,83 @@ impl<'a> FormatTableScan<'a> {
         self
     }
 
+    pub(super) fn with_query_auth_scope(
+        mut self,
+        filter_columns: std::collections::HashSet<usize>,
+        projected: Option<Vec<usize>>,
+    ) -> Self {
+        self.query_auth_filter_columns = filter_columns;
+        self.query_auth_projected = projected;
+        self
+    }
+
     pub(crate) async fn plan(&self) -> crate::Result<Plan> {
-        self.ensure_query_auth_allowed()?;
-        self.plan_inner(None).await
+        let grant = self.ensure_query_auth_allowed().await?;
+        let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
+        self.plan_inner(None, has_row_filter)
+            .await
+            .map(|plan| self.finalize_plan(plan, grant.as_ref()))
     }
 
     pub(crate) async fn plan_with_trace(&self) -> crate::Result<(Plan, ScanTrace)> {
-        self.ensure_query_auth_allowed()?;
+        let grant = self.ensure_query_auth_allowed().await?;
+        let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
         let mut trace = ScanTrace::default();
-        let plan = self.plan_inner(Some(&mut trace)).await?;
+        let plan = self.plan_inner(Some(&mut trace), has_row_filter).await?;
         trace.planned_data_file_bytes = plan.planned_data_file_bytes();
-        Ok((plan, trace))
+        Ok((self.finalize_plan(plan, grant.as_ref()), trace))
     }
 
-    fn ensure_query_auth_allowed(&self) -> crate::Result<()> {
-        CoreOptions::new(self.table.schema().options()).ensure_read_authorized()
+    /// Stamp the grant onto every split (so `TableRead::to_arrow` enforces it)
+    /// and mark row counts inexact when it carries a row filter.
+    fn finalize_plan(
+        &self,
+        plan: Plan,
+        grant: Option<&std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>,
+    ) -> Plan {
+        // Any restricted grant invalidates the plan's statistics (see the
+        // Paimon `TableScan::finalize_plan`).
+        let restricted = grant.is_some_and(|g| g.has_server_restrictions());
+        let plan = plan.stamp_query_auth_grant(grant.cloned());
+        if restricted {
+            plan.with_inexact_row_counts()
+        } else {
+            plan
+        }
     }
 
-    async fn plan_inner(&self, trace: Option<&mut ScanTrace>) -> crate::Result<Plan> {
+    async fn ensure_query_auth_allowed(
+        &self,
+    ) -> crate::Result<Option<std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>> {
+        // Fetch/refresh the grant at plan time (Java parity), then guard
+        // against pruning on masked or out-of-scope columns.
+        let select = self.query_auth_projected.as_ref().map(|projected| {
+            projected
+                .iter()
+                .copied()
+                .chain(self.query_auth_filter_columns.iter().copied())
+                .collect::<std::collections::HashSet<usize>>()
+        });
+        let grant = self
+            .table
+            .verify_query_auth_for_read(select.as_ref())
+            .await?;
+        if let Some(grant) = &grant {
+            crate::table::query_auth::scope_check(
+                grant,
+                self.table.schema().fields(),
+                &self.query_auth_filter_columns,
+                self.query_auth_projected.clone(),
+            )?;
+        }
+        Ok(grant)
+    }
+
+    async fn plan_inner(
+        &self,
+        trace: Option<&mut ScanTrace>,
+        query_auth_row_filter: bool,
+    ) -> crate::Result<Plan> {
         if self.row_ranges.is_some() {
             return Err(crate::Error::Unsupported {
                 message: "Row ranges are not supported for format tables".to_string(),
@@ -141,7 +204,7 @@ impl<'a> FormatTableScan<'a> {
                     .cmp(&right.data_files()[0].file_name)
             })
         });
-        splits = self.apply_limit_pushdown(splits);
+        splits = self.apply_limit_pushdown(splits, query_auth_row_filter);
 
         if let Some(trace) = trace {
             trace.record_final_plan(splits.len(), splits.len(), splits.len());
@@ -318,7 +381,13 @@ impl<'a> FormatTableScan<'a> {
     pub(crate) fn apply_limit_pushdown(
         &self,
         splits: Vec<crate::DataSplit>,
+        query_auth_row_filter: bool,
     ) -> Vec<crate::DataSplit> {
+        // A query-auth row filter runs as a residual pass at read time, so the
+        // scan must not cap files by an unfiltered limit before that.
+        if query_auth_row_filter {
+            return splits;
+        }
         match self.limit {
             Some(0) => Vec::new(),
             _ => splits,

--- a/crates/paimon/src/table/format_table_scan.rs
+++ b/crates/paimon/src/table/format_table_scan.rs
@@ -124,9 +124,23 @@ impl<'a> FormatTableScan<'a> {
         });
         let grant = self
             .table
-            .verify_query_auth_for_read(select.as_ref(), &self.query_auth_system_select)
+            .verify_query_auth_for_read(select.as_ref(), Some(&self.query_auth_system_select))
             .await?;
         if let Some(grant) = &grant {
+            // The grant authorizes the catalog table, but `plan_inner` reads
+            // from `CoreOptions::path`. An override could point the scan at
+            // another directory and have those splits stamped with this grant.
+            let core = CoreOptions::new(self.table.schema().options());
+            if core.path().is_some_and(|p| {
+                p.trim_end_matches('/') != self.table.location().trim_end_matches('/')
+            }) {
+                return Err(crate::Error::Unsupported {
+                    message: "a 'path' override cannot be used on a \
+                              'query-auth.enabled' table: the grant authorizes the \
+                              catalog table's location, not the overridden one"
+                        .to_string(),
+                });
+            }
             crate::table::query_auth::scope_check(
                 grant,
                 self.table.schema().fields(),

--- a/crates/paimon/src/table/format_table_scan.rs
+++ b/crates/paimon/src/table/format_table_scan.rs
@@ -36,6 +36,8 @@ pub(crate) struct FormatTableScan<'a> {
     row_ranges: Option<Vec<RowRange>>,
     query_auth_filter_columns: std::collections::HashSet<usize>,
     query_auth_projected: Option<Vec<usize>>,
+    /// Sent in `select`, but has no index to scope.
+    query_auth_system_select: Vec<String>,
 }
 
 impl<'a> FormatTableScan<'a> {
@@ -52,6 +54,7 @@ impl<'a> FormatTableScan<'a> {
             row_ranges,
             query_auth_filter_columns: std::collections::HashSet::new(),
             query_auth_projected: None,
+            query_auth_system_select: Vec::new(),
         }
     }
 
@@ -64,9 +67,11 @@ impl<'a> FormatTableScan<'a> {
         mut self,
         filter_columns: std::collections::HashSet<usize>,
         projected: Option<Vec<usize>>,
+        system_select: Vec<String>,
     ) -> Self {
         self.query_auth_filter_columns = filter_columns;
         self.query_auth_projected = projected;
+        self.query_auth_system_select = system_select;
         self
     }
 
@@ -119,7 +124,7 @@ impl<'a> FormatTableScan<'a> {
         });
         let grant = self
             .table
-            .verify_query_auth_for_read(select.as_ref())
+            .verify_query_auth_for_read(select.as_ref(), &self.query_auth_system_select)
             .await?;
         if let Some(grant) = &grant {
             crate::table::query_auth::scope_check(

--- a/crates/paimon/src/table/full_text_search_builder.rs
+++ b/crates/paimon/src/table/full_text_search_builder.rs
@@ -116,8 +116,10 @@ impl<'a> FullTextSearchBuilder<'a> {
 
     pub async fn execute_scored(&self) -> crate::Result<SearchResult> {
         // Fail closed: returns data-derived row ranges outside `TableScan`/`TableRead`.
+        // Strict: search results bypass the query-auth row filter, so only a
+        // fully unrestricted grant may search.
+        self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
-        core.ensure_read_authorized()?;
         let text_column =
             self.text_column
                 .as_deref()
@@ -202,9 +204,11 @@ impl<'a> FullTextSearchBuilder<'a> {
     /// returning nothing, since the append/data-evolution materialized read is not
     /// supported here.
     pub async fn execute_read(&self) -> crate::Result<ArrowRecordBatchStream> {
-        // Fail closed: returns data outside `TableScan`/`TableRead`.
+        // Fail closed: materializes rows outside `TableScan`/`TableRead`, so it
+        // cannot apply the row filter / masking — only a fully unrestricted
+        // grant may run it (same gate as the scored entry points).
+        self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
-        core.ensure_read_authorized()?;
         let text_column =
             self.text_column
                 .as_deref()

--- a/crates/paimon/src/table/global_index_drop_builder.rs
+++ b/crates/paimon/src/table/global_index_drop_builder.rs
@@ -54,6 +54,10 @@ impl<'a> GlobalIndexDropBuilder<'a> {
         crate::spec::CoreOptions::new(self.table.schema().options()).ensure_read_authorized()?;
 
         self.table.ensure_not_branch_reference_for_write()?;
+        // Before any metadata read: the commit-time gate is too late, since a
+        // restricted caller would otherwise learn whether a matching index
+        // exists from the difference between `Ok(0)` and a rejection.
+        self.table.authorize_unrestricted_write().await?;
 
         let index_type =
             normalize_global_index_type_for_drop(&self.index_type).ok_or_else(|| {

--- a/crates/paimon/src/table/hybrid_search_builder.rs
+++ b/crates/paimon/src/table/hybrid_search_builder.rs
@@ -286,8 +286,10 @@ impl<'a> HybridSearchBuilder<'a> {
     }
 
     pub async fn execute_scored(&self) -> crate::Result<SearchResult> {
+        // Strict: search results bypass the query-auth row filter, so only a
+        // fully unrestricted grant may search.
+        self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
-        core.ensure_read_authorized()?;
         let limit = self.limit.ok_or_else(|| crate::Error::ConfigInvalid {
             message: "Limit must be set via with_limit()".to_string(),
         })?;
@@ -350,8 +352,11 @@ impl<'a> HybridSearchBuilder<'a> {
     /// (append/data-evolution) hybrid is unsupported here — those use
     /// `execute`/`execute_scored`. Mirrors Java `HybridSearchBuilderImpl` PK path.
     pub async fn execute_read(&self) -> crate::Result<ArrowRecordBatchStream> {
+        // Materializes rows outside `TableScan`/`TableRead`, so it cannot apply
+        // the row filter / masking — only a fully unrestricted grant may run it
+        // (same gate as the vector and full-text builders).
+        self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
-        core.ensure_read_authorized()?;
         let limit = self.limit.ok_or_else(|| crate::Error::ConfigInvalid {
             message: "Limit must be set via with_limit()".to_string(),
         })?;

--- a/crates/paimon/src/table/incremental_scan.rs
+++ b/crates/paimon/src/table/incremental_scan.rs
@@ -158,6 +158,24 @@ impl IncrementalPlan {
             })
             .collect()
     }
+
+    /// Every data split this plan reads, including both sides of a
+    /// [`IncrementalSplit::DiffPair`]. Authorization must use this rather than
+    /// [`Self::data_splits`], which drops the diff pairs — a Diff plan would
+    /// otherwise present no splits and skip the query-auth grant check.
+    pub(crate) fn all_data_splits(&self) -> Vec<&DataSplit> {
+        let mut out = Vec::new();
+        for split in &self.splits {
+            match split {
+                IncrementalSplit::Data(data) => out.push(data),
+                IncrementalSplit::DiffPair { before, after } => {
+                    out.extend(before.iter());
+                    out.extend(after.iter());
+                }
+            }
+        }
+        out
+    }
 }
 
 pub(crate) fn validate_diff_pair(before: &[DataSplit], after: &[DataSplit]) -> crate::Result<()> {

--- a/crates/paimon/src/table/incremental_scan.rs
+++ b/crates/paimon/src/table/incremental_scan.rs
@@ -159,10 +159,10 @@ impl IncrementalPlan {
             .collect()
     }
 
-    /// Every data split this plan reads, including both sides of a
-    /// [`IncrementalSplit::DiffPair`]. Authorization must use this rather than
-    /// [`Self::data_splits`], which drops the diff pairs — a Diff plan would
-    /// otherwise present no splits and skip the query-auth grant check.
+    /// Every data split this plan reads, both sides of a
+    /// [`IncrementalSplit::DiffPair`] included. Authorization must use this:
+    /// [`Self::data_splits`] drops the pairs, so a Diff plan would present no
+    /// splits and skip the grant check.
     pub(crate) fn all_data_splits(&self) -> Vec<&DataSplit> {
         let mut out = Vec::new();
         for split in &self.splits {
@@ -240,6 +240,19 @@ impl<'a> IncrementalScan<'a> {
     ) -> Self {
         let scan = TableScan::new(table, None, Vec::new(), None, None, None);
         Self::new(table, scan, mode, start_exclusive, end_inclusive)
+    }
+
+    /// Declare the system fields an audit-log read emits on top of the read
+    /// type, so planning asks the server about them.
+    pub(crate) fn with_audit_system_fields(mut self) -> Self {
+        let mut names = vec![crate::spec::ROW_KIND_FIELD_NAME.to_string()];
+        if crate::table::table_read::audit_sequence_number_enabled(self.table) {
+            names.push(crate::spec::SEQUENCE_NUMBER_FIELD_NAME.to_string());
+        }
+        self.scan = self
+            .scan
+            .with_query_auth_scope(std::collections::HashSet::new(), None, names);
+        self
     }
 
     pub(crate) fn new(

--- a/crates/paimon/src/table/lumina_index_build_builder.rs
+++ b/crates/paimon/src/table/lumina_index_build_builder.rs
@@ -72,6 +72,11 @@ impl<'a> LuminaIndexBuildBuilder<'a> {
 
     pub async fn execute(&self) -> Result<usize> {
         self.table.ensure_not_branch_reference_for_write()?;
+        // Authorize before reading any manifest or index metadata, and once for
+        // the whole build: doing it per shard both skipped the early-return
+        // paths and issued one REST round-trip per shard.
+        let build_grant = self.table.authorize_unrestricted_read().await?;
+        let grant = build_grant.as_ref();
 
         if !is_lumina_index_type(&self.index_type) {
             return Err(Error::DataInvalid {
@@ -159,7 +164,8 @@ impl<'a> LuminaIndexBuildBuilder<'a> {
         let shard_count = shards.len();
         let mut messages = Vec::with_capacity(shard_count);
         for shard in shards {
-            let vectors = extract_vectors(self.table, &shard, index_column, dimension).await?;
+            let vectors =
+                extract_vectors(self.table, &shard, index_column, dimension, grant).await?;
             let index_file = self
                 .build_index_file(
                     &shard,
@@ -570,11 +576,10 @@ async fn extract_vectors(
     shard: &LuminaIndexShard,
     index_column: &str,
     dimension: i32,
+    grant: Option<&std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>,
 ) -> Result<Vec<f32>> {
-    // Index building reads raw values, so it requires an unrestricted grant (a
-    // restricted one would index a filtered/masked view); stamp it so the read
-    // is authorized. Mirrors the B-tree index builder.
-    let build_grant = table.authorize_unrestricted_read().await?;
+    // Index building reads raw values, so `grant` must be the unrestricted one
+    // the caller obtained; stamp it so the read is authorized.
     let split = DataSplitBuilder::new()
         .with_snapshot(shard.snapshot_id)
         .with_partition(shard.partition.clone())
@@ -587,7 +592,7 @@ async fn extract_vectors(
             shard.row_range_end,
         )])
         .build()?
-        .with_query_auth_grant(build_grant);
+        .with_query_auth_grant(grant.cloned());
 
     let mut read_builder = table.new_read_builder();
     read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME])?;

--- a/crates/paimon/src/table/lumina_index_build_builder.rs
+++ b/crates/paimon/src/table/lumina_index_build_builder.rs
@@ -571,6 +571,10 @@ async fn extract_vectors(
     index_column: &str,
     dimension: i32,
 ) -> Result<Vec<f32>> {
+    // Index building reads raw values, so it requires an unrestricted grant (a
+    // restricted one would index a filtered/masked view); stamp it so the read
+    // is authorized. Mirrors the B-tree index builder.
+    let build_grant = table.authorize_unrestricted_read().await?;
     let split = DataSplitBuilder::new()
         .with_snapshot(shard.snapshot_id)
         .with_partition(shard.partition.clone())
@@ -582,7 +586,8 @@ async fn extract_vectors(
             shard.row_range_start,
             shard.row_range_end,
         )])
-        .build()?;
+        .build()?
+        .with_query_auth_grant(build_grant);
 
     let mut read_builder = table.new_read_builder();
     read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME])?;

--- a/crates/paimon/src/table/lumina_index_build_builder.rs
+++ b/crates/paimon/src/table/lumina_index_build_builder.rs
@@ -70,9 +70,12 @@ impl<'a> LuminaIndexBuildBuilder<'a> {
 
     pub async fn execute(&self) -> Result<usize> {
         // Building the index scans the table's rows.
-        CoreOptions::new(self.table.schema().options()).ensure_read_authorized()?;
-
         self.table.ensure_not_branch_reference_for_write()?;
+        // Authorize before reading any manifest or index metadata, and once for
+        // the whole build: doing it per shard both skipped the early-return
+        // paths and issued one REST round-trip per shard.
+        let build_grant = self.table.authorize_unrestricted_read().await?;
+        let grant = build_grant.as_ref();
 
         if !is_lumina_index_type(&self.index_type) {
             return Err(Error::DataInvalid {
@@ -169,7 +172,8 @@ impl<'a> LuminaIndexBuildBuilder<'a> {
         let mut messages = Vec::with_capacity(shard_count);
         for shard in shards {
             let build_result = async {
-                let vectors = extract_vectors(self.table, &shard, index_column, dimension).await?;
+                let vectors =
+                    extract_vectors(self.table, &shard, index_column, dimension, grant).await?;
                 self.build_index_file(
                     &shard,
                     &vectors,

--- a/crates/paimon/src/table/lumina_index_build_builder/extraction.rs
+++ b/crates/paimon/src/table/lumina_index_build_builder/extraction.rs
@@ -31,6 +31,10 @@ pub(super) async fn extract_vectors(
     index_column: &str,
     dimension: i32,
 ) -> Result<Vec<f32>> {
+    // Index building reads raw values, so it requires an unrestricted grant (a
+    // restricted one would index a filtered/masked view); stamp it so the read
+    // is authorized. Mirrors the B-tree index builder.
+    let build_grant = table.authorize_unrestricted_read().await?;
     let split = DataSplitBuilder::new()
         .with_snapshot(shard.snapshot_id)
         .with_partition(shard.partition.clone())
@@ -42,7 +46,8 @@ pub(super) async fn extract_vectors(
             shard.row_range_start,
             shard.row_range_end,
         )])
-        .build()?;
+        .build()?
+        .with_query_auth_grant(build_grant);
 
     let mut read_builder = table.new_read_builder();
     read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME])?;

--- a/crates/paimon/src/table/lumina_index_build_builder/extraction.rs
+++ b/crates/paimon/src/table/lumina_index_build_builder/extraction.rs
@@ -30,11 +30,10 @@ pub(super) async fn extract_vectors(
     shard: &LuminaIndexShard,
     index_column: &str,
     dimension: i32,
+    grant: Option<&std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>,
 ) -> Result<Vec<f32>> {
-    // Index building reads raw values, so it requires an unrestricted grant (a
-    // restricted one would index a filtered/masked view); stamp it so the read
-    // is authorized. Mirrors the B-tree index builder.
-    let build_grant = table.authorize_unrestricted_read().await?;
+    // Index building reads raw values, so `grant` must be the unrestricted one
+    // the caller obtained; stamp it so the read is authorized.
     let split = DataSplitBuilder::new()
         .with_snapshot(shard.snapshot_id)
         .with_partition(shard.partition.clone())
@@ -47,7 +46,7 @@ pub(super) async fn extract_vectors(
             shard.row_range_end,
         )])
         .build()?
-        .with_query_auth_grant(build_grant);
+        .with_query_auth_grant(grant.cloned());
 
     let mut read_builder = table.new_read_builder();
     read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME])?;

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -248,6 +248,7 @@ impl Table {
     pub(crate) async fn verify_query_auth_for_read(
         &self,
         select: Option<&HashSet<usize>>,
+        system_select: &[String],
     ) -> Result<Option<Arc<QueryAuthGrant>>> {
         if !CoreOptions::new(self.schema.options()).query_auth_enabled() {
             return Ok(None);
@@ -260,19 +261,28 @@ impl Table {
             });
         };
         let fields = self.schema.fields();
+        // Java's `select` is `readType.getFieldNames()`, so projected system
+        // fields go too. They have no index to scope, but the server may still
+        // refuse them.
         let select_names = select.map(|indices| {
             fields
                 .iter()
                 .enumerate()
                 .filter(|(i, _)| indices.contains(i))
                 .map(|(_, f)| f.name().to_string())
+                .chain(system_select.iter().cloned())
                 .collect::<Vec<_>>()
         });
         let auth = rest_env.table_query_auth(select_names).await?;
         let filters = query_auth::parse_auth_filters(&auth.filter.unwrap_or_default(), fields)?;
         let masks =
             query_auth::parse_column_masking(&auth.column_masking.unwrap_or_default(), fields)?;
-        let grant = QueryAuthGrant::new(filters, masks, select.cloned(), self.schema.id());
+        let grant = QueryAuthGrant::new(
+            filters,
+            masks,
+            select.cloned(),
+            query_auth::GrantBinding::of(self),
+        );
 
         // The server expresses its rules against the table's CURRENT schema, but
         // a time-travelled or branch copy reads a DIFFERENT one. Binding those
@@ -298,7 +308,7 @@ impl Table {
     /// path must never run under a partial grant, since it would either leak
     /// (search/metadata) or silently drop/mask rows into a committed rewrite.
     pub(crate) async fn authorize_unrestricted_read(&self) -> Result<Option<Arc<QueryAuthGrant>>> {
-        match self.verify_query_auth_for_read(None).await? {
+        match self.verify_query_auth_for_read(None, &[]).await? {
             Some(grant) if grant.is_unrestricted() => Ok(Some(grant)),
             Some(_) => Err(crate::Error::Unsupported {
                 message: "this read on a 'query-auth.enabled' table must see raw rows, so it \
@@ -322,10 +332,7 @@ impl Table {
         // This is the only public API that stamps a grant, so it must not be
         // usable to launder splits: refuse ones that already carry a restricted
         // grant rather than overwriting it.
-        if splits
-            .iter()
-            .any(DataSplit::has_restricted_query_auth_grant)
-        {
+        if splits.iter().any(DataSplit::carries_query_auth_restriction) {
             return Err(crate::Error::Unsupported {
                 message: "cannot re-authorize a split already planned under a query-auth row \
                           filter / column masking grant"
@@ -683,10 +690,9 @@ mod tests {
         use crate::io::FileIOBuilder;
         use crate::spec::{CoreOptions, DataType, IntType, Schema, TableSchema};
 
-        // `query-auth.enabled` arrives on the REST table response, so the
-        // branch's on-disk schema does not carry it. If `copy_with_branch`
-        // dropped it, `t$branch_x` would read the same data files raw and
-        // unauthorized, so drive the real method rather than its inputs.
+        // The flag arrives on the REST table response, not the branch's
+        // on-disk schema; if `copy_with_branch` dropped it, `t$branch_x` would
+        // read the same files unauthorized. Drive the real method.
         let tmp = tempfile::tempdir().unwrap();
         let location = tmp.path().display().to_string();
         let file_io = FileIOBuilder::new("file").build().unwrap();

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -232,23 +232,21 @@ impl Table {
         })
     }
 
-    /// Authorize this user against the REST server when `query-auth.enabled` is
-    /// set: fetch and parse the per-user row filter / column masking and return
-    /// it as the grant the read pipeline enforces. `select` are the queried
-    /// columns (table-schema indices; `None` = all) — like Java's
-    /// `readType.getFieldNames()`, so a column-restricted user can still read
-    /// an authorized subset; the grant is scoped to exactly those columns and a
-    /// wider read fails closed until it re-plans. Returns `None` when the table
-    /// is not `query-auth.enabled`. Called from scan planning and search
-    /// execution at the same per-plan frequency as Java's
-    /// `CatalogEnvironment.tableQueryAuth()`, so a revoked grant takes effect on
-    /// the next plan. The grant is threaded to the read on the split it plans
-    /// (never a shared mutable slot), so it is per-query and cannot leak into a
-    /// concurrent query or a write-path rewrite.
+    /// Fetch the per-user row filter / column masking as the grant the read
+    /// pipeline enforces; `None` when the table is not `query-auth.enabled`.
+    ///
+    /// `select` are the queried columns (table-schema indices, `None` = all),
+    /// like Java's `readType.getFieldNames()`: a column-restricted user can
+    /// read an authorized subset, and a wider read fails closed until it
+    /// re-plans. Called per plan, as Java's `CatalogEnvironment.tableQueryAuth`
+    /// is, so a revoked grant takes effect on the next one.
+    /// `system_select` is `None` for internal raw reads, which run only under a
+    /// fully unrestricted grant and legitimately touch `_ROW_ID`; scan planning
+    /// always passes `Some(names)`, and an empty slice then approves none.
     pub(crate) async fn verify_query_auth_for_read(
         &self,
         select: Option<&HashSet<usize>>,
-        system_select: &[String],
+        system_select: Option<&[String]>,
     ) -> Result<Option<Arc<QueryAuthGrant>>> {
         if !CoreOptions::new(self.schema.options()).query_auth_enabled() {
             return Ok(None);
@@ -263,33 +261,59 @@ impl Table {
         let fields = self.schema.fields();
         // Java's `select` is `readType.getFieldNames()`, so projected system
         // fields go too. They have no index to scope, but the server may still
-        // refuse them.
-        let select_names = select.map(|indices| {
-            fields
-                .iter()
-                .enumerate()
-                .filter(|(i, _)| indices.contains(i))
-                .map(|(_, f)| f.name().to_string())
-                .chain(system_select.iter().cloned())
-                .collect::<Vec<_>>()
-        });
+        // refuse them — which it can only do if they are actually sent, so a
+        // full read that wants one must spell out every column rather than rely
+        // on a null select.
+        let wanted_system: &[String] = system_select.unwrap_or(&[]);
+        let select_names = match select {
+            Some(indices) => Some(
+                fields
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| indices.contains(i))
+                    .map(|(_, f)| f.name().to_string())
+                    .chain(wanted_system.iter().cloned())
+                    .collect::<Vec<_>>(),
+            ),
+            None if wanted_system.is_empty() => None,
+            None => Some(
+                fields
+                    .iter()
+                    .map(|f| f.name().to_string())
+                    .chain(wanted_system.iter().cloned())
+                    .collect::<Vec<_>>(),
+            ),
+        };
         let auth = rest_env.table_query_auth(select_names).await?;
         let filters = query_auth::parse_auth_filters(&auth.filter.unwrap_or_default(), fields)?;
         let masks =
             query_auth::parse_column_masking(&auth.column_masking.unwrap_or_default(), fields)?;
+
+        // Rules are expressed against the LATEST schema, but this `Table` may
+        // predate a concurrent evolution: a re-added column keeps its name and
+        // gets a fresh id. Java re-validates on every plan.
+        // Also with no rules: `select` names columns of THIS copy's schema, so a
+        // column dropped since would be authorized against a latest schema that
+        // no longer has it, while the read still decodes it by field id.
+        // Always, not just when rules exist: `select` (and `None`, meaning every
+        // column of THIS copy) names columns of this schema, so one dropped
+        // since would be authorized against a latest schema that no longer has
+        // it while the read still decodes it by field id.
+        self.ensure_rules_bind_to_latest_schema(&filters, &masks, select)
+            .await?;
         let grant = QueryAuthGrant::new(
             filters,
             masks,
             select.cloned(),
+            system_select.map(|names| names.iter().cloned().collect()),
             query_auth::GrantBinding::of(self),
         );
 
-        // The server expresses its rules against the table's CURRENT schema, but
-        // a time-travelled or branch copy reads a DIFFERENT one. Binding those
-        // rules by name onto it is unsound — a column dropped and re-added under
-        // the same name has a different field id, so a filter or mask would bind
-        // to an unrelated historical column. Fail closed rather than mis-bind.
-        if !grant.is_unrestricted() && (self.time_traveled || self.branch_reference) {
+        // Rules are expressed against the CURRENT schema; a time-travelled or
+        // branch copy reads a different one, where the same name may be an
+        // unrelated field id. Keyed on server rules, not `is_unrestricted()`:
+        // the client's own projection scope binds nothing to the schema.
+        if grant.has_server_restrictions() && (self.time_traveled || self.branch_reference) {
             return Err(crate::Error::Unsupported {
                 message: "a query-auth row filter / column masking grant cannot be applied to a \
                           time-travelled or branch read: the grant is bound to the table's \
@@ -301,14 +325,81 @@ impl Table {
         Ok(Some(Arc::new(grant)))
     }
 
-    /// Authorize a read that cannot enforce a row filter / masking on its output
-    /// (search, system tables, or a write-path rewrite that must read raw).
-    /// Returns the grant to stamp on the splits it reads (`None` = not a
-    /// query-auth table). Fails closed when the grant is restricted — such a
-    /// path must never run under a partial grant, since it would either leak
-    /// (search/metadata) or silently drop/mask rows into a committed rewrite.
+    /// Fail closed when a rule column binds to a different field in the latest
+    /// schema than in this copy — a rename or drop-and-re-add would apply the
+    /// rule to unrelated data. Mirrors Java `validateReadableWithoutRename`.
+    async fn ensure_rules_bind_to_latest_schema(
+        &self,
+        filters: &[crate::spec::Predicate],
+        masks: &[query_auth::ColumnMask],
+        select: Option<&HashSet<usize>>,
+    ) -> Result<()> {
+        // Compare ids before loading: the directory listing is the freshness
+        // check and cannot be skipped, but the schema itself need not be read
+        // when this copy is already current (the common case).
+        // A table with no on-disk schema directory has no drift to detect — the
+        // REST-provided schema is all there is. Listing it is also the only file
+        // access on this path, so a table whose location is not readable (mock
+        // catalogs, tables served entirely over REST) must not fail the read.
+        let Ok(ids) = self.schema_manager.list_all_ids().await else {
+            return Ok(());
+        };
+        let Some(&latest_id) = ids.last() else {
+            return Ok(());
+        };
+        if latest_id == self.schema.id() {
+            return Ok(());
+        }
+        let latest = self.schema_manager.schema(latest_id).await?;
+        let mut referenced = HashSet::new();
+        for filter in filters {
+            filter.collect_leaf_field_indices(&mut referenced);
+        }
+        for mask in masks {
+            referenced.insert(mask.column);
+            mask.transform.collect_field_indices(&mut referenced);
+        }
+        let fields = self.schema.fields();
+        match select {
+            Some(select) => referenced.extend(select.iter().copied()),
+            // `None` = every column of this copy, which is exactly what a full
+            // read decodes.
+            None => referenced.extend(0..fields.len()),
+        }
+        for index in referenced {
+            let Some(field) = fields.get(index) else {
+                continue;
+            };
+            // Type too, not just name and id: `disable-explicit-type-casting`
+            // defaults to false, so a narrowing evolution (DOUBLE -> FLOAT) is
+            // allowed. The auth JSON is parsed and evaluated against THIS
+            // copy's type, so `x > 0.1` on a stale DOUBLE would admit values the
+            // current FLOAT semantics reject.
+            let matched = latest
+                .fields()
+                .iter()
+                .find(|f| f.name() == field.name())
+                .is_some_and(|f| f.id() == field.id() && f.data_type() == field.data_type());
+            if !matched {
+                return Err(crate::Error::Unsupported {
+                    message: format!(
+                        "query-auth read references column `{}`, which the table's latest \
+                         schema exposes as a different column (renamed, or dropped and \
+                         re-added); refusing to read rather than apply it to unrelated data",
+                        field.name()
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Authorize a read that cannot enforce filtering / masking on its output
+    /// (search, system tables, write-path rewrites). Returns the grant to stamp
+    /// on its splits; fails closed on a restricted one, which would either leak
+    /// (search/metadata) or commit a filtered view (rewrites).
     pub(crate) async fn authorize_unrestricted_read(&self) -> Result<Option<Arc<QueryAuthGrant>>> {
-        match self.verify_query_auth_for_read(None, &[]).await? {
+        match self.verify_query_auth_for_read(None, None).await? {
             Some(grant) if grant.is_unrestricted() => Ok(Some(grant)),
             Some(_) => Err(crate::Error::Unsupported {
                 message: "this read on a 'query-auth.enabled' table must see raw rows, so it \
@@ -323,11 +414,10 @@ impl Table {
     /// Authorize an internal read that rewrites data (copy-on-write DML, index
     /// builds) and stamp the grant on `splits`.
     ///
-    /// Such a read must see raw rows — rewriting from a filtered or masked view
-    /// would destroy hidden rows and persist masked values — so it requires a
-    /// fully unrestricted grant and fails closed otherwise. The grant the caller
-    /// would get from scan planning must NOT be used here: under a row filter it
-    /// shifts row offsets, and rewrites replay those offsets.
+    /// Rewriting from a filtered or masked view would destroy hidden rows and
+    /// persist masked values, so this requires a fully unrestricted grant. Scan
+    /// planning's grant must NOT be used: a row filter shifts the positional
+    /// row offsets rewrites replay.
     pub async fn authorize_rewrite_splits(&self, splits: Vec<DataSplit>) -> Result<Vec<DataSplit>> {
         // This is the only public API that stamps a grant, so it must not be
         // usable to launder splits: refuse ones that already carry a restricted
@@ -339,6 +429,25 @@ impl Table {
                     .to_string(),
             });
         }
+        // Catch another table's splits being handed to a permissive one.
+        // Bucket paths only: `external_path` legitimately points anywhere. A
+        // sanity guard, not a boundary against in-process code.
+        let root = self.location().trim_end_matches('/');
+        if let Some(split) = splits.iter().find(|s| {
+            // On a component boundary: `.../t` must reject `.../t2`.
+            s.bucket_path()
+                .trim_end_matches('/')
+                .strip_prefix(root)
+                .is_none_or(|rest| !rest.is_empty() && !rest.starts_with('/'))
+        }) {
+            return Err(crate::Error::Unsupported {
+                message: format!(
+                    "cannot authorize a split at `{}`: it does not belong to table `{}`",
+                    split.bucket_path(),
+                    self.identifier().full_name()
+                ),
+            });
+        }
         let grant = self.authorize_unrestricted_read().await?;
         Ok(splits
             .into_iter()
@@ -346,11 +455,10 @@ impl Table {
             .collect())
     }
 
-    /// Authorize a commit. Writes must require a fully unrestricted grant: the
-    /// data being committed may have come from an enforced read (e.g. `INSERT
-    /// OVERWRITE t SELECT * FROM t`), which would destroy rows the grant hid and
-    /// persist masked values as the stored data. Committing cannot tell where
-    /// its rows came from, so it fails closed for any restricted grant.
+    /// Authorize a commit. The data may have come from an enforced read (e.g.
+    /// `INSERT OVERWRITE t SELECT * FROM t`), which would destroy hidden rows
+    /// and persist masked values; committing cannot tell, so it fails closed
+    /// for any restricted grant.
     pub(crate) async fn authorize_unrestricted_write(&self) -> Result<()> {
         self.authorize_unrestricted_read().await.map(|_| ())
     }
@@ -589,10 +697,9 @@ impl Table {
             })?;
         let mut options = schema.options().clone();
         options.insert("branch".to_string(), branch.clone());
-        // `query-auth.enabled` is delivered by the REST catalog on the table
-        // response, so the branch's on-disk schema need not carry it. Inherit it
-        // from this table: a branch references the same data files, and dropping
-        // the flag here would make `t$branch_x` read them raw, unauthorized.
+        // The flag comes from the REST table response, not the branch's on-disk
+        // schema. A branch references the same files, so dropping it would make
+        // `t$branch_x` read them unauthorized.
         let branch_schema = if CoreOptions::new(self.schema.options()).query_auth_enabled() {
             schema
                 .copy_with_replaced_options(options)
@@ -671,11 +778,9 @@ pub(crate) fn query_auth_table() -> Table {
 mod tests {
     #[tokio::test]
     async fn test_authorize_unrestricted_read_fails_closed() {
-        // Every write/build path (cow_writer, data_evolution_writer, btree index
-        // build, cross-partition bucket assign) authorizes through this gate
-        // before its internal read. A query-auth table it cannot authorize as
-        // unrestricted must fail closed rather than read raw and rewrite
-        // filtered/masked data into a committed result.
+        // Every write/build path authorizes through this gate before its
+        // internal read, so a table it cannot authorize as unrestricted must
+        // fail closed rather than commit a filtered/masked view.
         let table = super::query_auth_table();
         let err = table.authorize_unrestricted_read().await.unwrap_err();
         assert!(
@@ -684,6 +789,82 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_latest_schema_check_tolerates_an_unlistable_location() {
+        use crate::catalog::Identifier;
+        use crate::io::FileIOBuilder;
+        use crate::spec::{DataType, IntType, Schema, TableSchema};
+
+        // The check is the only file access on the authorization path. A table
+        // served entirely over REST — or a mock catalog — may point at a
+        // location with no schema directory, and that must not fail the read.
+        let table = super::Table::new(
+            FileIOBuilder::new("file").build().unwrap(),
+            Identifier::new("default", "t"),
+            "/nonexistent-a1b2c3/does/not/exist".to_string(),
+            TableSchema::new(
+                0,
+                &Schema::builder()
+                    .column("id", DataType::Int(IntType::new()))
+                    .build()
+                    .unwrap(),
+            ),
+            None,
+        );
+        assert!(
+            table
+                .ensure_rules_bind_to_latest_schema(&[], &[], None)
+                .await
+                .is_ok(),
+            "an unlistable location must not fail authorization"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authorize_rewrite_splits_rejects_foreign_splits() {
+        use crate::spec::BinaryRow;
+        use crate::table::DataSplitBuilder;
+
+        let table = super::query_auth_table();
+        let root = table.location().to_string();
+        let split_at = |path: &str| {
+            DataSplitBuilder::new()
+                .with_snapshot(1)
+                .with_partition(BinaryRow::new(0))
+                .with_bucket(0)
+                .with_bucket_path(path.to_string())
+                .with_total_buckets(1)
+                .with_data_files(vec![])
+                .build()
+                .unwrap()
+        };
+
+        // A sibling sharing this location's prefix must not pass.
+        let sibling = format!("{root}2/bucket-0");
+        let err = table
+            .authorize_rewrite_splits(vec![split_at(&sibling)])
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::Error::Unsupported { ref message } if message.contains("does not belong to table")),
+            "prefix-sharing sibling must be rejected, got: {err}"
+        );
+
+        // Its own split passes provenance and fails later, at authorization.
+        let own = format!("{root}/bucket-0");
+        let err = table
+            .authorize_rewrite_splits(vec![split_at(&own)])
+            .await
+            .unwrap_err();
+        assert!(
+            !err.to_string().contains("does not belong to table"),
+            "own split must pass the provenance check, got: {err}"
+        );
+    }
+
+    // `copy_with_branch` lists the schema directory, and opendal's fs lister
+    // panics on Windows when stripping the prefix of a `file:/C:/…` path.
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn test_branch_copy_inherits_query_auth_flag() {
         use crate::catalog::Identifier;
@@ -694,7 +875,15 @@ mod tests {
         // on-disk schema; if `copy_with_branch` dropped it, `t$branch_x` would
         // read the same files unauthorized. Drive the real method.
         let tmp = tempfile::tempdir().unwrap();
-        let location = tmp.path().display().to_string();
+        // `file:` URL with forward slashes; a bare path breaks on Windows.
+        let location = {
+            let p = tmp.path().to_string_lossy().replace('\\', "/");
+            if p.starts_with('/') {
+                format!("file:{p}")
+            } else {
+                format!("file:/{p}")
+            }
+        };
         let file_io = FileIOBuilder::new("file").build().unwrap();
 
         // The on-disk schema deliberately has NO query-auth option.

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -74,6 +74,7 @@ mod pk_vector_position_read;
 mod pk_vector_scan;
 mod postpone_file_writer;
 mod prepared_files;
+pub(crate) mod query_auth;
 mod read_builder;
 pub mod referenced_files;
 pub(crate) mod rest_env;
@@ -142,7 +143,9 @@ pub use write_builder::WriteBuilder;
 use crate::catalog::{validate_branch_name, Identifier, DEFAULT_MAIN_BRANCH};
 use crate::io::FileIO;
 use crate::spec::{CoreOptions, DataField, Snapshot, TableSchema};
-use std::collections::HashMap;
+use query_auth::QueryAuthGrant;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 /// Table represents a table in the catalog.
 #[derive(Debug, Clone)]
@@ -227,6 +230,130 @@ impl Table {
             time_traveled: false,
             travel_snapshot: None,
         })
+    }
+
+    /// Authorize this user against the REST server when `query-auth.enabled` is
+    /// set: fetch and parse the per-user row filter / column masking and return
+    /// it as the grant the read pipeline enforces. `select` are the queried
+    /// columns (table-schema indices; `None` = all) — like Java's
+    /// `readType.getFieldNames()`, so a column-restricted user can still read
+    /// an authorized subset; the grant is scoped to exactly those columns and a
+    /// wider read fails closed until it re-plans. Returns `None` when the table
+    /// is not `query-auth.enabled`. Called from scan planning and search
+    /// execution at the same per-plan frequency as Java's
+    /// `CatalogEnvironment.tableQueryAuth()`, so a revoked grant takes effect on
+    /// the next plan. The grant is threaded to the read on the split it plans
+    /// (never a shared mutable slot), so it is per-query and cannot leak into a
+    /// concurrent query or a write-path rewrite.
+    pub(crate) async fn verify_query_auth_for_read(
+        &self,
+        select: Option<&HashSet<usize>>,
+    ) -> Result<Option<Arc<QueryAuthGrant>>> {
+        if !CoreOptions::new(self.schema.options()).query_auth_enabled() {
+            return Ok(None);
+        }
+        let Some(rest_env) = &self.rest_env else {
+            return Err(crate::Error::Unsupported {
+                message: "reading a table with 'query-auth.enabled' = true requires a REST \
+                          catalog to authorize the query"
+                    .to_string(),
+            });
+        };
+        let fields = self.schema.fields();
+        let select_names = select.map(|indices| {
+            fields
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| indices.contains(i))
+                .map(|(_, f)| f.name().to_string())
+                .collect::<Vec<_>>()
+        });
+        let auth = rest_env.table_query_auth(select_names).await?;
+        let filters = query_auth::parse_auth_filters(&auth.filter.unwrap_or_default(), fields)?;
+        let masks =
+            query_auth::parse_column_masking(&auth.column_masking.unwrap_or_default(), fields)?;
+        let grant =
+            QueryAuthGrant::new(filters, masks, select.cloned()).with_schema_id(self.schema.id());
+
+        // The server expresses its rules against the table's CURRENT schema, but
+        // a time-travelled or branch copy reads a DIFFERENT one. Binding those
+        // rules by name onto it is unsound — a column dropped and re-added under
+        // the same name has a different field id, so a filter or mask would bind
+        // to an unrelated historical column. Fail closed rather than mis-bind.
+        if !grant.is_unrestricted() && (self.time_traveled || self.branch_reference) {
+            return Err(crate::Error::Unsupported {
+                message: "a query-auth row filter / column masking grant cannot be applied to a \
+                          time-travelled or branch read: the grant is bound to the table's \
+                          current schema"
+                    .to_string(),
+            });
+        }
+
+        Ok(Some(Arc::new(grant)))
+    }
+
+    /// Authorize a read that cannot enforce a row filter / masking on its output
+    /// (search, system tables, or a write-path rewrite that must read raw).
+    /// Returns the grant to stamp on the splits it reads (`None` = not a
+    /// query-auth table). Fails closed when the grant is restricted — such a
+    /// path must never run under a partial grant, since it would either leak
+    /// (search/metadata) or silently drop/mask rows into a committed rewrite.
+    pub(crate) async fn authorize_unrestricted_read(&self) -> Result<Option<Arc<QueryAuthGrant>>> {
+        match self.verify_query_auth_for_read(None).await? {
+            Some(grant) if grant.is_unrestricted() => Ok(Some(grant)),
+            Some(_) => {
+                // A restricted grant only arrives on a query-auth.enabled table,
+                // where the strict schema check always fails closed.
+                CoreOptions::new(self.schema.options()).ensure_read_authorized()?;
+                Ok(None)
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Authorize an internal read that rewrites data (copy-on-write DML, index
+    /// builds) and stamp the grant on `splits`.
+    ///
+    /// Such a read must see raw rows — rewriting from a filtered or masked view
+    /// would destroy hidden rows and persist masked values — so it requires a
+    /// fully unrestricted grant and fails closed otherwise. The grant the caller
+    /// would get from scan planning must NOT be used here: under a row filter it
+    /// shifts row offsets, and rewrites replay those offsets.
+    pub async fn authorize_rewrite_splits(&self, splits: Vec<DataSplit>) -> Result<Vec<DataSplit>> {
+        // This is the only public API that stamps a grant, so it must not be
+        // usable to launder splits: refuse ones that already carry a restricted
+        // grant rather than overwriting it.
+        if splits
+            .iter()
+            .any(DataSplit::has_restricted_query_auth_grant)
+        {
+            return Err(crate::Error::Unsupported {
+                message: "cannot re-authorize a split already planned under a query-auth row \
+                          filter / column masking grant"
+                    .to_string(),
+            });
+        }
+        let grant = self.authorize_unrestricted_read().await?;
+        Ok(splits
+            .into_iter()
+            .map(|split| split.with_query_auth_grant(grant.clone()))
+            .collect())
+    }
+
+    /// Authorize a commit. Writes must require a fully unrestricted grant: the
+    /// data being committed may have come from an enforced read (e.g. `INSERT
+    /// OVERWRITE t SELECT * FROM t`), which would destroy rows the grant hid and
+    /// persist masked values as the stored data. Committing cannot tell where
+    /// its rows came from, so it fails closed for any restricted grant.
+    pub(crate) async fn authorize_unrestricted_write(&self) -> Result<()> {
+        self.authorize_unrestricted_read().await.map(|_| ())
+    }
+
+    /// Fail closed when a read reaches `TableRead::to_arrow` without a grant
+    /// stamped on its splits (an unauthorized path) and the table is
+    /// `query-auth.enabled`; a no-op otherwise.
+    pub(crate) fn ensure_read_without_grant(&self) -> Result<()> {
+        CoreOptions::new(self.schema.options()).ensure_read_authorized()
     }
 
     /// Get the table's identifier.
@@ -456,11 +583,22 @@ impl Table {
             })?;
         let mut options = schema.options().clone();
         options.insert("branch".to_string(), branch.clone());
+        // `query-auth.enabled` is delivered by the REST catalog on the table
+        // response, so the branch's on-disk schema need not carry it. Inherit it
+        // from this table: a branch references the same data files, and dropping
+        // the flag here would make `t$branch_x` read them raw, unauthorized.
+        let branch_schema = if CoreOptions::new(self.schema.options()).query_auth_enabled() {
+            schema
+                .copy_with_replaced_options(options)
+                .copy_with_query_auth_enabled()
+        } else {
+            schema.copy_with_replaced_options(options)
+        };
         Ok(Self {
             file_io: self.file_io.clone(),
             identifier: self.identifier.clone(),
             location: self.location.clone(),
-            schema: schema.copy_with_replaced_options(options),
+            schema: branch_schema,
             schema_manager,
             branch,
             branch_reference: true,
@@ -521,4 +659,52 @@ pub(crate) fn query_auth_table() -> Table {
         table_schema,
         None,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn test_authorize_unrestricted_read_fails_closed() {
+        // Every write/build path (cow_writer, data_evolution_writer, btree index
+        // build, cross-partition bucket assign) authorizes through this gate
+        // before its internal read. A query-auth table it cannot authorize as
+        // unrestricted must fail closed rather than read raw and rewrite
+        // filtered/masked data into a committed result.
+        let table = super::query_auth_table();
+        let err = table.authorize_unrestricted_read().await.unwrap_err();
+        assert!(
+            matches!(err, crate::Error::Unsupported { ref message } if message.contains("query-auth.enabled")),
+            "write-path authorization must fail closed, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_branch_copy_inherits_query_auth_flag() {
+        use crate::spec::CoreOptions;
+
+        // `query-auth.enabled` arrives on the REST table response, so a branch's
+        // on-disk schema need not carry it. If the branch copy dropped it,
+        // `t$branch_x` would read the same data files raw and unauthorized.
+        let table = super::query_auth_table();
+        assert!(CoreOptions::new(table.schema().options()).query_auth_enabled());
+
+        // `copy_with_branch` replaces the options wholesale with the branch
+        // schema's; the flag must survive that replacement.
+        let branch_schema =
+            table
+                .schema()
+                .copy_with_replaced_options(std::collections::HashMap::from([(
+                    "branch".to_string(),
+                    "b1".to_string(),
+                )]));
+        assert!(
+            !CoreOptions::new(branch_schema.options()).query_auth_enabled(),
+            "precondition: a replaced-options copy loses the flag on its own"
+        );
+        assert!(
+            CoreOptions::new(branch_schema.copy_with_query_auth_enabled().options())
+                .query_auth_enabled(),
+            "the branch copy must re-assert query-auth.enabled"
+        );
+    }
 }

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -272,8 +272,7 @@ impl Table {
         let filters = query_auth::parse_auth_filters(&auth.filter.unwrap_or_default(), fields)?;
         let masks =
             query_auth::parse_column_masking(&auth.column_masking.unwrap_or_default(), fields)?;
-        let grant =
-            QueryAuthGrant::new(filters, masks, select.cloned()).with_schema_id(self.schema.id());
+        let grant = QueryAuthGrant::new(filters, masks, select.cloned(), self.schema.id());
 
         // The server expresses its rules against the table's CURRENT schema, but
         // a time-travelled or branch copy reads a DIFFERENT one. Binding those
@@ -301,12 +300,12 @@ impl Table {
     pub(crate) async fn authorize_unrestricted_read(&self) -> Result<Option<Arc<QueryAuthGrant>>> {
         match self.verify_query_auth_for_read(None).await? {
             Some(grant) if grant.is_unrestricted() => Ok(Some(grant)),
-            Some(_) => {
-                // A restricted grant only arrives on a query-auth.enabled table,
-                // where the strict schema check always fails closed.
-                CoreOptions::new(self.schema.options()).ensure_read_authorized()?;
-                Ok(None)
-            }
+            Some(_) => Err(crate::Error::Unsupported {
+                message: "this read on a 'query-auth.enabled' table must see raw rows, so it \
+                          cannot apply the server's row filter / column masking and refuses to \
+                          run under a restricted grant"
+                    .to_string(),
+            }),
             None => Ok(None),
         }
     }
@@ -678,33 +677,72 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_branch_copy_inherits_query_auth_flag() {
-        use crate::spec::CoreOptions;
+    #[tokio::test]
+    async fn test_branch_copy_inherits_query_auth_flag() {
+        use crate::catalog::Identifier;
+        use crate::io::FileIOBuilder;
+        use crate::spec::{CoreOptions, DataType, IntType, Schema, TableSchema};
 
-        // `query-auth.enabled` arrives on the REST table response, so a branch's
-        // on-disk schema need not carry it. If the branch copy dropped it,
-        // `t$branch_x` would read the same data files raw and unauthorized.
-        let table = super::query_auth_table();
-        assert!(CoreOptions::new(table.schema().options()).query_auth_enabled());
+        // `query-auth.enabled` arrives on the REST table response, so the
+        // branch's on-disk schema does not carry it. If `copy_with_branch`
+        // dropped it, `t$branch_x` would read the same data files raw and
+        // unauthorized, so drive the real method rather than its inputs.
+        let tmp = tempfile::tempdir().unwrap();
+        let location = tmp.path().display().to_string();
+        let file_io = FileIOBuilder::new("file").build().unwrap();
 
-        // `copy_with_branch` replaces the options wholesale with the branch
-        // schema's; the flag must survive that replacement.
-        let branch_schema =
-            table
-                .schema()
-                .copy_with_replaced_options(std::collections::HashMap::from([(
-                    "branch".to_string(),
-                    "b1".to_string(),
-                )]));
-        assert!(
-            !CoreOptions::new(branch_schema.options()).query_auth_enabled(),
-            "precondition: a replaced-options copy loses the flag on its own"
+        // The on-disk schema deliberately has NO query-auth option.
+        let on_disk = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .build()
+                .unwrap(),
         );
+        let sm = super::SchemaManager::new(file_io.clone(), location.clone());
+        file_io
+            .new_output(&sm.schema_path(0))
+            .unwrap()
+            .write(serde_json::to_vec(&on_disk).unwrap().into())
+            .await
+            .unwrap();
+
+        let build = |schema: TableSchema| {
+            super::Table::new(
+                file_io.clone(),
+                Identifier::new("default", "auth_t"),
+                location.clone(),
+                schema,
+                None,
+            )
+        };
+
+        let plain = build(on_disk.clone());
         assert!(
-            CoreOptions::new(branch_schema.copy_with_query_auth_enabled().options())
-                .query_auth_enabled(),
-            "the branch copy must re-assert query-auth.enabled"
+            !CoreOptions::new(
+                plain
+                    .copy_with_branch(super::DEFAULT_MAIN_BRANCH)
+                    .await
+                    .unwrap()
+                    .schema()
+                    .options()
+            )
+            .query_auth_enabled(),
+            "a branch of a non-query-auth table must not gain the flag"
+        );
+
+        let guarded = build(on_disk.copy_with_query_auth_enabled());
+        assert!(
+            CoreOptions::new(
+                guarded
+                    .copy_with_branch(super::DEFAULT_MAIN_BRANCH)
+                    .await
+                    .unwrap()
+                    .schema()
+                    .options()
+            )
+            .query_auth_enabled(),
+            "the branch copy must inherit query-auth.enabled from the REST table"
         );
     }
 }

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -83,6 +83,7 @@ mod postpone_fixed_bucket_router;
 mod postpone_fixed_bucket_write;
 mod postpone_fixed_bucket_write_builder;
 mod prepared_files;
+pub(crate) mod query_auth;
 mod read_builder;
 pub mod referenced_files;
 pub(crate) mod rest_env;
@@ -169,7 +170,9 @@ use crate::spec::{
     CoreOptions, DataField, Snapshot, TableSchema, SCAN_SNAPSHOT_ID_OPTION, SCAN_TAG_NAME_OPTION,
     SCAN_TIMESTAMP_MILLIS_OPTION, SCAN_VERSION_OPTION, SCAN_WATERMARK_OPTION,
 };
-use std::collections::HashMap;
+use query_auth::QueryAuthGrant;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 /// Table represents a table in the catalog.
 #[derive(Debug, Clone)]
@@ -254,6 +257,130 @@ impl Table {
             time_traveled: false,
             travel_snapshot: None,
         })
+    }
+
+    /// Authorize this user against the REST server when `query-auth.enabled` is
+    /// set: fetch and parse the per-user row filter / column masking and return
+    /// it as the grant the read pipeline enforces. `select` are the queried
+    /// columns (table-schema indices; `None` = all) — like Java's
+    /// `readType.getFieldNames()`, so a column-restricted user can still read
+    /// an authorized subset; the grant is scoped to exactly those columns and a
+    /// wider read fails closed until it re-plans. Returns `None` when the table
+    /// is not `query-auth.enabled`. Called from scan planning and search
+    /// execution at the same per-plan frequency as Java's
+    /// `CatalogEnvironment.tableQueryAuth()`, so a revoked grant takes effect on
+    /// the next plan. The grant is threaded to the read on the split it plans
+    /// (never a shared mutable slot), so it is per-query and cannot leak into a
+    /// concurrent query or a write-path rewrite.
+    pub(crate) async fn verify_query_auth_for_read(
+        &self,
+        select: Option<&HashSet<usize>>,
+    ) -> Result<Option<Arc<QueryAuthGrant>>> {
+        if !CoreOptions::new(self.schema.options()).query_auth_enabled() {
+            return Ok(None);
+        }
+        let Some(rest_env) = &self.rest_env else {
+            return Err(crate::Error::Unsupported {
+                message: "reading a table with 'query-auth.enabled' = true requires a REST \
+                          catalog to authorize the query"
+                    .to_string(),
+            });
+        };
+        let fields = self.schema.fields();
+        let select_names = select.map(|indices| {
+            fields
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| indices.contains(i))
+                .map(|(_, f)| f.name().to_string())
+                .collect::<Vec<_>>()
+        });
+        let auth = rest_env.table_query_auth(select_names).await?;
+        let filters = query_auth::parse_auth_filters(&auth.filter.unwrap_or_default(), fields)?;
+        let masks =
+            query_auth::parse_column_masking(&auth.column_masking.unwrap_or_default(), fields)?;
+        let grant =
+            QueryAuthGrant::new(filters, masks, select.cloned()).with_schema_id(self.schema.id());
+
+        // The server expresses its rules against the table's CURRENT schema, but
+        // a time-travelled or branch copy reads a DIFFERENT one. Binding those
+        // rules by name onto it is unsound — a column dropped and re-added under
+        // the same name has a different field id, so a filter or mask would bind
+        // to an unrelated historical column. Fail closed rather than mis-bind.
+        if !grant.is_unrestricted() && (self.time_traveled || self.branch_reference) {
+            return Err(crate::Error::Unsupported {
+                message: "a query-auth row filter / column masking grant cannot be applied to a \
+                          time-travelled or branch read: the grant is bound to the table's \
+                          current schema"
+                    .to_string(),
+            });
+        }
+
+        Ok(Some(Arc::new(grant)))
+    }
+
+    /// Authorize a read that cannot enforce a row filter / masking on its output
+    /// (search, system tables, or a write-path rewrite that must read raw).
+    /// Returns the grant to stamp on the splits it reads (`None` = not a
+    /// query-auth table). Fails closed when the grant is restricted — such a
+    /// path must never run under a partial grant, since it would either leak
+    /// (search/metadata) or silently drop/mask rows into a committed rewrite.
+    pub(crate) async fn authorize_unrestricted_read(&self) -> Result<Option<Arc<QueryAuthGrant>>> {
+        match self.verify_query_auth_for_read(None).await? {
+            Some(grant) if grant.is_unrestricted() => Ok(Some(grant)),
+            Some(_) => {
+                // A restricted grant only arrives on a query-auth.enabled table,
+                // where the strict schema check always fails closed.
+                CoreOptions::new(self.schema.options()).ensure_read_authorized()?;
+                Ok(None)
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Authorize an internal read that rewrites data (copy-on-write DML, index
+    /// builds) and stamp the grant on `splits`.
+    ///
+    /// Such a read must see raw rows — rewriting from a filtered or masked view
+    /// would destroy hidden rows and persist masked values — so it requires a
+    /// fully unrestricted grant and fails closed otherwise. The grant the caller
+    /// would get from scan planning must NOT be used here: under a row filter it
+    /// shifts row offsets, and rewrites replay those offsets.
+    pub async fn authorize_rewrite_splits(&self, splits: Vec<DataSplit>) -> Result<Vec<DataSplit>> {
+        // This is the only public API that stamps a grant, so it must not be
+        // usable to launder splits: refuse ones that already carry a restricted
+        // grant rather than overwriting it.
+        if splits
+            .iter()
+            .any(DataSplit::has_restricted_query_auth_grant)
+        {
+            return Err(crate::Error::Unsupported {
+                message: "cannot re-authorize a split already planned under a query-auth row \
+                          filter / column masking grant"
+                    .to_string(),
+            });
+        }
+        let grant = self.authorize_unrestricted_read().await?;
+        Ok(splits
+            .into_iter()
+            .map(|split| split.with_query_auth_grant(grant.clone()))
+            .collect())
+    }
+
+    /// Authorize a commit. Writes must require a fully unrestricted grant: the
+    /// data being committed may have come from an enforced read (e.g. `INSERT
+    /// OVERWRITE t SELECT * FROM t`), which would destroy rows the grant hid and
+    /// persist masked values as the stored data. Committing cannot tell where
+    /// its rows came from, so it fails closed for any restricted grant.
+    pub(crate) async fn authorize_unrestricted_write(&self) -> Result<()> {
+        self.authorize_unrestricted_read().await.map(|_| ())
+    }
+
+    /// Fail closed when a read reaches `TableRead::to_arrow` without a grant
+    /// stamped on its splits (an unauthorized path) and the table is
+    /// `query-auth.enabled`; a no-op otherwise.
+    pub(crate) fn ensure_read_without_grant(&self) -> Result<()> {
+        CoreOptions::new(self.schema.options()).ensure_read_authorized()
     }
 
     /// Get the table's identifier.
@@ -578,11 +705,22 @@ impl Table {
             })?;
         let mut options = schema.options().clone();
         options.insert("branch".to_string(), branch.clone());
+        // `query-auth.enabled` is delivered by the REST catalog on the table
+        // response, so the branch's on-disk schema need not carry it. Inherit it
+        // from this table: a branch references the same data files, and dropping
+        // the flag here would make `t$branch_x` read them raw, unauthorized.
+        let branch_schema = if CoreOptions::new(self.schema.options()).query_auth_enabled() {
+            schema
+                .copy_with_replaced_options(options)
+                .copy_with_query_auth_enabled()
+        } else {
+            schema.copy_with_replaced_options(options)
+        };
         Ok(Self {
             file_io: self.file_io.clone(),
             identifier: self.identifier.clone(),
             location: self.location.clone(),
-            schema: schema.copy_with_replaced_options(options),
+            schema: branch_schema,
             schema_manager,
             branch,
             branch_reference: true,
@@ -698,6 +836,51 @@ mod tests {
         assert_eq!(
             copied.schema().options().get("scan.snapshot-id"),
             Some(&"3".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authorize_unrestricted_read_fails_closed() {
+        // Every write/build path (cow_writer, data_evolution_writer, btree index
+        // build, cross-partition bucket assign) authorizes through this gate
+        // before its internal read. A query-auth table it cannot authorize as
+        // unrestricted must fail closed rather than read raw and rewrite
+        // filtered/masked data into a committed result.
+        let table = super::query_auth_table();
+        let err = table.authorize_unrestricted_read().await.unwrap_err();
+        assert!(
+            matches!(err, crate::Error::Unsupported { ref message } if message.contains("query-auth.enabled")),
+            "write-path authorization must fail closed, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_branch_copy_inherits_query_auth_flag() {
+        use crate::spec::CoreOptions;
+
+        // `query-auth.enabled` arrives on the REST table response, so a branch's
+        // on-disk schema need not carry it. If the branch copy dropped it,
+        // `t$branch_x` would read the same data files raw and unauthorized.
+        let table = super::query_auth_table();
+        assert!(CoreOptions::new(table.schema().options()).query_auth_enabled());
+
+        // `copy_with_branch` replaces the options wholesale with the branch
+        // schema's; the flag must survive that replacement.
+        let branch_schema =
+            table
+                .schema()
+                .copy_with_replaced_options(std::collections::HashMap::from([(
+                    "branch".to_string(),
+                    "b1".to_string(),
+                )]));
+        assert!(
+            !CoreOptions::new(branch_schema.options()).query_auth_enabled(),
+            "precondition: a replaced-options copy loses the flag on its own"
+        );
+        assert!(
+            CoreOptions::new(branch_schema.copy_with_query_auth_enabled().options())
+                .query_auth_enabled(),
+            "the branch copy must re-assert query-auth.enabled"
         );
     }
 }

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -299,8 +299,7 @@ impl Table {
         let filters = query_auth::parse_auth_filters(&auth.filter.unwrap_or_default(), fields)?;
         let masks =
             query_auth::parse_column_masking(&auth.column_masking.unwrap_or_default(), fields)?;
-        let grant =
-            QueryAuthGrant::new(filters, masks, select.cloned()).with_schema_id(self.schema.id());
+        let grant = QueryAuthGrant::new(filters, masks, select.cloned(), self.schema.id());
 
         // The server expresses its rules against the table's CURRENT schema, but
         // a time-travelled or branch copy reads a DIFFERENT one. Binding those
@@ -328,12 +327,12 @@ impl Table {
     pub(crate) async fn authorize_unrestricted_read(&self) -> Result<Option<Arc<QueryAuthGrant>>> {
         match self.verify_query_auth_for_read(None).await? {
             Some(grant) if grant.is_unrestricted() => Ok(Some(grant)),
-            Some(_) => {
-                // A restricted grant only arrives on a query-auth.enabled table,
-                // where the strict schema check always fails closed.
-                CoreOptions::new(self.schema.options()).ensure_read_authorized()?;
-                Ok(None)
-            }
+            Some(_) => Err(crate::Error::Unsupported {
+                message: "this read on a 'query-auth.enabled' table must see raw rows, so it \
+                          cannot apply the server's row filter / column masking and refuses to \
+                          run under a restricted grant"
+                    .to_string(),
+            }),
             None => Ok(None),
         }
     }
@@ -854,33 +853,72 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_branch_copy_inherits_query_auth_flag() {
-        use crate::spec::CoreOptions;
+    #[tokio::test]
+    async fn test_branch_copy_inherits_query_auth_flag() {
+        use crate::catalog::Identifier;
+        use crate::io::FileIOBuilder;
+        use crate::spec::{CoreOptions, DataType, IntType, Schema, TableSchema};
 
-        // `query-auth.enabled` arrives on the REST table response, so a branch's
-        // on-disk schema need not carry it. If the branch copy dropped it,
-        // `t$branch_x` would read the same data files raw and unauthorized.
-        let table = super::query_auth_table();
-        assert!(CoreOptions::new(table.schema().options()).query_auth_enabled());
+        // `query-auth.enabled` arrives on the REST table response, so the
+        // branch's on-disk schema does not carry it. If `copy_with_branch`
+        // dropped it, `t$branch_x` would read the same data files raw and
+        // unauthorized, so drive the real method rather than its inputs.
+        let tmp = tempfile::tempdir().unwrap();
+        let location = tmp.path().display().to_string();
+        let file_io = FileIOBuilder::new("file").build().unwrap();
 
-        // `copy_with_branch` replaces the options wholesale with the branch
-        // schema's; the flag must survive that replacement.
-        let branch_schema =
-            table
-                .schema()
-                .copy_with_replaced_options(std::collections::HashMap::from([(
-                    "branch".to_string(),
-                    "b1".to_string(),
-                )]));
-        assert!(
-            !CoreOptions::new(branch_schema.options()).query_auth_enabled(),
-            "precondition: a replaced-options copy loses the flag on its own"
+        // The on-disk schema deliberately has NO query-auth option.
+        let on_disk = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .build()
+                .unwrap(),
         );
+        let sm = super::SchemaManager::new(file_io.clone(), location.clone());
+        file_io
+            .new_output(&sm.schema_path(0))
+            .unwrap()
+            .write(serde_json::to_vec(&on_disk).unwrap().into())
+            .await
+            .unwrap();
+
+        let build = |schema: TableSchema| {
+            super::Table::new(
+                file_io.clone(),
+                Identifier::new("default", "auth_t"),
+                location.clone(),
+                schema,
+                None,
+            )
+        };
+
+        let plain = build(on_disk.clone());
         assert!(
-            CoreOptions::new(branch_schema.copy_with_query_auth_enabled().options())
-                .query_auth_enabled(),
-            "the branch copy must re-assert query-auth.enabled"
+            !CoreOptions::new(
+                plain
+                    .copy_with_branch(super::DEFAULT_MAIN_BRANCH)
+                    .await
+                    .unwrap()
+                    .schema()
+                    .options()
+            )
+            .query_auth_enabled(),
+            "a branch of a non-query-auth table must not gain the flag"
+        );
+
+        let guarded = build(on_disk.copy_with_query_auth_enabled());
+        assert!(
+            CoreOptions::new(
+                guarded
+                    .copy_with_branch(super::DEFAULT_MAIN_BRANCH)
+                    .await
+                    .unwrap()
+                    .schema()
+                    .options()
+            )
+            .query_auth_enabled(),
+            "the branch copy must inherit query-auth.enabled from the REST table"
         );
     }
 }

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -275,6 +275,7 @@ impl Table {
     pub(crate) async fn verify_query_auth_for_read(
         &self,
         select: Option<&HashSet<usize>>,
+        system_select: &[String],
     ) -> Result<Option<Arc<QueryAuthGrant>>> {
         if !CoreOptions::new(self.schema.options()).query_auth_enabled() {
             return Ok(None);
@@ -287,19 +288,28 @@ impl Table {
             });
         };
         let fields = self.schema.fields();
+        // Java's `select` is `readType.getFieldNames()`, so projected system
+        // fields go too. They have no index to scope, but the server may still
+        // refuse them.
         let select_names = select.map(|indices| {
             fields
                 .iter()
                 .enumerate()
                 .filter(|(i, _)| indices.contains(i))
                 .map(|(_, f)| f.name().to_string())
+                .chain(system_select.iter().cloned())
                 .collect::<Vec<_>>()
         });
         let auth = rest_env.table_query_auth(select_names).await?;
         let filters = query_auth::parse_auth_filters(&auth.filter.unwrap_or_default(), fields)?;
         let masks =
             query_auth::parse_column_masking(&auth.column_masking.unwrap_or_default(), fields)?;
-        let grant = QueryAuthGrant::new(filters, masks, select.cloned(), self.schema.id());
+        let grant = QueryAuthGrant::new(
+            filters,
+            masks,
+            select.cloned(),
+            query_auth::GrantBinding::of(self),
+        );
 
         // The server expresses its rules against the table's CURRENT schema, but
         // a time-travelled or branch copy reads a DIFFERENT one. Binding those
@@ -325,7 +335,7 @@ impl Table {
     /// path must never run under a partial grant, since it would either leak
     /// (search/metadata) or silently drop/mask rows into a committed rewrite.
     pub(crate) async fn authorize_unrestricted_read(&self) -> Result<Option<Arc<QueryAuthGrant>>> {
-        match self.verify_query_auth_for_read(None).await? {
+        match self.verify_query_auth_for_read(None, &[]).await? {
             Some(grant) if grant.is_unrestricted() => Ok(Some(grant)),
             Some(_) => Err(crate::Error::Unsupported {
                 message: "this read on a 'query-auth.enabled' table must see raw rows, so it \
@@ -349,10 +359,7 @@ impl Table {
         // This is the only public API that stamps a grant, so it must not be
         // usable to launder splits: refuse ones that already carry a restricted
         // grant rather than overwriting it.
-        if splits
-            .iter()
-            .any(DataSplit::has_restricted_query_auth_grant)
-        {
+        if splits.iter().any(DataSplit::carries_query_auth_restriction) {
             return Err(crate::Error::Unsupported {
                 message: "cannot re-authorize a split already planned under a query-auth row \
                           filter / column masking grant"
@@ -859,10 +866,9 @@ mod tests {
         use crate::io::FileIOBuilder;
         use crate::spec::{CoreOptions, DataType, IntType, Schema, TableSchema};
 
-        // `query-auth.enabled` arrives on the REST table response, so the
-        // branch's on-disk schema does not carry it. If `copy_with_branch`
-        // dropped it, `t$branch_x` would read the same data files raw and
-        // unauthorized, so drive the real method rather than its inputs.
+        // The flag arrives on the REST table response, not the branch's
+        // on-disk schema; if `copy_with_branch` dropped it, `t$branch_x` would
+        // read the same files unauthorized. Drive the real method.
         let tmp = tempfile::tempdir().unwrap();
         let location = tmp.path().display().to_string();
         let file_io = FileIOBuilder::new("file").build().unwrap();

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -259,23 +259,18 @@ impl Table {
         })
     }
 
-    /// Authorize this user against the REST server when `query-auth.enabled` is
-    /// set: fetch and parse the per-user row filter / column masking and return
-    /// it as the grant the read pipeline enforces. `select` are the queried
-    /// columns (table-schema indices; `None` = all) — like Java's
-    /// `readType.getFieldNames()`, so a column-restricted user can still read
-    /// an authorized subset; the grant is scoped to exactly those columns and a
-    /// wider read fails closed until it re-plans. Returns `None` when the table
-    /// is not `query-auth.enabled`. Called from scan planning and search
-    /// execution at the same per-plan frequency as Java's
-    /// `CatalogEnvironment.tableQueryAuth()`, so a revoked grant takes effect on
-    /// the next plan. The grant is threaded to the read on the split it plans
-    /// (never a shared mutable slot), so it is per-query and cannot leak into a
-    /// concurrent query or a write-path rewrite.
+    /// Fetch the per-user row filter / column masking as the grant the read
+    /// pipeline enforces; `None` when the table is not `query-auth.enabled`.
+    ///
+    /// `select` are the queried columns (table-schema indices, `None` = all), so
+    /// a column-restricted user can read an authorized subset and a wider read
+    /// fails closed. Called per plan, like Java, so a revoked grant takes effect
+    /// on the next one. `system_select` is `None` only for internal raw reads,
+    /// which run under a fully unrestricted grant.
     pub(crate) async fn verify_query_auth_for_read(
         &self,
         select: Option<&HashSet<usize>>,
-        system_select: &[String],
+        system_select: Option<&[String]>,
     ) -> Result<Option<Arc<QueryAuthGrant>>> {
         if !CoreOptions::new(self.schema.options()).query_auth_enabled() {
             return Ok(None);
@@ -288,35 +283,62 @@ impl Table {
             });
         };
         let fields = self.schema.fields();
-        // Java's `select` is `readType.getFieldNames()`, so projected system
-        // fields go too. They have no index to scope, but the server may still
-        // refuse them.
-        let select_names = select.map(|indices| {
-            fields
-                .iter()
-                .enumerate()
-                .filter(|(i, _)| indices.contains(i))
-                .map(|(_, f)| f.name().to_string())
-                .chain(system_select.iter().cloned())
-                .collect::<Vec<_>>()
-        });
+        // Java sends `readType.getFieldNames()`, system fields included: they
+        // have no index to scope, and the server can only refuse one it was
+        // actually sent.
+        let wanted_system: &[String] = system_select.unwrap_or(&[]);
+        let select_names = match select {
+            Some(indices) => Some(
+                fields
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| indices.contains(i))
+                    .map(|(_, f)| f.name().to_string())
+                    .chain(wanted_system.iter().cloned())
+                    .collect::<Vec<_>>(),
+            ),
+            None if wanted_system.is_empty() => None,
+            None => Some(
+                fields
+                    .iter()
+                    .map(|f| f.name().to_string())
+                    .chain(wanted_system.iter().cloned())
+                    .collect::<Vec<_>>(),
+            ),
+        };
+        // Address the branch, not the base table: it can carry stricter rules,
+        // and Java spells it into the identifier the same way.
+        let rest_env = rest_env.for_branch(&self.branch)?;
+        // The response names no table, so bracket the exchange: a drop and
+        // re-create in between would otherwise let a replacement's grant
+        // authorize this handle's files.
+        rest_env.ensure_uuid_is_current().await?;
         let auth = rest_env.table_query_auth(select_names).await?;
+        rest_env.ensure_uuid_is_current().await?;
         let filters = query_auth::parse_auth_filters(&auth.filter.unwrap_or_default(), fields)?;
         let masks =
             query_auth::parse_column_masking(&auth.column_masking.unwrap_or_default(), fields)?;
+
+        // Rules are expressed against the LATEST schema while this `Table` may
+        // predate an evolution: a re-added column keeps its name and gets a fresh
+        // id. Java re-validates on every plan. Always, not only when rules exist:
+        // `select` names columns of THIS copy, so one dropped since would be
+        // authorized against a schema that no longer has it.
+        self.ensure_rules_bind_to_latest_schema(&filters, &masks, select)
+            .await?;
         let grant = QueryAuthGrant::new(
             filters,
             masks,
             select.cloned(),
+            system_select.map(|names| names.iter().cloned().collect()),
             query_auth::GrantBinding::of(self),
         );
 
-        // The server expresses its rules against the table's CURRENT schema, but
-        // a time-travelled or branch copy reads a DIFFERENT one. Binding those
-        // rules by name onto it is unsound — a column dropped and re-added under
-        // the same name has a different field id, so a filter or mask would bind
-        // to an unrelated historical column. Fail closed rather than mis-bind.
-        if !grant.is_unrestricted() && (self.time_traveled || self.branch_reference) {
+        // Rules are expressed against the CURRENT schema; a time-travelled or
+        // branch copy reads a different one, where the same name may be an
+        // unrelated field id. Keyed on server rules, not `is_unrestricted()`:
+        // the client's own projection scope binds nothing to the schema.
+        if grant.has_server_restrictions() && (self.time_traveled || self.branch_reference) {
             return Err(crate::Error::Unsupported {
                 message: "a query-auth row filter / column masking grant cannot be applied to a \
                           time-travelled or branch read: the grant is bound to the table's \
@@ -328,14 +350,81 @@ impl Table {
         Ok(Some(Arc::new(grant)))
     }
 
-    /// Authorize a read that cannot enforce a row filter / masking on its output
-    /// (search, system tables, or a write-path rewrite that must read raw).
-    /// Returns the grant to stamp on the splits it reads (`None` = not a
-    /// query-auth table). Fails closed when the grant is restricted — such a
-    /// path must never run under a partial grant, since it would either leak
-    /// (search/metadata) or silently drop/mask rows into a committed rewrite.
+    /// Fail closed when a rule column binds to a different field in the latest
+    /// schema than in this copy — a rename or drop-and-re-add would apply the
+    /// rule to unrelated data. Mirrors Java `validateReadableWithoutRename`.
+    async fn ensure_rules_bind_to_latest_schema(
+        &self,
+        filters: &[crate::spec::Predicate],
+        masks: &[query_auth::ColumnMask],
+        select: Option<&HashSet<usize>>,
+    ) -> Result<()> {
+        // Compare ids before loading: the listing is the freshness check, but the
+        // schema need not be read when this copy is already current. A missing
+        // directory yields an empty list, not an error, and has no drift anyway.
+        //
+        // A listing that FAILS means freshness cannot be established. Tolerate
+        // that only for a grant with no server rules; with a filter or mask in
+        // play it would silently bind them to a stale schema.
+        let ids = match self.schema_manager.list_all_ids().await {
+            Ok(ids) => ids,
+            Err(_) if filters.is_empty() && masks.is_empty() => return Ok(()),
+            Err(e) => return Err(e),
+        };
+        let Some(&latest_id) = ids.last() else {
+            return Ok(());
+        };
+        if latest_id == self.schema.id() {
+            return Ok(());
+        }
+        let latest = self.schema_manager.schema(latest_id).await?;
+        let mut referenced = HashSet::new();
+        for filter in filters {
+            filter.collect_leaf_field_indices(&mut referenced);
+        }
+        for mask in masks {
+            referenced.insert(mask.column);
+            mask.transform.collect_field_indices(&mut referenced);
+        }
+        let fields = self.schema.fields();
+        match select {
+            Some(select) => referenced.extend(select.iter().copied()),
+            // `None` = every column of this copy, which is exactly what a full
+            // read decodes.
+            None => referenced.extend(0..fields.len()),
+        }
+        for index in referenced {
+            let Some(field) = fields.get(index) else {
+                continue;
+            };
+            // Type too: a narrowing evolution (DOUBLE -> FLOAT) is allowed, and
+            // the auth JSON is evaluated against THIS copy's type, so `x > 0.1`
+            // on a stale DOUBLE would admit values FLOAT rejects.
+            let matched = latest
+                .fields()
+                .iter()
+                .find(|f| f.name() == field.name())
+                .is_some_and(|f| f.id() == field.id() && f.data_type() == field.data_type());
+            if !matched {
+                return Err(crate::Error::Unsupported {
+                    message: format!(
+                        "query-auth read references column `{}`, which the table's latest \
+                         schema exposes as a different column (renamed, or dropped and \
+                         re-added); refusing to read rather than apply it to unrelated data",
+                        field.name()
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Authorize a read that cannot enforce filtering / masking on its output
+    /// (search, system tables, write-path rewrites). Returns the grant to stamp
+    /// on its splits; fails closed on a restricted one, which would either leak
+    /// (search/metadata) or commit a filtered view (rewrites).
     pub(crate) async fn authorize_unrestricted_read(&self) -> Result<Option<Arc<QueryAuthGrant>>> {
-        match self.verify_query_auth_for_read(None, &[]).await? {
+        match self.verify_query_auth_for_read(None, None).await? {
             Some(grant) if grant.is_unrestricted() => Ok(Some(grant)),
             Some(_) => Err(crate::Error::Unsupported {
                 message: "this read on a 'query-auth.enabled' table must see raw rows, so it \
@@ -350,11 +439,9 @@ impl Table {
     /// Authorize an internal read that rewrites data (copy-on-write DML, index
     /// builds) and stamp the grant on `splits`.
     ///
-    /// Such a read must see raw rows — rewriting from a filtered or masked view
-    /// would destroy hidden rows and persist masked values — so it requires a
-    /// fully unrestricted grant and fails closed otherwise. The grant the caller
-    /// would get from scan planning must NOT be used here: under a row filter it
-    /// shifts row offsets, and rewrites replay those offsets.
+    /// Rewriting from a filtered or masked view would destroy hidden rows and
+    /// persist masked values, so this needs a fully unrestricted grant — and not
+    /// planning's, whose row filter shifts the offsets rewrites replay.
     pub async fn authorize_rewrite_splits(&self, splits: Vec<DataSplit>) -> Result<Vec<DataSplit>> {
         // This is the only public API that stamps a grant, so it must not be
         // usable to launder splits: refuse ones that already carry a restricted
@@ -366,6 +453,25 @@ impl Table {
                     .to_string(),
             });
         }
+        // Catch another table's splits being handed to a permissive one.
+        // Bucket paths only: `external_path` legitimately points anywhere. A
+        // sanity guard, not a boundary against in-process code.
+        let root = self.location().trim_end_matches('/');
+        if let Some(split) = splits.iter().find(|s| {
+            // On a component boundary: `.../t` must reject `.../t2`.
+            s.bucket_path()
+                .trim_end_matches('/')
+                .strip_prefix(root)
+                .is_none_or(|rest| !rest.is_empty() && !rest.starts_with('/'))
+        }) {
+            return Err(crate::Error::Unsupported {
+                message: format!(
+                    "cannot authorize a split at `{}`: it does not belong to table `{}`",
+                    split.bucket_path(),
+                    self.identifier().full_name()
+                ),
+            });
+        }
         let grant = self.authorize_unrestricted_read().await?;
         Ok(splits
             .into_iter()
@@ -373,11 +479,10 @@ impl Table {
             .collect())
     }
 
-    /// Authorize a commit. Writes must require a fully unrestricted grant: the
-    /// data being committed may have come from an enforced read (e.g. `INSERT
-    /// OVERWRITE t SELECT * FROM t`), which would destroy rows the grant hid and
-    /// persist masked values as the stored data. Committing cannot tell where
-    /// its rows came from, so it fails closed for any restricted grant.
+    /// Authorize a commit. The data may have come from an enforced read (e.g.
+    /// `INSERT OVERWRITE t SELECT * FROM t`), which would destroy hidden rows
+    /// and persist masked values; committing cannot tell, so it fails closed
+    /// for any restricted grant.
     pub(crate) async fn authorize_unrestricted_write(&self) -> Result<()> {
         self.authorize_unrestricted_read().await.map(|_| ())
     }
@@ -711,10 +816,9 @@ impl Table {
             })?;
         let mut options = schema.options().clone();
         options.insert("branch".to_string(), branch.clone());
-        // `query-auth.enabled` is delivered by the REST catalog on the table
-        // response, so the branch's on-disk schema need not carry it. Inherit it
-        // from this table: a branch references the same data files, and dropping
-        // the flag here would make `t$branch_x` read them raw, unauthorized.
+        // The flag comes from the REST table response, not the branch's on-disk
+        // schema. A branch references the same files, so dropping it would make
+        // `t$branch_x` read them unauthorized.
         let branch_schema = if CoreOptions::new(self.schema.options()).query_auth_enabled() {
             schema
                 .copy_with_replaced_options(options)
@@ -847,11 +951,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_authorize_unrestricted_read_fails_closed() {
-        // Every write/build path (cow_writer, data_evolution_writer, btree index
-        // build, cross-partition bucket assign) authorizes through this gate
-        // before its internal read. A query-auth table it cannot authorize as
-        // unrestricted must fail closed rather than read raw and rewrite
-        // filtered/masked data into a committed result.
+        // Every write/build path authorizes through this gate before its
+        // internal read, so a table it cannot authorize as unrestricted must
+        // fail closed rather than commit a filtered/masked view.
         let table = super::query_auth_table();
         let err = table.authorize_unrestricted_read().await.unwrap_err();
         assert!(
@@ -860,6 +962,82 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_latest_schema_check_tolerates_an_unlistable_location() {
+        use crate::catalog::Identifier;
+        use crate::io::FileIOBuilder;
+        use crate::spec::{DataType, IntType, Schema, TableSchema};
+
+        // The check is the only file access on the authorization path. A table
+        // served entirely over REST — or a mock catalog — may point at a
+        // location with no schema directory, and that must not fail the read.
+        let table = super::Table::new(
+            FileIOBuilder::new("file").build().unwrap(),
+            Identifier::new("default", "t"),
+            "/nonexistent-a1b2c3/does/not/exist".to_string(),
+            TableSchema::new(
+                0,
+                &Schema::builder()
+                    .column("id", DataType::Int(IntType::new()))
+                    .build()
+                    .unwrap(),
+            ),
+            None,
+        );
+        assert!(
+            table
+                .ensure_rules_bind_to_latest_schema(&[], &[], None)
+                .await
+                .is_ok(),
+            "an unlistable location must not fail authorization"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authorize_rewrite_splits_rejects_foreign_splits() {
+        use crate::spec::BinaryRow;
+        use crate::table::DataSplitBuilder;
+
+        let table = super::query_auth_table();
+        let root = table.location().to_string();
+        let split_at = |path: &str| {
+            DataSplitBuilder::new()
+                .with_snapshot(1)
+                .with_partition(BinaryRow::new(0))
+                .with_bucket(0)
+                .with_bucket_path(path.to_string())
+                .with_total_buckets(1)
+                .with_data_files(vec![])
+                .build()
+                .unwrap()
+        };
+
+        // A sibling sharing this location's prefix must not pass.
+        let sibling = format!("{root}2/bucket-0");
+        let err = table
+            .authorize_rewrite_splits(vec![split_at(&sibling)])
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::Error::Unsupported { ref message } if message.contains("does not belong to table")),
+            "prefix-sharing sibling must be rejected, got: {err}"
+        );
+
+        // Its own split passes provenance and fails later, at authorization.
+        let own = format!("{root}/bucket-0");
+        let err = table
+            .authorize_rewrite_splits(vec![split_at(&own)])
+            .await
+            .unwrap_err();
+        assert!(
+            !err.to_string().contains("does not belong to table"),
+            "own split must pass the provenance check, got: {err}"
+        );
+    }
+
+    // `copy_with_branch` lists the schema directory, and opendal's fs lister
+    // panics on Windows when stripping the prefix of a `file:/C:/…` path.
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn test_branch_copy_inherits_query_auth_flag() {
         use crate::catalog::Identifier;
@@ -870,7 +1048,15 @@ mod tests {
         // on-disk schema; if `copy_with_branch` dropped it, `t$branch_x` would
         // read the same files unauthorized. Drive the real method.
         let tmp = tempfile::tempdir().unwrap();
-        let location = tmp.path().display().to_string();
+        // `file:` URL with forward slashes; a bare path breaks on Windows.
+        let location = {
+            let p = tmp.path().to_string_lossy().replace('\\', "/");
+            if p.starts_with('/') {
+                format!("file:{p}")
+            } else {
+                format!("file:/{p}")
+            }
+        };
         let file_io = FileIOBuilder::new("file").build().unwrap();
 
         // The on-disk schema deliberately has NO query-auth option.

--- a/crates/paimon/src/table/partition_stat.rs
+++ b/crates/paimon/src/table/partition_stat.rs
@@ -64,6 +64,11 @@ impl Table {
     ///
     /// Returns an empty Vec when the table has no snapshots yet.
     pub async fn partition_stats(&self) -> crate::Result<Vec<PartitionStat>> {
+        // Per-partition record counts and partition-key values are derived from
+        // the raw manifests, so a row filter would not apply: they disclose the
+        // size and key space of data the grant hides. Require an unrestricted
+        // grant (this also covers `list_partitions`, which delegates here).
+        self.authorize_unrestricted_read().await?;
         let sm = SnapshotManager::new(self.file_io().clone(), self.location().to_string());
         let snapshot = match sm.get_latest_snapshot().await? {
             Some(s) => s,

--- a/crates/paimon/src/table/partition_stat.rs
+++ b/crates/paimon/src/table/partition_stat.rs
@@ -64,10 +64,8 @@ impl Table {
     ///
     /// Returns an empty Vec when the table has no snapshots yet.
     pub async fn partition_stats(&self) -> crate::Result<Vec<PartitionStat>> {
-        // Per-partition record counts and partition-key values are derived from
-        // the raw manifests, so a row filter would not apply: they disclose the
-        // size and key space of data the grant hides. Require an unrestricted
-        // grant (this also covers `list_partitions`, which delegates here).
+        // Record counts and key values come from raw manifests, which a row
+        // filter would not touch. Also covers `list_partitions`.
         self.authorize_unrestricted_read().await?;
         let sm = SnapshotManager::new(self.file_io().clone(), self.location().to_string());
         let snapshot = match sm.get_latest_snapshot().await? {

--- a/crates/paimon/src/table/partition_stat.rs
+++ b/crates/paimon/src/table/partition_stat.rs
@@ -64,8 +64,11 @@ impl Table {
     ///
     /// Returns an empty Vec when the table has no snapshots yet.
     pub async fn partition_stats(&self) -> crate::Result<Vec<PartitionStat>> {
-        // Manifests carry partition values and per-column stats.
-        CoreOptions::new(self.schema().options()).ensure_read_authorized()?;
+        // Per-partition record counts and partition-key values are derived from
+        // the raw manifests, so a row filter would not apply: they disclose the
+        // size and key space of data the grant hides. Require an unrestricted
+        // grant (this also covers `list_partitions`, which delegates here).
+        self.authorize_unrestricted_read().await?;
         let sm = SnapshotManager::new(self.file_io().clone(), self.location().to_string());
         let snapshot = match sm.get_latest_snapshot().await? {
             Some(s) => s,

--- a/crates/paimon/src/table/query_auth.rs
+++ b/crates/paimon/src/table/query_auth.rs
@@ -21,8 +21,8 @@
 //! error, so callers keep the table fail-closed.
 
 use crate::arrow::residual::{
-    boolean_mask_from_predicate, evaluate_column_predicate, literal_scalar_for_arrow_filter,
-    sanitize_filter_mask,
+    boolean_mask_from_predicate, evaluate_column_predicate, evaluate_decimal_leaf,
+    literal_scalar_for_arrow_filter, sanitize_filter_mask,
 };
 use crate::spec::{
     DataField, DataType, Datum, Predicate, PredicateOperator, Transform, TransformInput,
@@ -33,15 +33,23 @@ use arrow_array::{ArrayRef, BooleanArray, Float32Array, Float64Array, RecordBatc
 use std::collections::HashSet;
 use std::sync::Arc;
 
-/// Row filters and column masks the REST server granted the current user for a
-/// specific set of columns. `authorized = None` means all columns were approved
-/// (the request used `select = all`); `Some(set)` scopes the grant to those
+/// Row filters and column masks the REST server granted this user.
+/// `authorized = None` means all columns; `Some(set)` scopes the grant to those
 /// table-schema indices. Only the REST catalog constructs grants.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct QueryAuthGrant {
     filters: Vec<Predicate>,
     masks: Vec<ColumnMask>,
     authorized: Option<HashSet<usize>>,
+    /// System fields the request asked about (`_ROW_ID`, …). They have no table
+    /// index, so `authorized` cannot hold them.
+    ///
+    /// `Some(set)` approves exactly `set` — an empty set approves none, so a
+    /// full projection is not blanket approval for `_ROW_ID`. `None` means
+    /// system scoping does not apply: internal raw reads (index builds, write
+    /// rewrites) authorize through `authorize_unrestricted_read`, run only when
+    /// the server imposed no rules at all, and legitimately read `_ROW_ID`.
+    authorized_system: Option<HashSet<String>>,
     /// Where this grant's positional indices are meaningful. The schema id
     /// alone would not do: it is a per-table counter, so two fresh tables
     /// both sit at 0.
@@ -51,6 +59,11 @@ pub(crate) struct QueryAuthGrant {
 /// Identity a grant is bound to.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct GrantBinding {
+    /// REST table UUID when available: an identifier or schema id can be reused
+    /// across catalogs or a drop/recreate, a UUID cannot.
+    uuid: Option<String>,
+    /// Catalog identity: two REST aliases can share a location.
+    identifier: String,
     location: String,
     branch: String,
     schema_id: i64,
@@ -59,6 +72,8 @@ pub(crate) struct GrantBinding {
 impl GrantBinding {
     pub(crate) fn of(table: &super::Table) -> Self {
         Self {
+            uuid: table.rest_env().map(|e| e.uuid().to_string()),
+            identifier: table.identifier().full_name(),
             location: table.location().to_string(),
             branch: table.branch().to_string(),
             schema_id: table.schema().id(),
@@ -72,14 +87,49 @@ impl QueryAuthGrant {
         filters: Vec<Predicate>,
         masks: Vec<ColumnMask>,
         authorized: Option<HashSet<usize>>,
+        authorized_system: Option<HashSet<String>>,
         binding: GrantBinding,
     ) -> Self {
         Self {
             filters,
             masks,
             authorized,
+            authorized_system,
             binding,
         }
+    }
+
+    /// Like [`Self::check_system_scope`], for system fields a read path adds on
+    /// top of its read type (the audit schema's `rowkind`).
+    pub(crate) fn check_system_scope_by_name(&self, names: &[&str]) -> Result<()> {
+        let Some(approved) = &self.authorized_system else {
+            return Ok(());
+        };
+        for name in names {
+            if !approved.contains(*name) {
+                return Err(unsupported(format!(
+                    "query-auth read emits system column `{name}` outside the authorized set"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Fail closed when `read_type` projects a system field outside this grant's
+    /// scope. Scoped by name: system fields have no table index.
+    pub(crate) fn check_system_scope(&self, read_type: &[DataField]) -> Result<()> {
+        let Some(approved) = &self.authorized_system else {
+            return Ok(());
+        };
+        for field in read_type.iter().filter(|f| is_reserved_system_field(f)) {
+            if !approved.contains(field.name()) {
+                return Err(unsupported(format!(
+                    "query-auth read projects system column `{}` outside the authorized set",
+                    field.name()
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// Whether this grant may be enforced on `table`.
@@ -92,10 +142,9 @@ impl QueryAuthGrant {
         self.authorized.is_none() && self.filters.is_empty() && self.masks.is_empty()
     }
 
-    /// Whether the SERVER restricted this user (a row filter or a column mask),
-    /// as opposed to the client merely scoping its own projection. Statistics
-    /// suppression, split transport and the incremental-read gate key off this:
-    /// a column-scoped grant with no filter and no mask distorts nothing.
+    /// Whether the SERVER restricted this user, as opposed to the client merely
+    /// scoping its own projection. Statistics suppression and the historical /
+    /// scan-all gates key off this: a column scope distorts nothing.
     pub(crate) fn has_server_restrictions(&self) -> bool {
         !self.filters.is_empty() || !self.masks.is_empty()
     }
@@ -141,10 +190,9 @@ impl QueryAuthGrant {
         columns.into_iter().find(|c| !self.authorizes_columns([*c]))
     }
 
-    /// Field IDs the grant must physically read (row-filter columns, mask
-    /// targets, and mask inputs). Scan projection planning must include these so
-    /// data-evolution column-slice pruning does not drop files that hold them
-    /// (an omitted column would read as null and wrongly satisfy `IS_NULL`).
+    /// Field IDs the grant must physically read (filter columns, mask targets
+    /// and inputs). Projection planning must include them, or column-slice
+    /// pruning drops the file and the column reads as null.
     pub(crate) fn read_field_ids(&self, fields: &[DataField]) -> Vec<i32> {
         let mut indices = HashSet::new();
         for filter in &self.filters {
@@ -194,9 +242,8 @@ pub(crate) fn unauthorized_column_error(fields: &[DataField], column: usize) -> 
 }
 
 /// Reserved system fields a read type may project. The reader produces them, so
-/// they are not table columns and carry no grant scope. Both id and name must
-/// match, so a forged field cannot borrow a system id. Mirrors Java
-/// `SpecialFields.SYSTEM_FIELD_NAMES`.
+/// they carry no grant scope. Both id and name must match, so a forged field
+/// cannot borrow a system id. Mirrors Java `SpecialFields.SYSTEM_FIELD_NAMES`.
 const RESERVED_SYSTEM_FIELDS: [(i32, &str); 4] = [
     (crate::spec::ROW_ID_FIELD_ID, crate::spec::ROW_ID_FIELD_NAME),
     (
@@ -213,6 +260,10 @@ const RESERVED_SYSTEM_FIELDS: [(i32, &str); 4] = [
     ),
 ];
 
+pub(crate) fn is_reserved_system_field_name(name: &str) -> bool {
+    RESERVED_SYSTEM_FIELDS.iter().any(|(_, n)| *n == name)
+}
+
 pub(crate) fn is_reserved_system_field(field: &DataField) -> bool {
     RESERVED_SYSTEM_FIELDS
         .iter()
@@ -222,10 +273,9 @@ pub(crate) fn is_reserved_system_field(field: &DataField) -> bool {
 /// Table-schema indices a read type touches, rejecting any field that is not a
 /// canonical `(id, name)` pair of `fields`.
 ///
-/// Scoping and masking resolve by id while the physical read resolves by name,
-/// so a read type pairing an authorized id with another column's name would be
-/// scoped by id and read by name. `TableRead::new` / `with_read_type` are
-/// public, so this is reachable — fail closed.
+/// Scoping resolves by id while the physical read resolves by name, so an
+/// authorized id under another column's name would be scoped by one and read as
+/// the other. `TableRead::new` is public, so this is reachable.
 pub(crate) fn canonical_projection(
     fields: &[DataField],
     read_type: &[DataField],
@@ -236,10 +286,9 @@ pub(crate) fn canonical_projection(
         let by_name = fields.iter().position(|s| s.name() == field.name());
         match (by_id, by_name) {
             (Some(i), Some(n)) if i == n => indices.push(i),
-            // Absent from the schema. Anything but a reserved system field is
-            // a column dropped by schema evolution, which the reader still
-            // resolves by field id in older files and returns raw. Java rejects
-            // it in `TableQueryAuthResult.checkFieldExists`.
+            // Absent from the schema. Anything but a system field is a dropped
+            // column, which the reader still resolves by id in older files.
+            // Java rejects it in `TableQueryAuthResult.checkFieldExists`.
             (None, None) if is_reserved_system_field(field) => {}
             _ => {
                 return Err(unsupported(format!(
@@ -253,10 +302,78 @@ pub(crate) fn canonical_projection(
     Ok(indices)
 }
 
-/// Live query-auth scope check shared by the read/scan gates: fail closed when
-/// the caller filter references a masked column (pruning on its raw value would
-/// leak it) or when the projection/filter touches a column outside the grant's
-/// authorized scope. `projected = None` means all columns.
+/// Names of the reserved system fields a read projects, plus any the caller's
+/// filter references. Shared by the Paimon and Format read builders, which
+/// otherwise kept two copies of this and drifted apart.
+///
+/// `filter_system_names` must be captured before row-id extraction rewrites the
+/// predicates, and `slices_by_row_id` covers an explicit row-range slice, which
+/// selects by `_ROW_ID` with no predicate at all.
+pub(crate) fn projected_system_field_names(
+    read_type: Option<&[DataField]>,
+    filter_system_names: &HashSet<String>,
+    slices_by_row_id: bool,
+) -> Vec<String> {
+    let mut names: HashSet<String> = read_type
+        .map(|fields| {
+            fields
+                .iter()
+                .filter(|f| is_reserved_system_field(f))
+                .map(|f| f.name().to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+    names.extend(filter_system_names.iter().cloned());
+    if slices_by_row_id {
+        names.insert(crate::spec::ROW_ID_FIELD_NAME.to_string());
+    }
+    let mut names: Vec<String> = names.into_iter().collect();
+    names.sort();
+    names
+}
+
+/// Everything a read must satisfy to run under `grant`, in one place.
+///
+/// Every read-side gate calls exactly this, so a check cannot be added to one
+/// gate and forgotten in another — the failure mode this module kept hitting.
+/// Returns the read type's table-schema indices, which callers need anyway.
+///
+/// `implicit_system_fields` are system columns the path emits on top of
+/// `read_type` (the audit schema prepends `rowkind`), which therefore never
+/// reached the projection or the auth request.
+pub(crate) fn authorize_read(
+    grant: &QueryAuthGrant,
+    table: &super::Table,
+    read_type: &[DataField],
+    predicates: &[Predicate],
+    implicit_system_fields: &[&str],
+) -> crate::Result<Vec<usize>> {
+    // The grant's positional indices only mean anything on the table it was
+    // issued for; `Table::authorize_rewrite_splits` is public, so a grant can
+    // arrive on another table's splits.
+    if !grant.matches_table(table) {
+        return Err(unsupported(
+            "a query-auth grant issued for a different table or schema cannot be \
+             enforced here; re-plan the scan"
+                .to_string(),
+        ));
+    }
+    grant.check_system_scope(read_type)?;
+    grant.check_system_scope_by_name(implicit_system_fields)?;
+
+    let fields = table.schema().fields();
+    let projected = canonical_projection(fields, read_type)?;
+    let mut filter_columns = HashSet::new();
+    for predicate in predicates {
+        predicate.collect_leaf_field_indices(&mut filter_columns);
+    }
+    scope_check(grant, fields, &filter_columns, Some(projected.clone()))?;
+    Ok(projected)
+}
+
+/// Scope check shared by the read/scan gates: fail closed when the caller filter
+/// references a masked column (pruning on its raw value would leak it) or
+/// touches one outside the grant. `projected = None` means all columns.
 pub(crate) fn scope_check(
     grant: &QueryAuthGrant,
     fields: &[DataField],
@@ -288,17 +405,19 @@ pub(crate) fn parse_auth_filters(
 ) -> Result<Vec<Predicate>> {
     filters
         .iter()
-        .filter(|f| !f.trim().is_empty())
+        // Java skips only length-0 entries (`StringUtils.isEmpty`). Whitespace
+        // is invalid JSON: dropping it could leave a grant with no filter.
+        .filter(|f| !f.is_empty())
         .map(|f| Predicate::from_rest_json(f, fields))
         .collect()
 }
 
 // ==================== Exact evaluation ====================
 
-/// Exactly evaluate the ANDed `predicates` against `batch` (whose columns
-/// correspond 1:1 to `batch_fields`; leaf indices refer to `schema_fields`)
-/// and drop non-matching rows. Unlike the pruning evaluators, anything that
-/// cannot be evaluated is an error — a security filter must not fall open.
+/// Evaluate the ANDed `predicates` against `batch` (columns 1:1 with
+/// `batch_fields`; leaf indices into `schema_fields`) and drop non-matching
+/// rows. Unlike the pruning evaluators, anything unevaluable is an error — a
+/// security filter must not fall open.
 pub(crate) fn strict_filter_batch(
     batch: &RecordBatch,
     predicates: &[Predicate],
@@ -366,12 +485,10 @@ fn strict_mask(
 
 /// Replace every NaN in a float column with the canonical (positive) NaN.
 ///
-/// Arrow's comparison kernels use a total ordering in which a NEGATIVE NaN sorts
-/// below every finite value, so an auth filter like `f < 0` would admit a
-/// negative-NaN row. Java canonicalizes NaN in `Float`/`Double.compare`, making
-/// every NaN greater than all finite values, so the row is rejected. Applied
-/// only to authorization filters — ordinary query pushdown keeps Arrow
-/// semantics. Signed zero already agrees with Java and is left alone.
+/// Arrow's total ordering sorts a NEGATIVE NaN below every finite value, so
+/// `f < 0` would admit it; Java's `Float`/`Double.compare` makes every NaN the
+/// greatest. Authorization filters only — ordinary pushdown keeps Arrow
+/// semantics. Signed zero already agrees.
 fn canonicalize_nan(column: &ArrayRef) -> ArrayRef {
     match column.data_type() {
         arrow_schema::DataType::Float32 => {
@@ -433,6 +550,15 @@ fn strict_leaf_mask(
     op: PredicateOperator,
     literals: &[Datum],
 ) -> Result<BooleanArray> {
+    // Decimals compare by value across scales (`datum_cmp`), which no Arrow
+    // scalar expresses — `literal_scalar_for_arrow_filter` returns `None` for
+    // them by design, so without this every decimal policy would error. The
+    // exact evaluator keeps nulls, so Kleene combination is unchanged.
+    if matches!(column.data_type(), arrow_schema::DataType::Decimal128(_, _))
+        && !matches!(op, PredicateOperator::IsNull | PredicateOperator::IsNotNull)
+    {
+        return kleene(evaluate_decimal_leaf(column, op, literals));
+    }
     let scalar = |literal: &Datum| -> Result<arrow_array::Scalar<ArrayRef>> {
         literal_scalar_for_arrow_filter(literal, data_type)?.ok_or_else(|| {
             unsupported(format!(
@@ -537,11 +663,9 @@ pub(crate) fn parse_column_masking(
             .position(|f| f.name() == column)
             .ok_or_else(|| mask_err(format!("unknown field `{column}`")))?;
         let transform = Transform::from_rest_json(json, fields)?;
-        // The masked value replaces the column in place, so its type must match
-        // the column's; a type-changing transform (e.g. `CAST(id AS STRING)` on
-        // an INT column) cannot be represented and must fail closed rather than
-        // be cast back to the raw type. Types are compared via their arrow
-        // representation (nullability-agnostic).
+        // The masked value replaces the column in place, so a type-changing
+        // transform (`CAST(id AS STRING)` on an INT column) cannot be
+        // represented. Compared via the arrow type (nullability-agnostic).
         if let Some(out) = mask_output_type(&transform, fields) {
             let target_type = crate::arrow::paimon_type_to_arrow(fields[target].data_type())?;
             if out != target_type {
@@ -566,10 +690,9 @@ pub(crate) fn parse_column_masking(
     // Deterministic order regardless of map iteration.
     masks.sort_by_key(|m| m.column);
 
-    // Masks read their inputs from the RAW batch (like Java), so one mask that
-    // references ANOTHER mask's target would copy that column's unmasked value
-    // into its own output — defeating the second mask. Referencing your own
-    // target is the normal case (`name := UPPER(name)`) and stays valid.
+    // Masks read their inputs from the RAW batch (like Java), so a mask
+    // referencing ANOTHER mask's target would copy its unmasked value out.
+    // Referencing your own target (`name := UPPER(name)`) stays valid.
     let targets: HashSet<usize> = masks.iter().map(|m| m.column).collect();
     for mask in &masks {
         let mut inputs = HashSet::new();
@@ -652,10 +775,9 @@ pub(crate) fn mask_batch(
                 "query-auth mask references unknown field #{schema_index}"
             ))
         })?;
-        // Match on field id alone: the read type may carry the column under a
-        // different name (projection aliasing, or a renamed column read from an
-        // older file schema). Also matching the name would silently find no
-        // position and skip the mask, emitting the raw value.
+        // By field id alone: the read type may carry the column under another
+        // name (aliasing, or a rename seen from an older file schema), and
+        // matching the name too would skip the mask and emit the raw value.
         Ok(batch_fields
             .iter()
             .enumerate()
@@ -1144,6 +1266,136 @@ mod tests {
     }
 
     #[test]
+    fn test_implicit_system_fields_are_scope_checked() {
+        // The audit schema prepends `rowkind` (and may prepend
+        // `_SEQUENCE_NUMBER`) on top of the read type, so neither reaches the
+        // auth request via the projection and both need a by-name check.
+        let grant = QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+            Some(HashSet::from(
+                [crate::spec::ROW_KIND_FIELD_NAME.to_string()],
+            )),
+            GrantBinding::default(),
+        );
+        assert!(grant
+            .check_system_scope_by_name(&[crate::spec::ROW_KIND_FIELD_NAME])
+            .is_ok());
+        assert!(grant
+            .check_system_scope_by_name(&[
+                crate::spec::ROW_KIND_FIELD_NAME,
+                crate::spec::SEQUENCE_NUMBER_FIELD_NAME,
+            ])
+            .is_err());
+        // An unscoped grant covers everything.
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, None, GrantBinding::default());
+        assert!(all
+            .check_system_scope_by_name(&[crate::spec::SEQUENCE_NUMBER_FIELD_NAME])
+            .is_ok());
+    }
+
+    #[test]
+    fn test_whitespace_only_filter_fails_closed() {
+        use crate::spec::{DataType, IntType};
+        let fields = vec![DataField::new(
+            0,
+            "id".to_string(),
+            DataType::Int(IntType::new()),
+        )];
+        // Java skips only length-0 entries, so " " reaches the parser and throws.
+        // Dropping it here would leave a grant with no filter at all.
+        assert!(parse_auth_filters(&[" ".to_string()], &fields).is_err());
+        assert!(parse_auth_filters(&["\n".to_string()], &fields).is_err());
+        // A genuinely empty entry is still skipped (Java parity).
+        assert_eq!(
+            parse_auth_filters(&[String::new()], &fields).unwrap().len(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_system_scope_does_not_make_a_grant_restricted() {
+        // `is_unrestricted` answers "did the server restrict, or did the client
+        // scope columns". The system scope answers a different question, so
+        // letting it gate this made every write/build path on a query-auth table
+        // fail: `authorize_unrestricted_read` would never see an unrestricted
+        // grant.
+        let scoped_system = QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            None,
+            Some(HashSet::new()),
+            GrantBinding::default(),
+        );
+        assert!(
+            scoped_system.is_unrestricted(),
+            "an empty system scope with no rules is still unrestricted"
+        );
+        assert!(!scoped_system.has_server_restrictions());
+
+        // Internal raw reads carry no system scoping at all.
+        let internal =
+            QueryAuthGrant::new(Vec::new(), Vec::new(), None, None, GrantBinding::default());
+        assert!(internal.is_unrestricted());
+    }
+
+    #[test]
+    fn test_full_projection_is_not_blanket_system_approval() {
+        use crate::spec::{DataType, IntType};
+        // `select = None` means "every table column", never "every reserved
+        // system field": the request only carries the system names the read
+        // needs, so anything else was never shown to the server.
+        let grant = QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            None,
+            Some(HashSet::new()),
+            GrantBinding::default(),
+        );
+        let row_id = DataField::new(
+            crate::spec::ROW_ID_FIELD_ID,
+            crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            DataType::Int(IntType::new()),
+        );
+        assert!(grant.check_system_scope(&[row_id]).is_err());
+        assert!(grant
+            .check_system_scope_by_name(&[crate::spec::ROW_KIND_FIELD_NAME])
+            .is_err());
+    }
+
+    #[test]
+    fn test_system_field_scope_is_enforced_by_name() {
+        use crate::spec::{DataType, IntType};
+        let row_id = DataField::new(
+            crate::spec::ROW_ID_FIELD_ID,
+            crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            DataType::Int(IntType::new()),
+        );
+        let seq = DataField::new(
+            crate::spec::SEQUENCE_NUMBER_FIELD_ID,
+            crate::spec::SEQUENCE_NUMBER_FIELD_NAME.to_string(),
+            DataType::Int(IntType::new()),
+        );
+        // Authorized for _ROW_ID only: system fields have no table index, so the
+        // positional scope cannot cover them and they need their own check.
+        let grant = QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+            Some(HashSet::from([crate::spec::ROW_ID_FIELD_NAME.to_string()])),
+            GrantBinding::default(),
+        );
+        assert!(grant
+            .check_system_scope(std::slice::from_ref(&row_id))
+            .is_ok());
+        assert!(grant.check_system_scope(&[seq]).is_err());
+        // An unscoped grant covers everything.
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, None, GrantBinding::default());
+        assert!(all.check_system_scope(&[row_id]).is_ok());
+    }
+
+    #[test]
     fn test_canonical_projection_system_and_dropped_fields() {
         use crate::spec::{DataType, IntType};
         let fields = vec![DataField::new(
@@ -1188,13 +1440,14 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            None,
             GrantBinding::default(),
         );
         assert!(!grant.is_unrestricted());
         assert!(grant.authorizes_columns([0]));
         assert!(!grant.authorizes_columns([1]));
         // `None` (all columns) with no filter/mask is fully unrestricted.
-        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, GrantBinding::default());
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, None, GrantBinding::default());
         assert!(all.is_unrestricted());
         assert!(all.authorizes_columns([0, 1, 99]));
     }

--- a/crates/paimon/src/table/query_auth.rs
+++ b/crates/paimon/src/table/query_auth.rs
@@ -1,0 +1,1085 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Query-auth enforcement: apply the REST server's per-user row filter and
+//! column masking exactly to read output. Parsing of the Java `Predicate` /
+//! `Transform` JSON lives in [`crate::spec`]; anything unrecognised is an
+//! error, so callers keep the table fail-closed.
+
+use crate::arrow::residual::{
+    boolean_mask_from_predicate, evaluate_column_predicate, literal_scalar_for_arrow_filter,
+    sanitize_filter_mask,
+};
+use crate::spec::{
+    DataField, DataType, Datum, Predicate, PredicateOperator, Transform, TransformInput,
+};
+use crate::{Error, Result};
+use arrow_arith::boolean::{and_kleene, not, or_kleene};
+use arrow_array::{ArrayRef, BooleanArray, Float32Array, Float64Array, RecordBatch};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// Row filters and column masks the REST server granted the current user for a
+/// specific set of columns. `authorized = None` means all columns were approved
+/// (the request used `select = all`); `Some(set)` scopes the grant to those
+/// table-schema indices. Only the REST catalog constructs grants.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct QueryAuthGrant {
+    filters: Vec<Predicate>,
+    masks: Vec<ColumnMask>,
+    authorized: Option<HashSet<usize>>,
+    /// Schema this grant's positional filter/mask indices were parsed against.
+    /// Enforcing it on a different schema would bind them to other columns.
+    schema_id: Option<i64>,
+}
+
+impl QueryAuthGrant {
+    pub(crate) fn new(
+        filters: Vec<Predicate>,
+        masks: Vec<ColumnMask>,
+        authorized: Option<HashSet<usize>>,
+    ) -> Self {
+        Self {
+            filters,
+            masks,
+            authorized,
+            schema_id: None,
+        }
+    }
+
+    /// Bind this grant to the schema its indices were resolved against.
+    pub(crate) fn with_schema_id(mut self, schema_id: i64) -> Self {
+        self.schema_id = Some(schema_id);
+        self
+    }
+
+    /// Whether this grant may be enforced against `schema_id`. A grant with no
+    /// binding (test-constructed) matches anything.
+    pub(crate) fn matches_schema(&self, schema_id: i64) -> bool {
+        self.schema_id.is_none_or(|bound| bound == schema_id)
+    }
+
+    /// Fully unrestricted: every column approved, no filter, no masking.
+    pub(crate) fn is_unrestricted(&self) -> bool {
+        self.authorized.is_none() && self.filters.is_empty() && self.masks.is_empty()
+    }
+
+    /// Whether the SERVER restricted this user (a row filter or a column mask),
+    /// as opposed to the client merely scoping its own projection. Statistics
+    /// suppression, split transport and the incremental-read gate key off this:
+    /// a column-scoped grant with no filter and no mask distorts nothing.
+    pub(crate) fn has_server_restrictions(&self) -> bool {
+        !self.filters.is_empty() || !self.masks.is_empty()
+    }
+
+    pub(crate) fn filters(&self) -> &[Predicate] {
+        &self.filters
+    }
+
+    pub(crate) fn masks(&self) -> &[ColumnMask] {
+        &self.masks
+    }
+
+    /// Whether every table-schema index in `columns` was authorized. A grant
+    /// scoped to a subset does not authorize columns outside it, so a wider
+    /// projection or a predicate on an un-approved column fails closed.
+    pub(crate) fn authorizes_columns(&self, columns: impl IntoIterator<Item = usize>) -> bool {
+        match &self.authorized {
+            None => true,
+            Some(set) => columns.into_iter().all(|c| set.contains(&c)),
+        }
+    }
+
+    /// Whether this grant carries a row filter. Such a filter is applied as a
+    /// residual pass in `TableRead::to_arrow`, so split row counts, count
+    /// statistics, and count-based limit pushdown are no longer exact.
+    pub(crate) fn has_row_filter(&self) -> bool {
+        !self.filters.is_empty()
+    }
+
+    /// Table-schema indices of columns this grant masks (empty when no masking).
+    /// Callers must not push predicates on these columns to scan pruning, which
+    /// would leak the raw value via row presence.
+    pub(crate) fn masked_columns(&self) -> Vec<usize> {
+        self.masks.iter().map(|m| m.column).collect()
+    }
+
+    /// The first of `columns` (table-schema indices) this grant does not
+    /// authorize, if any.
+    pub(crate) fn first_unauthorized(
+        &self,
+        columns: impl IntoIterator<Item = usize>,
+    ) -> Option<usize> {
+        columns.into_iter().find(|c| !self.authorizes_columns([*c]))
+    }
+
+    /// Field IDs the grant must physically read (row-filter columns, mask
+    /// targets, and mask inputs). Scan projection planning must include these so
+    /// data-evolution column-slice pruning does not drop files that hold them
+    /// (an omitted column would read as null and wrongly satisfy `IS_NULL`).
+    pub(crate) fn read_field_ids(&self, fields: &[DataField]) -> Vec<i32> {
+        let mut indices = HashSet::new();
+        for filter in &self.filters {
+            filter.collect_leaf_field_indices(&mut indices);
+        }
+        for mask in &self.masks {
+            indices.insert(mask.column);
+            mask.transform.collect_field_indices(&mut indices);
+        }
+        indices
+            .into_iter()
+            .filter_map(|i| fields.get(i).map(|f| f.id()))
+            .collect()
+    }
+}
+
+/// Mask one column (by table-schema index) with a transform.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ColumnMask {
+    pub(crate) column: usize,
+    pub(crate) transform: Transform,
+}
+
+fn unsupported(message: String) -> Error {
+    Error::Unsupported { message }
+}
+
+fn field_name(fields: &[DataField], column: usize) -> &str {
+    fields.get(column).map(|f| f.name()).unwrap_or("?")
+}
+
+/// Fail-closed error for a caller predicate on a masked column (would leak the
+/// raw value via row selection). Shared by every builder/scan choke point.
+pub(crate) fn masked_filter_error(fields: &[DataField], column: usize) -> Error {
+    unsupported(format!(
+        "cannot filter on masked column `{}`",
+        field_name(fields, column)
+    ))
+}
+
+/// Fail-closed error for a read that touches a column outside the grant's scope.
+pub(crate) fn unauthorized_column_error(fields: &[DataField], column: usize) -> Error {
+    unsupported(format!(
+        "query-auth read touches column `{}` outside the authorized set",
+        field_name(fields, column)
+    ))
+}
+
+/// Live query-auth scope check shared by the read/scan gates: fail closed when
+/// the caller filter references a masked column (pruning on its raw value would
+/// leak it) or when the projection/filter touches a column outside the grant's
+/// authorized scope. `projected = None` means all columns.
+pub(crate) fn scope_check(
+    grant: &QueryAuthGrant,
+    fields: &[DataField],
+    filter_columns: &HashSet<usize>,
+    projected: Option<Vec<usize>>,
+) -> crate::Result<()> {
+    if let Some(column) = grant
+        .masked_columns()
+        .into_iter()
+        .find(|c| filter_columns.contains(c))
+    {
+        return Err(masked_filter_error(fields, column));
+    }
+    let projected = projected.unwrap_or_else(|| (0..fields.len()).collect());
+    if let Some(column) =
+        grant.first_unauthorized(projected.into_iter().chain(filter_columns.iter().copied()))
+    {
+        return Err(unauthorized_column_error(fields, column));
+    }
+    Ok(())
+}
+
+/// Parse the auth response's JSON filter strings into predicates whose leaf
+/// indices refer to `fields` (table-schema order). Empty strings are skipped
+/// (Java parity); anything unparseable is an error.
+pub(crate) fn parse_auth_filters(
+    filters: &[String],
+    fields: &[DataField],
+) -> Result<Vec<Predicate>> {
+    filters
+        .iter()
+        .filter(|f| !f.trim().is_empty())
+        .map(|f| Predicate::from_rest_json(f, fields))
+        .collect()
+}
+
+// ==================== Exact evaluation ====================
+
+/// Exactly evaluate the ANDed `predicates` against `batch` (whose columns
+/// correspond 1:1 to `batch_fields`; leaf indices refer to `schema_fields`)
+/// and drop non-matching rows. Unlike the pruning evaluators, anything that
+/// cannot be evaluated is an error — a security filter must not fall open.
+pub(crate) fn strict_filter_batch(
+    batch: &RecordBatch,
+    predicates: &[Predicate],
+    schema_fields: &[DataField],
+    batch_fields: &[DataField],
+) -> Result<RecordBatch> {
+    let mut combined: Option<BooleanArray> = None;
+    for predicate in predicates {
+        let mask = strict_mask(batch, predicate, schema_fields, batch_fields)?;
+        combined = Some(match combined {
+            Some(existing) => kleene(and_kleene(&existing, &mask))?,
+            None => mask,
+        });
+    }
+    let Some(mask) = combined else {
+        return Ok(batch.clone());
+    };
+    let mask = sanitize_filter_mask(mask);
+    arrow_select::filter::filter_record_batch(batch, &mask).map_err(|e| Error::DataInvalid {
+        message: format!("failed to apply query-auth row filter: {e}"),
+        source: Some(Box::new(e)),
+    })
+}
+
+fn strict_mask(
+    batch: &RecordBatch,
+    predicate: &Predicate,
+    schema_fields: &[DataField],
+    batch_fields: &[DataField],
+) -> Result<BooleanArray> {
+    match predicate {
+        Predicate::AlwaysTrue => Ok(BooleanArray::from(vec![true; batch.num_rows()])),
+        Predicate::AlwaysFalse => Ok(BooleanArray::from(vec![false; batch.num_rows()])),
+        Predicate::And(children) => fold_masks(batch, children, schema_fields, batch_fields, true),
+        Predicate::Or(children) => fold_masks(batch, children, schema_fields, batch_fields, false),
+        Predicate::Not(inner) => {
+            let mask = strict_mask(batch, inner, schema_fields, batch_fields)?;
+            kleene(not(&mask))
+        }
+        Predicate::Leaf {
+            index,
+            op,
+            literals,
+            ..
+        } => {
+            let field = schema_fields.get(*index).ok_or_else(|| {
+                unsupported(format!(
+                    "query-auth filter references unknown field #{index}"
+                ))
+            })?;
+            let position = batch_fields
+                .iter()
+                .position(|f| f.id() == field.id() && f.name() == field.name())
+                .ok_or_else(|| {
+                    unsupported(format!(
+                        "query-auth filter field `{}` missing from read",
+                        field.name()
+                    ))
+                })?;
+            let column = canonicalize_nan(batch.column(position));
+            strict_leaf_mask(&column, field.data_type(), *op, literals)
+        }
+    }
+}
+
+/// Replace every NaN in a float column with the canonical (positive) NaN.
+///
+/// Arrow's comparison kernels use a total ordering in which a NEGATIVE NaN sorts
+/// below every finite value, so an auth filter like `f < 0` would admit a
+/// negative-NaN row. Java canonicalizes NaN in `Float`/`Double.compare`, making
+/// every NaN greater than all finite values, so the row is rejected. Applied
+/// only to authorization filters — ordinary query pushdown keeps Arrow
+/// semantics. Signed zero already agrees with Java and is left alone.
+fn canonicalize_nan(column: &ArrayRef) -> ArrayRef {
+    match column.data_type() {
+        arrow_schema::DataType::Float32 => {
+            let values = column.as_any().downcast_ref::<Float32Array>();
+            match values {
+                Some(values) if values.iter().any(|v| v.is_some_and(f32::is_nan)) => {
+                    Arc::new(values.unary::<_, arrow_array::types::Float32Type>(|v| {
+                        if v.is_nan() {
+                            f32::NAN
+                        } else {
+                            v
+                        }
+                    })) as ArrayRef
+                }
+                _ => Arc::clone(column),
+            }
+        }
+        arrow_schema::DataType::Float64 => {
+            let values = column.as_any().downcast_ref::<Float64Array>();
+            match values {
+                Some(values) if values.iter().any(|v| v.is_some_and(f64::is_nan)) => {
+                    Arc::new(values.unary::<_, arrow_array::types::Float64Type>(|v| {
+                        if v.is_nan() {
+                            f64::NAN
+                        } else {
+                            v
+                        }
+                    })) as ArrayRef
+                }
+                _ => Arc::clone(column),
+            }
+        }
+        _ => Arc::clone(column),
+    }
+}
+
+fn fold_masks(
+    batch: &RecordBatch,
+    children: &[Predicate],
+    schema_fields: &[DataField],
+    batch_fields: &[DataField],
+    use_and: bool,
+) -> Result<BooleanArray> {
+    let mut combined: Option<BooleanArray> = None;
+    for child in children {
+        let mask = strict_mask(batch, child, schema_fields, batch_fields)?;
+        combined = Some(match combined {
+            Some(existing) if use_and => kleene(and_kleene(&existing, &mask))?,
+            Some(existing) => kleene(or_kleene(&existing, &mask))?,
+            None => mask,
+        });
+    }
+    combined.ok_or_else(|| unsupported("query-auth filter has an empty compound".to_string()))
+}
+
+fn strict_leaf_mask(
+    column: &ArrayRef,
+    data_type: &DataType,
+    op: PredicateOperator,
+    literals: &[Datum],
+) -> Result<BooleanArray> {
+    let scalar = |literal: &Datum| -> Result<arrow_array::Scalar<ArrayRef>> {
+        literal_scalar_for_arrow_filter(literal, data_type)?.ok_or_else(|| {
+            unsupported(format!(
+                "query-auth filter literal is not comparable to type {data_type:?}"
+            ))
+        })
+    };
+    match op {
+        PredicateOperator::IsNull => Ok(boolean_mask_from_predicate(column.len(), |row| {
+            column.is_null(row)
+        })),
+        PredicateOperator::IsNotNull => Ok(boolean_mask_from_predicate(column.len(), |row| {
+            column.is_valid(row)
+        })),
+        PredicateOperator::In | PredicateOperator::NotIn => {
+            // Kleene IN: OR of equalities; x NOT IN (..) = NOT(IN), nulls stay null.
+            let mut combined = BooleanArray::from(vec![false; column.len()]);
+            for literal in literals {
+                let eq = kleene(evaluate_column_predicate(
+                    column,
+                    &scalar(literal)?,
+                    PredicateOperator::Eq,
+                ))?;
+                combined = kleene(or_kleene(&combined, &eq))?;
+            }
+            if matches!(op, PredicateOperator::NotIn) {
+                combined = kleene(not(&combined))?;
+                if literals.is_empty() {
+                    // `x NOT IN ()` is true only for non-null rows.
+                    combined =
+                        boolean_mask_from_predicate(column.len(), |row| column.is_valid(row));
+                }
+            }
+            Ok(combined)
+        }
+        PredicateOperator::Eq
+        | PredicateOperator::NotEq
+        | PredicateOperator::Lt
+        | PredicateOperator::LtEq
+        | PredicateOperator::Gt
+        | PredicateOperator::GtEq
+        | PredicateOperator::StartsWith
+        | PredicateOperator::EndsWith
+        | PredicateOperator::Contains
+        | PredicateOperator::Like => {
+            let literal = literals.first().ok_or_else(|| {
+                unsupported("query-auth filter comparison without literal".to_string())
+            })?;
+            kleene(evaluate_column_predicate(column, &scalar(literal)?, op))
+        }
+        PredicateOperator::Between | PredicateOperator::NotBetween => {
+            let (Some(low), Some(high)) = (literals.first(), literals.get(1)) else {
+                return Err(unsupported(
+                    "query-auth BETWEEN filter without bounds".to_string(),
+                ));
+            };
+            let lo = kleene(evaluate_column_predicate(
+                column,
+                &scalar(low)?,
+                PredicateOperator::GtEq,
+            ))?;
+            let hi = kleene(evaluate_column_predicate(
+                column,
+                &scalar(high)?,
+                PredicateOperator::LtEq,
+            ))?;
+            let between = kleene(and_kleene(&lo, &hi))?;
+            if matches!(op, PredicateOperator::NotBetween) {
+                kleene(not(&between))
+            } else {
+                Ok(between)
+            }
+        }
+    }
+}
+
+fn kleene(
+    result: std::result::Result<BooleanArray, arrow_schema::ArrowError>,
+) -> Result<BooleanArray> {
+    result.map_err(|e| Error::DataInvalid {
+        message: format!("failed to evaluate query-auth row filter: {e}"),
+        source: Some(Box::new(e)),
+    })
+}
+
+// ==================== Column masking ====================
+
+fn mask_err(detail: impl std::fmt::Display) -> Error {
+    unsupported(format!("cannot parse query-auth column masking: {detail}"))
+}
+
+/// Parse the auth response's `columnMasking` map (column name -> Java
+/// `Transform` JSON) against `fields` (table-schema order).
+pub(crate) fn parse_column_masking(
+    masking: &std::collections::HashMap<String, String>,
+    fields: &[DataField],
+) -> Result<Vec<ColumnMask>> {
+    let mut masks = Vec::with_capacity(masking.len());
+    for (column, json) in masking {
+        let target = fields
+            .iter()
+            .position(|f| f.name() == column)
+            .ok_or_else(|| mask_err(format!("unknown field `{column}`")))?;
+        let transform = Transform::from_rest_json(json, fields)?;
+        // The masked value replaces the column in place, so its type must match
+        // the column's; a type-changing transform (e.g. `CAST(id AS STRING)` on
+        // an INT column) cannot be represented and must fail closed rather than
+        // be cast back to the raw type. Types are compared via their arrow
+        // representation (nullability-agnostic).
+        if let Some(out) = mask_output_type(&transform, fields) {
+            let target_type = crate::arrow::paimon_type_to_arrow(fields[target].data_type())?;
+            if out != target_type {
+                return Err(mask_err(format!(
+                    "masking `{column}` produces {out:?} but the column is {target_type:?}"
+                )));
+            }
+        }
+        // A mask that can yield null on a NOT NULL column would leave the output
+        // batch's schema claiming non-nullable, letting engines fold
+        // `col IS [NOT] NULL` before the masked-predicate guard. Fail closed.
+        if !fields[target].data_type().is_nullable() && mask_can_be_null(&transform, fields) {
+            return Err(mask_err(format!(
+                "masking `{column}` can produce null but the column is NOT NULL"
+            )));
+        }
+        masks.push(ColumnMask {
+            column: target,
+            transform,
+        });
+    }
+    // Deterministic order regardless of map iteration.
+    masks.sort_by_key(|m| m.column);
+
+    // Masks read their inputs from the RAW batch (like Java), so one mask that
+    // references ANOTHER mask's target would copy that column's unmasked value
+    // into its own output — defeating the second mask. Referencing your own
+    // target is the normal case (`name := UPPER(name)`) and stays valid.
+    let targets: HashSet<usize> = masks.iter().map(|m| m.column).collect();
+    for mask in &masks {
+        let mut inputs = HashSet::new();
+        mask.transform.collect_field_indices(&mut inputs);
+        if let Some(other) = inputs
+            .into_iter()
+            .find(|i| *i != mask.column && targets.contains(i))
+        {
+            return Err(mask_err(format!(
+                "masking `{}` reads masked column `{}`, which would expose its raw value",
+                field_name(fields, mask.column),
+                field_name(fields, other)
+            )));
+        }
+    }
+    Ok(masks)
+}
+
+/// Whether a mask transform can produce a null value.
+fn mask_can_be_null(transform: &Transform, fields: &[DataField]) -> bool {
+    let field_nullable = |index: &usize| fields[*index].data_type().is_nullable();
+    let input_nullable = |inputs: &[TransformInput]| {
+        inputs.iter().any(|i| match i {
+            TransformInput::Literal(literal) => literal.is_none(),
+            TransformInput::Field(index) => field_nullable(index),
+        })
+    };
+    match transform {
+        Transform::Null => true,
+        Transform::FieldRef(index) | Transform::Cast(index, _) => field_nullable(index),
+        Transform::Upper(inputs) | Transform::Lower(inputs) | Transform::Concat(inputs) => {
+            input_nullable(inputs)
+        }
+        // CONCAT_WS skips null payloads, so only a null separator (the first
+        // input) can make the result null.
+        Transform::ConcatWs(inputs) => inputs.first().is_some_and(|sep| match sep {
+            TransformInput::Literal(literal) => literal.is_none(),
+            TransformInput::Field(index) => field_nullable(index),
+        }),
+    }
+}
+
+/// Arrow output type of a mask transform, or `None` when it always matches the
+/// target column (the `NULL` transform builds a null of the column's own type).
+fn mask_output_type(transform: &Transform, fields: &[DataField]) -> Option<arrow_schema::DataType> {
+    let of = |index: &usize| crate::arrow::paimon_type_to_arrow(fields[*index].data_type()).ok();
+    match transform {
+        Transform::Null => None,
+        Transform::FieldRef(index) => of(index),
+        Transform::Cast(_, to) => crate::arrow::paimon_type_to_arrow(to).ok(),
+        Transform::Upper(_)
+        | Transform::Lower(_)
+        | Transform::Concat(_)
+        | Transform::ConcatWs(_) => Some(arrow_schema::DataType::Utf8),
+    }
+}
+
+/// Overwrite masked columns of `batch` (whose columns correspond 1:1 to
+/// `batch_fields`). Masks whose target column is not in the batch are skipped
+/// (Java parity); anything that cannot be evaluated is an error.
+pub(crate) fn mask_batch(
+    batch: &RecordBatch,
+    masks: &[ColumnMask],
+    schema_fields: &[DataField],
+    batch_fields: &[DataField],
+) -> Result<RecordBatch> {
+    use arrow_array::new_null_array;
+
+    // Nothing to mask (e.g. a `COUNT(*)` read projects no columns); return the
+    // batch unchanged, preserving its row count even with zero columns.
+    if masks.is_empty() {
+        return Ok(batch.clone());
+    }
+
+    // All batch positions holding a given table-schema field (a projection may
+    // repeat a column, so every copy must be masked, not just the first).
+    let positions_of = |schema_index: usize| -> Result<Vec<usize>> {
+        let field = schema_fields.get(schema_index).ok_or_else(|| {
+            unsupported(format!(
+                "query-auth mask references unknown field #{schema_index}"
+            ))
+        })?;
+        // Match on field id alone: the read type may carry the column under a
+        // different name (projection aliasing, or a renamed column read from an
+        // older file schema). Also matching the name would silently find no
+        // position and skip the mask, emitting the raw value.
+        Ok(batch_fields
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| f.id() == field.id())
+            .map(|(pos, _)| pos)
+            .collect())
+    };
+    let input_column = |schema_index: usize| -> Result<ArrayRef> {
+        positions_of(schema_index)?
+            .first()
+            .map(|pos| batch.column(*pos).clone())
+            .ok_or_else(|| unsupported("query-auth mask input missing from read".to_string()))
+    };
+
+    let mut columns = batch.columns().to_vec();
+    for mask in masks {
+        let targets = positions_of(mask.column)?;
+        // `masks` is already filtered to targets the caller projects, so a mask
+        // that resolves to no batch column means the read cannot enforce it —
+        // emitting the column unmasked would leak the raw value.
+        let Some(&first) = targets.first() else {
+            return Err(unsupported(format!(
+                "query-auth mask for column `{}` cannot be applied: the column is missing \
+                 from the read",
+                field_name(schema_fields, mask.column)
+            )));
+        };
+        let target_type = batch.schema().field(first).data_type().clone();
+        let masked: ArrayRef = match &mask.transform {
+            Transform::Null => new_null_array(&target_type, batch.num_rows()),
+            Transform::FieldRef(index) => input_column(*index)?,
+            Transform::Cast(index, to) => {
+                let to_arrow = crate::arrow::paimon_type_to_arrow(to)?;
+                cast_masked(&input_column(*index)?, &to_arrow)?
+            }
+            Transform::Upper(inputs) => string_mask(batch, inputs, &input_column, |v| {
+                Some(v.first()?.as_ref().map(|s| s.to_uppercase()))
+            })?,
+            Transform::Lower(inputs) => string_mask(batch, inputs, &input_column, |v| {
+                Some(v.first()?.as_ref().map(|s| s.to_lowercase()))
+            })?,
+            // SQL semantics: CONCAT is null if any input is null; CONCAT_WS
+            // uses the first input as separator and skips null values.
+            Transform::Concat(inputs) => string_mask(batch, inputs, &input_column, |v| {
+                Some(
+                    v.iter()
+                        .cloned()
+                        .collect::<Option<Vec<_>>>()
+                        .map(|p| p.concat()),
+                )
+            })?,
+            Transform::ConcatWs(inputs) => string_mask(batch, inputs, &input_column, |v| {
+                let (sep, rest) = v.split_first()?;
+                Some(
+                    sep.as_ref()
+                        .map(|sep| rest.iter().flatten().cloned().collect::<Vec<_>>().join(sep)),
+                )
+            })?,
+        };
+        // Parse-time type checks guarantee a compatible type, so this only
+        // aligns arrow representations. Mask every copy of the target column.
+        let masked = cast_masked(&masked, &target_type)?;
+        for pos in targets {
+            columns[pos] = masked.clone();
+        }
+    }
+    RecordBatch::try_new_with_options(
+        batch.schema(),
+        columns,
+        &arrow_array::RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+    )
+    .map_err(|e| Error::DataInvalid {
+        message: format!("failed to apply query-auth column masking: {e}"),
+        source: Some(Box::new(e)),
+    })
+}
+
+fn cast_masked(array: &ArrayRef, to: &arrow_schema::DataType) -> Result<ArrayRef> {
+    if array.data_type() == to {
+        return Ok(array.clone());
+    }
+    arrow_cast::cast(array, to).map_err(|e| {
+        unsupported(format!(
+            "query-auth mask value of type {:?} cannot be cast to column type {to:?}: {e}",
+            array.data_type()
+        ))
+    })
+}
+
+/// Evaluate a string transform row by row. `combine` receives the resolved
+/// inputs (None = SQL NULL) and returns the masked value; a `None` from
+/// `combine` means the transform is malformed for this input arity.
+fn string_mask(
+    batch: &RecordBatch,
+    inputs: &[TransformInput],
+    input_column: &dyn Fn(usize) -> Result<ArrayRef>,
+    combine: impl Fn(&[Option<String>]) -> Option<Option<String>>,
+) -> Result<ArrayRef> {
+    use arrow_array::{Array, StringArray};
+    use std::sync::Arc;
+
+    // Resolve field inputs once, as string arrays (None = literal slot).
+    let resolved: Vec<Option<ArrayRef>> = inputs
+        .iter()
+        .map(|input| match input {
+            TransformInput::Literal(_) => Ok(None),
+            TransformInput::Field(index) => {
+                cast_masked(&input_column(*index)?, &arrow_schema::DataType::Utf8).map(Some)
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut values: Vec<Option<String>> = Vec::with_capacity(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        let row_inputs = inputs
+            .iter()
+            .zip(&resolved)
+            .map(|(input, array)| match (input, array) {
+                (TransformInput::Literal(s), _) => Ok(s.clone()),
+                (TransformInput::Field(_), Some(array)) => {
+                    let strings = array
+                        .as_any()
+                        .downcast_ref::<StringArray>()
+                        .ok_or_else(|| unsupported("mask input is not a string".to_string()))?;
+                    Ok((!strings.is_null(row)).then(|| strings.value(row).to_string()))
+                }
+                (TransformInput::Field(_), None) => unreachable!("field inputs are resolved above"),
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let value = combine(&row_inputs)
+            .ok_or_else(|| unsupported("query-auth string mask is malformed".to_string()))?;
+        values.push(value);
+    }
+    Ok(Arc::new(StringArray::from(values)) as ArrayRef)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::{IntType, VarCharType};
+    use arrow_array::{Int32Array, StringArray};
+    use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+    use std::sync::Arc;
+
+    fn fields() -> Vec<DataField> {
+        vec![
+            DataField::new(0, "id".to_string(), DataType::Int(IntType::new())),
+            DataField::new(
+                1,
+                "name".to_string(),
+                DataType::VarChar(VarCharType::new(255).unwrap()),
+            ),
+        ]
+    }
+
+    fn leaf_json(function: &str, field: &str, literals: &str) -> String {
+        format!(
+            r#"{{"kind":"LEAF","transform":{{"name":"FIELD_REF","fieldRef":{{"index":0,"name":"{field}","type":"INT"}}}},"function":"{function}","literals":{literals}}}"#
+        )
+    }
+
+    fn batch() -> RecordBatch {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, true),
+            ArrowField::new("name", ArrowDataType::Utf8, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![Some(1), Some(2), None, Some(4)])),
+                Arc::new(StringArray::from(vec![
+                    Some("a"),
+                    Some("b"),
+                    Some("c"),
+                    Some("d"),
+                ])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_strict_filter_batch_filters_rows() {
+        let fields = fields();
+        let filters =
+            parse_auth_filters(&[leaf_json("GREATER_THAN", "id", "[1]")], &fields).unwrap();
+        let filtered = strict_filter_batch(&batch(), &filters, &fields, &fields).unwrap();
+        // id > 1 keeps rows 2 and 4; the NULL row is excluded.
+        assert_eq!(filtered.num_rows(), 2);
+    }
+
+    #[test]
+    fn test_strict_filter_matches_java_nan_ordering() {
+        use crate::spec::{DoubleType, PredicateBuilder};
+        use arrow_array::Float64Array;
+        use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+
+        // Java `Double.compare` canonicalizes NaN above every finite value, so
+        // `f < 0` must reject NaN — including a NEGATIVE NaN, which Arrow's
+        // total ordering would otherwise sort below finite values and admit.
+        let fields = vec![DataField::new(
+            0,
+            "f".to_string(),
+            DataType::Double(DoubleType::new()),
+        )];
+        let neg_nan = f64::from_bits(0xFFF8_0000_0000_0000);
+        let batch = RecordBatch::try_new(
+            std::sync::Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                "f",
+                ArrowDataType::Float64,
+                true,
+            )])),
+            vec![std::sync::Arc::new(Float64Array::from(vec![
+                neg_nan,
+                f64::NAN,
+                -1.0,
+                1.0,
+            ]))],
+        )
+        .unwrap();
+
+        let less = PredicateBuilder::new(&fields)
+            .less_than("f", crate::spec::Datum::Double(0.0))
+            .unwrap();
+        let filtered = strict_filter_batch(&batch, &[less], &fields, &fields).unwrap();
+        assert_eq!(
+            filtered.num_rows(),
+            1,
+            "only -1.0 may pass `f < 0`; neither NaN sign may"
+        );
+
+        let greater = PredicateBuilder::new(&fields)
+            .greater_than("f", crate::spec::Datum::Double(0.0))
+            .unwrap();
+        let filtered = strict_filter_batch(&batch, &[greater], &fields, &fields).unwrap();
+        assert_eq!(
+            filtered.num_rows(),
+            3,
+            "both NaNs and 1.0 pass `f > 0` (NaN is greatest, like Java)"
+        );
+    }
+
+    #[test]
+    fn test_strict_filter_not_excludes_nulls() {
+        let fields = fields();
+        // NOT (id = 2): NULL rows must stay excluded (SQL three-valued logic).
+        let json = format!(
+            r#"{{"kind":"COMPOUND","function":"AND","children":[{}]}}"#,
+            leaf_json("NOT_EQUAL", "id", "[2]")
+        );
+        let filters = parse_auth_filters(&[json], &fields).unwrap();
+        let filtered = strict_filter_batch(&batch(), &filters, &fields, &fields).unwrap();
+        assert_eq!(
+            filtered.num_rows(),
+            2,
+            "rows 1 and 4 only, not the NULL row"
+        );
+    }
+
+    /// Java #7034 baseline: filter each supported literal type exactly.
+    #[test]
+    fn test_strict_filter_batch_typed_matrix() {
+        use crate::spec::{BigIntType, BooleanType, DoubleType, FloatType};
+        use arrow_array::{BooleanArray, Float32Array, Float64Array, Int64Array};
+
+        let fields = vec![
+            DataField::new(0, "id".to_string(), DataType::Int(IntType::new())),
+            DataField::new(1, "age".to_string(), DataType::BigInt(BigIntType::new())),
+            DataField::new(2, "salary".to_string(), DataType::Double(DoubleType::new())),
+            DataField::new(
+                3,
+                "is_active".to_string(),
+                DataType::Boolean(BooleanType::new()),
+            ),
+            DataField::new(4, "score".to_string(), DataType::Float(FloatType::new())),
+            DataField::new(
+                5,
+                "name".to_string(),
+                DataType::VarChar(VarCharType::new(255).unwrap()),
+            ),
+        ];
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, true),
+            ArrowField::new("age", ArrowDataType::Int64, true),
+            ArrowField::new("salary", ArrowDataType::Float64, true),
+            ArrowField::new("is_active", ArrowDataType::Boolean, true),
+            ArrowField::new("score", ArrowDataType::Float32, true),
+            ArrowField::new("name", ArrowDataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+                Arc::new(Int64Array::from(vec![25, 30, 35, 28])),
+                Arc::new(Float64Array::from(vec![50000.0, 60000.0, 70000.0, 55000.0])),
+                Arc::new(BooleanArray::from(vec![true, false, true, true])),
+                Arc::new(Float32Array::from(vec![85.5, 90.0, 95.5, 88.0])),
+                Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie", "David"])),
+            ],
+        )
+        .unwrap();
+        fn typed_leaf(function: &str, field: &str, ftype: &str, literals: &str) -> String {
+            format!(
+                r#"{{"kind":"LEAF","transform":{{"name":"FIELD_REF","fieldRef":{{"index":0,"name":"{field}","type":"{ftype}"}}}},"function":"{function}","literals":{literals}}}"#
+            )
+        }
+        // (filter, expected surviving ids) — mirrors Java MockRESTCatalogTest.
+        let cases: Vec<(String, Vec<i32>)> = vec![
+            (typed_leaf("GREATER_THAN", "id", "INT", "[2]"), vec![3, 4]),
+            (
+                typed_leaf("GREATER_OR_EQUAL", "age", "BIGINT", "[30]"),
+                vec![2, 3],
+            ),
+            (
+                typed_leaf("GREATER_THAN", "salary", "DOUBLE", "[55000.0]"),
+                vec![2, 3],
+            ),
+            (
+                typed_leaf("EQUAL", "is_active", "BOOLEAN", "[true]"),
+                vec![1, 3, 4],
+            ),
+            (
+                typed_leaf("GREATER_OR_EQUAL", "score", "FLOAT", "[90.0]"),
+                vec![2, 3],
+            ),
+            (
+                typed_leaf("EQUAL", "name", "STRING", "[\"Alice\"]"),
+                vec![1],
+            ),
+            (
+                // Two predicates ANDed by the grant list semantics.
+                format!(
+                    r#"{{"kind":"COMPOUND","function":"AND","children":[{},{}]}}"#,
+                    typed_leaf("GREATER_OR_EQUAL", "age", "BIGINT", "[30]"),
+                    typed_leaf("EQUAL", "is_active", "BOOLEAN", "[true]")
+                ),
+                vec![3],
+            ),
+        ];
+        for (json, expected) in cases {
+            let filters = parse_auth_filters(std::slice::from_ref(&json), &fields).unwrap();
+            let filtered = strict_filter_batch(&batch, &filters, &fields, &fields).unwrap();
+            let ids = filtered
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .values()
+                .to_vec();
+            assert_eq!(ids, expected, "for {json}");
+        }
+    }
+
+    fn masking(column: &str, json: &str) -> std::collections::HashMap<String, String> {
+        std::collections::HashMap::from([(column.to_string(), json.to_string())])
+    }
+
+    #[test]
+    fn test_reject_mask_reading_another_masked_column() {
+        // `name := UPPER(name)` is the normal self-reference and stays valid.
+        let fields = fields();
+        assert!(parse_column_masking(
+            &masking(
+                "name",
+                r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#
+            ),
+            &fields
+        )
+        .is_ok());
+
+        // But a mask that reads ANOTHER masked column would copy that column's
+        // raw value out (masks read the unmasked batch), defeating its mask.
+        let both = std::collections::HashMap::from([
+            ("id".to_string(), r#"{"name":"NULL"}"#.to_string()),
+            (
+                "name".to_string(),
+                r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#
+                    .to_string(),
+            ),
+        ]);
+        assert!(
+            parse_column_masking(&both, &fields).is_ok(),
+            "unrelated masks are fine"
+        );
+
+        let cross = std::collections::HashMap::from([
+            ("name".to_string(), r#"{"name":"NULL"}"#.to_string()),
+            (
+                "alias".to_string(),
+                r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#
+                    .to_string(),
+            ),
+        ]);
+        let mut fields_with_alias = fields.clone();
+        fields_with_alias.push(DataField::new(
+            2,
+            "alias".to_string(),
+            DataType::VarChar(VarCharType::new(255).unwrap()),
+        ));
+        let Err(err) = parse_column_masking(&cross, &fields_with_alias) else {
+            panic!("a mask reading another masked column must fail closed");
+        };
+        assert!(err.to_string().contains("raw value"), "got: {err}");
+    }
+
+    #[test]
+    fn test_parse_column_masking() {
+        let fields = fields();
+        let masks = parse_column_masking(&masking("name", r#"{"name":"NULL"}"#), &fields).unwrap();
+        assert!(matches!(masks[0].transform, Transform::Null));
+        assert_eq!(masks[0].column, 1);
+
+        let upper = r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#;
+        let masks = parse_column_masking(&masking("name", upper), &fields).unwrap();
+        assert!(matches!(&masks[0].transform, Transform::Upper(inputs) if inputs.len() == 1));
+
+        // Unknown transform / unknown column / bad JSON: all fail closed.
+        for (column, json) in [
+            ("name", r#"{"name":"ROT13"}"#),
+            ("missing", r#"{"name":"NULL"}"#),
+            ("name", "not json"),
+        ] {
+            assert!(parse_column_masking(&masking(column, json), &fields).is_err());
+        }
+    }
+
+    #[test]
+    fn test_mask_batch_null_and_string_transforms() {
+        use arrow_array::Array;
+        let fields = fields();
+
+        // NULL mask: the whole column becomes null.
+        let masks = parse_column_masking(&masking("name", r#"{"name":"NULL"}"#), &fields).unwrap();
+        let masked = mask_batch(&batch(), &masks, &fields, &fields).unwrap();
+        assert_eq!(masked.column(1).null_count(), 4);
+        assert_eq!(masked.column(0).null_count(), 1, "other columns untouched");
+
+        // CONCAT_WS("-", literal, field): "x-a", "x-b", ...
+        let concat =
+            r#"{"name":"CONCAT_WS","inputs":["-","x",{"index":1,"name":"name","type":"STRING"}]}"#;
+        let masks = parse_column_masking(&masking("name", concat), &fields).unwrap();
+        let masked = mask_batch(&batch(), &masks, &fields, &fields).unwrap();
+        let names = masked
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(names.value(0), "x-a");
+
+        // Masked column absent from the batch: fail closed. The caller filters
+        // masks to projected targets, so this means the read cannot enforce the
+        // mask — emitting the column unmasked would leak the raw value.
+        let one_col = batch().project(&[0]).unwrap();
+        let one_field = vec![fields[0].clone()];
+        let masks = parse_column_masking(&masking("name", r#"{"name":"NULL"}"#), &fields).unwrap();
+        let Err(err) = mask_batch(&one_col, &masks, &fields, &one_field) else {
+            panic!("a mask whose target is missing from the read must fail closed");
+        };
+        assert!(err.to_string().contains("cannot be applied"), "got: {err}");
+    }
+
+    #[test]
+    fn test_reject_type_changing_cast_mask() {
+        let fields = fields();
+        // CAST(id AS STRING) on an INT column changes type -> fail closed.
+        let cast =
+            r#"{"name":"CAST","fieldRef":{"index":0,"name":"id","type":"INT"},"type":"STRING"}"#;
+        assert!(parse_column_masking(&masking("id", cast), &fields).is_err());
+        // A string transform on a non-string column also fails closed.
+        let upper = r#"{"name":"UPPER","inputs":[{"index":0,"name":"id","type":"INT"}]}"#;
+        assert!(parse_column_masking(&masking("id", upper), &fields).is_err());
+    }
+
+    #[test]
+    fn test_mask_batch_masks_every_duplicate_target() {
+        use arrow_array::Array;
+        let fields = fields();
+        let masks = parse_column_masking(&masking("name", r#"{"name":"NULL"}"#), &fields).unwrap();
+        // A projection that repeats the masked column: both copies must be masked.
+        let base = batch();
+        let dup = base.project(&[1, 1]).unwrap();
+        let dup_fields = vec![fields[1].clone(), fields[1].clone()];
+        let masked = mask_batch(&dup, &masks, &fields, &dup_fields).unwrap();
+        assert_eq!(masked.column(0).null_count(), 4);
+        assert_eq!(masked.column(1).null_count(), 4);
+    }
+
+    #[test]
+    fn test_grant_authorized_column_scope() {
+        // A grant scoped to a subset is not globally unrestricted and rejects
+        // columns outside the approved set.
+        let grant = QueryAuthGrant::new(Vec::new(), Vec::new(), Some(HashSet::from([0])));
+        assert!(!grant.is_unrestricted());
+        assert!(grant.authorizes_columns([0]));
+        assert!(!grant.authorizes_columns([1]));
+        // `None` (all columns) with no filter/mask is fully unrestricted.
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None);
+        assert!(all.is_unrestricted());
+        assert!(all.authorizes_columns([0, 1, 99]));
+    }
+}

--- a/crates/paimon/src/table/query_auth.rs
+++ b/crates/paimon/src/table/query_auth.rs
@@ -44,33 +44,29 @@ pub(crate) struct QueryAuthGrant {
     authorized: Option<HashSet<usize>>,
     /// Schema this grant's positional filter/mask indices were parsed against.
     /// Enforcing it on a different schema would bind them to other columns.
-    schema_id: Option<i64>,
+    schema_id: i64,
 }
 
 impl QueryAuthGrant {
+    /// `schema_id` binds the grant to the schema its column indices were
+    /// resolved against; it is required so the binding cannot be forgotten.
     pub(crate) fn new(
         filters: Vec<Predicate>,
         masks: Vec<ColumnMask>,
         authorized: Option<HashSet<usize>>,
+        schema_id: i64,
     ) -> Self {
         Self {
             filters,
             masks,
             authorized,
-            schema_id: None,
+            schema_id,
         }
     }
 
-    /// Bind this grant to the schema its indices were resolved against.
-    pub(crate) fn with_schema_id(mut self, schema_id: i64) -> Self {
-        self.schema_id = Some(schema_id);
-        self
-    }
-
-    /// Whether this grant may be enforced against `schema_id`. A grant with no
-    /// binding (test-constructed) matches anything.
+    /// Whether this grant may be enforced against `schema_id`.
     pub(crate) fn matches_schema(&self, schema_id: i64) -> bool {
-        self.schema_id.is_none_or(|bound| bound == schema_id)
+        self.schema_id == schema_id
     }
 
     /// Fully unrestricted: every column approved, no filter, no masking.
@@ -177,6 +173,39 @@ pub(crate) fn unauthorized_column_error(fields: &[DataField], column: usize) -> 
         "query-auth read touches column `{}` outside the authorized set",
         field_name(fields, column)
     ))
+}
+
+/// Table-schema indices a read type touches, rejecting any field that is not a
+/// canonical `(id, name)` pair of `fields`.
+///
+/// Authorization and mask selection resolve columns by id, but the physical read
+/// resolves them by name, so a read type pairing an authorized id with another
+/// column's name would be scoped by id while reading the other column.
+/// `TableRead::new` / `with_read_type` are public, so this is reachable — fail
+/// closed. A field matching neither an id nor a name is a system column (row id,
+/// etc.), which carries no grant scope and maps to no index.
+pub(crate) fn canonical_projection(
+    fields: &[DataField],
+    read_type: &[DataField],
+) -> crate::Result<Vec<usize>> {
+    let mut indices = Vec::with_capacity(read_type.len());
+    for field in read_type {
+        let by_id = fields.iter().position(|s| s.id() == field.id());
+        let by_name = fields.iter().position(|s| s.name() == field.name());
+        match (by_id, by_name) {
+            // Both lookups land on the same schema field.
+            (Some(i), Some(n)) if i == n => indices.push(i),
+            (None, None) => {}
+            _ => {
+                return Err(unsupported(format!(
+                    "query-auth read type field #{} `{}` is not a column of this table",
+                    field.id(),
+                    field.name()
+                )))
+            }
+        }
+    }
+    Ok(indices)
 }
 
 /// Live query-auth scope check shared by the read/scan gates: fail closed when
@@ -1073,12 +1102,12 @@ mod tests {
     fn test_grant_authorized_column_scope() {
         // A grant scoped to a subset is not globally unrestricted and rejects
         // columns outside the approved set.
-        let grant = QueryAuthGrant::new(Vec::new(), Vec::new(), Some(HashSet::from([0])));
+        let grant = QueryAuthGrant::new(Vec::new(), Vec::new(), Some(HashSet::from([0])), 0);
         assert!(!grant.is_unrestricted());
         assert!(grant.authorizes_columns([0]));
         assert!(!grant.authorizes_columns([1]));
         // `None` (all columns) with no filter/mask is fully unrestricted.
-        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None);
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, 0);
         assert!(all.is_unrestricted());
         assert!(all.authorizes_columns([0, 1, 99]));
     }

--- a/crates/paimon/src/table/query_auth.rs
+++ b/crates/paimon/src/table/query_auth.rs
@@ -42,31 +42,49 @@ pub(crate) struct QueryAuthGrant {
     filters: Vec<Predicate>,
     masks: Vec<ColumnMask>,
     authorized: Option<HashSet<usize>>,
-    /// Schema this grant's positional filter/mask indices were parsed against.
-    /// Enforcing it on a different schema would bind them to other columns.
+    /// Where this grant's positional indices are meaningful. The schema id
+    /// alone would not do: it is a per-table counter, so two fresh tables
+    /// both sit at 0.
+    binding: GrantBinding,
+}
+
+/// Identity a grant is bound to.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct GrantBinding {
+    location: String,
+    branch: String,
     schema_id: i64,
 }
 
+impl GrantBinding {
+    pub(crate) fn of(table: &super::Table) -> Self {
+        Self {
+            location: table.location().to_string(),
+            branch: table.branch().to_string(),
+            schema_id: table.schema().id(),
+        }
+    }
+}
+
 impl QueryAuthGrant {
-    /// `schema_id` binds the grant to the schema its column indices were
-    /// resolved against; it is required so the binding cannot be forgotten.
+    /// `binding` is required so it cannot be forgotten.
     pub(crate) fn new(
         filters: Vec<Predicate>,
         masks: Vec<ColumnMask>,
         authorized: Option<HashSet<usize>>,
-        schema_id: i64,
+        binding: GrantBinding,
     ) -> Self {
         Self {
             filters,
             masks,
             authorized,
-            schema_id,
+            binding,
         }
     }
 
-    /// Whether this grant may be enforced against `schema_id`.
-    pub(crate) fn matches_schema(&self, schema_id: i64) -> bool {
-        self.schema_id == schema_id
+    /// Whether this grant may be enforced on `table`.
+    pub(crate) fn matches_table(&self, table: &super::Table) -> bool {
+        self.binding == GrantBinding::of(table)
     }
 
     /// Fully unrestricted: every column approved, no filter, no masking.
@@ -175,15 +193,39 @@ pub(crate) fn unauthorized_column_error(fields: &[DataField], column: usize) -> 
     ))
 }
 
+/// Reserved system fields a read type may project. The reader produces them, so
+/// they are not table columns and carry no grant scope. Both id and name must
+/// match, so a forged field cannot borrow a system id. Mirrors Java
+/// `SpecialFields.SYSTEM_FIELD_NAMES`.
+const RESERVED_SYSTEM_FIELDS: [(i32, &str); 4] = [
+    (crate::spec::ROW_ID_FIELD_ID, crate::spec::ROW_ID_FIELD_NAME),
+    (
+        crate::spec::SEQUENCE_NUMBER_FIELD_ID,
+        crate::spec::SEQUENCE_NUMBER_FIELD_NAME,
+    ),
+    (
+        crate::spec::VALUE_KIND_FIELD_ID,
+        crate::spec::VALUE_KIND_FIELD_NAME,
+    ),
+    (
+        crate::spec::ROW_KIND_FIELD_ID,
+        crate::spec::ROW_KIND_FIELD_NAME,
+    ),
+];
+
+pub(crate) fn is_reserved_system_field(field: &DataField) -> bool {
+    RESERVED_SYSTEM_FIELDS
+        .iter()
+        .any(|(id, name)| *id == field.id() && *name == field.name())
+}
+
 /// Table-schema indices a read type touches, rejecting any field that is not a
 /// canonical `(id, name)` pair of `fields`.
 ///
-/// Authorization and mask selection resolve columns by id, but the physical read
-/// resolves them by name, so a read type pairing an authorized id with another
-/// column's name would be scoped by id while reading the other column.
-/// `TableRead::new` / `with_read_type` are public, so this is reachable — fail
-/// closed. A field matching neither an id nor a name is a system column (row id,
-/// etc.), which carries no grant scope and maps to no index.
+/// Scoping and masking resolve by id while the physical read resolves by name,
+/// so a read type pairing an authorized id with another column's name would be
+/// scoped by id and read by name. `TableRead::new` / `with_read_type` are
+/// public, so this is reachable — fail closed.
 pub(crate) fn canonical_projection(
     fields: &[DataField],
     read_type: &[DataField],
@@ -193,9 +235,12 @@ pub(crate) fn canonical_projection(
         let by_id = fields.iter().position(|s| s.id() == field.id());
         let by_name = fields.iter().position(|s| s.name() == field.name());
         match (by_id, by_name) {
-            // Both lookups land on the same schema field.
             (Some(i), Some(n)) if i == n => indices.push(i),
-            (None, None) => {}
+            // Absent from the schema. Anything but a reserved system field is
+            // a column dropped by schema evolution, which the reader still
+            // resolves by field id in older files and returns raw. Java rejects
+            // it in `TableQueryAuthResult.checkFieldExists`.
+            (None, None) if is_reserved_system_field(field) => {}
             _ => {
                 return Err(unsupported(format!(
                     "query-auth read type field #{} `{}` is not a column of this table",
@@ -1099,15 +1144,57 @@ mod tests {
     }
 
     #[test]
+    fn test_canonical_projection_system_and_dropped_fields() {
+        use crate::spec::{DataType, IntType};
+        let fields = vec![DataField::new(
+            0,
+            "id".to_string(),
+            DataType::Int(IntType::new()),
+        )];
+
+        // Produced by the reader, so it maps to no index and is allowed.
+        let row_id = DataField::new(
+            crate::spec::ROW_ID_FIELD_ID,
+            crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            DataType::Int(IntType::new()),
+        );
+        assert_eq!(
+            canonical_projection(&fields, std::slice::from_ref(&row_id)).unwrap(),
+            Vec::<usize>::new()
+        );
+
+        // Matches neither an id nor a name, but is still readable by field id
+        // from older files — must not pass as a system field.
+        let dropped = DataField::new(7, "dropped".to_string(), DataType::Int(IntType::new()));
+        assert!(
+            canonical_projection(&fields, &[dropped]).is_err(),
+            "a dropped column must not be waved through as a system field"
+        );
+
+        // A system id under another name is not a system field.
+        let forged = DataField::new(
+            crate::spec::ROW_ID_FIELD_ID,
+            "not_row_id".to_string(),
+            DataType::Int(IntType::new()),
+        );
+        assert!(canonical_projection(&fields, &[forged]).is_err());
+    }
+
+    #[test]
     fn test_grant_authorized_column_scope() {
         // A grant scoped to a subset is not globally unrestricted and rejects
         // columns outside the approved set.
-        let grant = QueryAuthGrant::new(Vec::new(), Vec::new(), Some(HashSet::from([0])), 0);
+        let grant = QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+            GrantBinding::default(),
+        );
         assert!(!grant.is_unrestricted());
         assert!(grant.authorizes_columns([0]));
         assert!(!grant.authorizes_columns([1]));
         // `None` (all columns) with no filter/mask is fully unrestricted.
-        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, 0);
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, GrantBinding::default());
         assert!(all.is_unrestricted());
         assert!(all.authorizes_columns([0, 1, 99]));
     }

--- a/crates/paimon/src/table/query_auth.rs
+++ b/crates/paimon/src/table/query_auth.rs
@@ -21,8 +21,8 @@
 //! error, so callers keep the table fail-closed.
 
 use crate::arrow::residual::{
-    boolean_mask_from_predicate, evaluate_column_predicate, literal_scalar_for_arrow_filter,
-    sanitize_filter_mask,
+    boolean_mask_from_predicate, evaluate_column_predicate, evaluate_decimal_leaf,
+    literal_scalar_for_arrow_filter, sanitize_filter_mask,
 };
 use crate::spec::{
     DataField, DataType, Datum, Predicate, PredicateOperator, Transform, TransformInput,
@@ -33,15 +33,19 @@ use arrow_array::{ArrayRef, BooleanArray, Float32Array, Float64Array, RecordBatc
 use std::collections::HashSet;
 use std::sync::Arc;
 
-/// Row filters and column masks the REST server granted the current user for a
-/// specific set of columns. `authorized = None` means all columns were approved
-/// (the request used `select = all`); `Some(set)` scopes the grant to those
+/// Row filters and column masks the REST server granted this user.
+/// `authorized = None` means all columns; `Some(set)` scopes the grant to those
 /// table-schema indices. Only the REST catalog constructs grants.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct QueryAuthGrant {
     filters: Vec<Predicate>,
     masks: Vec<ColumnMask>,
     authorized: Option<HashSet<usize>>,
+    /// System fields the request asked about (`_ROW_ID`, …); they have no table
+    /// index, so `authorized` cannot hold them. `Some(set)` approves exactly
+    /// `set`, so a full projection is not blanket approval. `None` exempts the
+    /// internal raw reads, which run only under an unrestricted grant.
+    authorized_system: Option<HashSet<String>>,
     /// Where this grant's positional indices are meaningful. The schema id
     /// alone would not do: it is a per-table counter, so two fresh tables
     /// both sit at 0.
@@ -51,6 +55,11 @@ pub(crate) struct QueryAuthGrant {
 /// Identity a grant is bound to.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct GrantBinding {
+    /// REST table UUID when available: an identifier or schema id can be reused
+    /// across catalogs or a drop/recreate, a UUID cannot.
+    uuid: Option<String>,
+    /// Catalog identity: two REST aliases can share a location.
+    identifier: String,
     location: String,
     branch: String,
     schema_id: i64,
@@ -59,6 +68,8 @@ pub(crate) struct GrantBinding {
 impl GrantBinding {
     pub(crate) fn of(table: &super::Table) -> Self {
         Self {
+            uuid: table.rest_env().map(|e| e.uuid().to_string()),
+            identifier: table.identifier().full_name(),
             location: table.location().to_string(),
             branch: table.branch().to_string(),
             schema_id: table.schema().id(),
@@ -72,14 +83,49 @@ impl QueryAuthGrant {
         filters: Vec<Predicate>,
         masks: Vec<ColumnMask>,
         authorized: Option<HashSet<usize>>,
+        authorized_system: Option<HashSet<String>>,
         binding: GrantBinding,
     ) -> Self {
         Self {
             filters,
             masks,
             authorized,
+            authorized_system,
             binding,
         }
+    }
+
+    /// Like [`Self::check_system_scope`], for system fields a read path adds on
+    /// top of its read type (the audit schema's `rowkind`).
+    pub(crate) fn check_system_scope_by_name(&self, names: &[&str]) -> Result<()> {
+        let Some(approved) = &self.authorized_system else {
+            return Ok(());
+        };
+        for name in names {
+            if !approved.contains(*name) {
+                return Err(unsupported(format!(
+                    "query-auth read emits system column `{name}` outside the authorized set"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Fail closed when `read_type` projects a system field outside this grant's
+    /// scope. Scoped by name: system fields have no table index.
+    pub(crate) fn check_system_scope(&self, read_type: &[DataField]) -> Result<()> {
+        let Some(approved) = &self.authorized_system else {
+            return Ok(());
+        };
+        for field in read_type.iter().filter(|f| is_reserved_system_field(f)) {
+            if !approved.contains(field.name()) {
+                return Err(unsupported(format!(
+                    "query-auth read projects system column `{}` outside the authorized set",
+                    field.name()
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// Whether this grant may be enforced on `table`.
@@ -92,10 +138,9 @@ impl QueryAuthGrant {
         self.authorized.is_none() && self.filters.is_empty() && self.masks.is_empty()
     }
 
-    /// Whether the SERVER restricted this user (a row filter or a column mask),
-    /// as opposed to the client merely scoping its own projection. Statistics
-    /// suppression, split transport and the incremental-read gate key off this:
-    /// a column-scoped grant with no filter and no mask distorts nothing.
+    /// Whether the SERVER restricted this user, as opposed to the client merely
+    /// scoping its own projection. Statistics suppression and the historical /
+    /// scan-all gates key off this: a column scope distorts nothing.
     pub(crate) fn has_server_restrictions(&self) -> bool {
         !self.filters.is_empty() || !self.masks.is_empty()
     }
@@ -141,10 +186,9 @@ impl QueryAuthGrant {
         columns.into_iter().find(|c| !self.authorizes_columns([*c]))
     }
 
-    /// Field IDs the grant must physically read (row-filter columns, mask
-    /// targets, and mask inputs). Scan projection planning must include these so
-    /// data-evolution column-slice pruning does not drop files that hold them
-    /// (an omitted column would read as null and wrongly satisfy `IS_NULL`).
+    /// Field IDs the grant must physically read (filter columns, mask targets
+    /// and inputs). Projection planning must include them, or column-slice
+    /// pruning drops the file and the column reads as null.
     pub(crate) fn read_field_ids(&self, fields: &[DataField]) -> Vec<i32> {
         let mut indices = HashSet::new();
         for filter in &self.filters {
@@ -194,9 +238,8 @@ pub(crate) fn unauthorized_column_error(fields: &[DataField], column: usize) -> 
 }
 
 /// Reserved system fields a read type may project. The reader produces them, so
-/// they are not table columns and carry no grant scope. Both id and name must
-/// match, so a forged field cannot borrow a system id. Mirrors Java
-/// `SpecialFields.SYSTEM_FIELD_NAMES`.
+/// they carry no grant scope. Both id and name must match, so a forged field
+/// cannot borrow a system id. Mirrors Java `SpecialFields.SYSTEM_FIELD_NAMES`.
 const RESERVED_SYSTEM_FIELDS: [(i32, &str); 4] = [
     (crate::spec::ROW_ID_FIELD_ID, crate::spec::ROW_ID_FIELD_NAME),
     (
@@ -213,6 +256,10 @@ const RESERVED_SYSTEM_FIELDS: [(i32, &str); 4] = [
     ),
 ];
 
+pub(crate) fn is_reserved_system_field_name(name: &str) -> bool {
+    RESERVED_SYSTEM_FIELDS.iter().any(|(_, n)| *n == name)
+}
+
 pub(crate) fn is_reserved_system_field(field: &DataField) -> bool {
     RESERVED_SYSTEM_FIELDS
         .iter()
@@ -220,12 +267,9 @@ pub(crate) fn is_reserved_system_field(field: &DataField) -> bool {
 }
 
 /// Table-schema indices a read type touches, rejecting any field that is not a
-/// canonical `(id, name)` pair of `fields`.
-///
-/// Scoping and masking resolve by id while the physical read resolves by name,
-/// so a read type pairing an authorized id with another column's name would be
-/// scoped by id and read by name. `TableRead::new` / `with_read_type` are
-/// public, so this is reachable — fail closed.
+/// canonical `(id, name)` pair of `fields`. Scoping resolves by id and the
+/// physical read by name, so a mismatched pair would be scoped as one column
+/// and read as another — reachable, since `TableRead::new` is public.
 pub(crate) fn canonical_projection(
     fields: &[DataField],
     read_type: &[DataField],
@@ -236,10 +280,9 @@ pub(crate) fn canonical_projection(
         let by_name = fields.iter().position(|s| s.name() == field.name());
         match (by_id, by_name) {
             (Some(i), Some(n)) if i == n => indices.push(i),
-            // Absent from the schema. Anything but a reserved system field is
-            // a column dropped by schema evolution, which the reader still
-            // resolves by field id in older files and returns raw. Java rejects
-            // it in `TableQueryAuthResult.checkFieldExists`.
+            // Absent from the schema. Anything but a system field is a dropped
+            // column, which the reader still resolves by id in older files.
+            // Java rejects it in `TableQueryAuthResult.checkFieldExists`.
             (None, None) if is_reserved_system_field(field) => {}
             _ => {
                 return Err(unsupported(format!(
@@ -253,10 +296,73 @@ pub(crate) fn canonical_projection(
     Ok(indices)
 }
 
-/// Live query-auth scope check shared by the read/scan gates: fail closed when
-/// the caller filter references a masked column (pruning on its raw value would
-/// leak it) or when the projection/filter touches a column outside the grant's
-/// authorized scope. `projected = None` means all columns.
+/// Names of the reserved system fields a read projects, plus any its filter
+/// references. `filter_system_names` must be captured before row-id extraction
+/// rewrites the predicates; `slices_by_row_id` covers a row-range slice, which
+/// selects by `_ROW_ID` with no predicate at all.
+pub(crate) fn projected_system_field_names(
+    read_type: Option<&[DataField]>,
+    filter_system_names: &HashSet<String>,
+    slices_by_row_id: bool,
+) -> Vec<String> {
+    let mut names: HashSet<String> = read_type
+        .map(|fields| {
+            fields
+                .iter()
+                .filter(|f| is_reserved_system_field(f))
+                .map(|f| f.name().to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+    names.extend(filter_system_names.iter().cloned());
+    if slices_by_row_id {
+        names.insert(crate::spec::ROW_ID_FIELD_NAME.to_string());
+    }
+    let mut names: Vec<String> = names.into_iter().collect();
+    names.sort();
+    names
+}
+
+/// Everything a read must satisfy to run under `grant`, in one place, so a
+/// check cannot be added to one gate and forgotten in another. Returns the read
+/// type's table-schema indices, which callers need anyway.
+///
+/// `implicit_system_fields` are system columns the path emits on top of
+/// `read_type` (the audit schema prepends `rowkind`), so they never reached the
+/// projection or the auth request.
+pub(crate) fn authorize_read(
+    grant: &QueryAuthGrant,
+    table: &super::Table,
+    read_type: &[DataField],
+    predicates: &[Predicate],
+    implicit_system_fields: &[&str],
+) -> crate::Result<Vec<usize>> {
+    // The grant's positional indices only mean anything on the table it was
+    // issued for; `Table::authorize_rewrite_splits` is public, so a grant can
+    // arrive on another table's splits.
+    if !grant.matches_table(table) {
+        return Err(unsupported(
+            "a query-auth grant issued for a different table or schema cannot be \
+             enforced here; re-plan the scan"
+                .to_string(),
+        ));
+    }
+    grant.check_system_scope(read_type)?;
+    grant.check_system_scope_by_name(implicit_system_fields)?;
+
+    let fields = table.schema().fields();
+    let projected = canonical_projection(fields, read_type)?;
+    let mut filter_columns = HashSet::new();
+    for predicate in predicates {
+        predicate.collect_leaf_field_indices(&mut filter_columns);
+    }
+    scope_check(grant, fields, &filter_columns, Some(projected.clone()))?;
+    Ok(projected)
+}
+
+/// Scope check shared by the read/scan gates: fail closed when the caller filter
+/// references a masked column (pruning on its raw value would leak it) or
+/// touches one outside the grant. `projected = None` means all columns.
 pub(crate) fn scope_check(
     grant: &QueryAuthGrant,
     fields: &[DataField],
@@ -288,17 +394,36 @@ pub(crate) fn parse_auth_filters(
 ) -> Result<Vec<Predicate>> {
     filters
         .iter()
-        .filter(|f| !f.trim().is_empty())
-        .map(|f| Predicate::from_rest_json(f, fields))
+        // Java skips only length-0 entries (`StringUtils.isEmpty`). Whitespace
+        // is invalid JSON: dropping it could leave a grant with no filter.
+        .filter(|f| !f.is_empty())
+        .map(|f| {
+            Predicate::from_rest_json(f, fields).map_err(|e| {
+                // A system column has no position in the table schema, so a rule
+                // on one cannot be bound. Say that, not "malformed filter".
+                match RESERVED_SYSTEM_FIELDS
+                    .iter()
+                    .map(|(_, name)| *name)
+                    .find(|name| f.contains(name))
+                {
+                    Some(name) => Error::ConfigInvalid {
+                        message: format!(
+                            "a query-auth row filter on the system column `{name}` is not \
+                             supported"
+                        ),
+                    },
+                    None => e,
+                }
+            })
+        })
         .collect()
 }
 
 // ==================== Exact evaluation ====================
 
-/// Exactly evaluate the ANDed `predicates` against `batch` (whose columns
-/// correspond 1:1 to `batch_fields`; leaf indices refer to `schema_fields`)
-/// and drop non-matching rows. Unlike the pruning evaluators, anything that
-/// cannot be evaluated is an error — a security filter must not fall open.
+/// Evaluate the ANDed `predicates` against `batch` (columns 1:1 with
+/// `batch_fields`; leaf indices into `schema_fields`) and drop non-matching
+/// rows. Unlike the pruning evaluators, anything unevaluable is an error.
 pub(crate) fn strict_filter_batch(
     batch: &RecordBatch,
     predicates: &[Predicate],
@@ -366,12 +491,9 @@ fn strict_mask(
 
 /// Replace every NaN in a float column with the canonical (positive) NaN.
 ///
-/// Arrow's comparison kernels use a total ordering in which a NEGATIVE NaN sorts
-/// below every finite value, so an auth filter like `f < 0` would admit a
-/// negative-NaN row. Java canonicalizes NaN in `Float`/`Double.compare`, making
-/// every NaN greater than all finite values, so the row is rejected. Applied
-/// only to authorization filters — ordinary query pushdown keeps Arrow
-/// semantics. Signed zero already agrees with Java and is left alone.
+/// Arrow sorts a NEGATIVE NaN below every finite value, so `f < 0` would admit
+/// it, while Java's `Float.compare` makes every NaN the greatest. Authorization
+/// filters only; ordinary pushdown keeps Arrow semantics.
 fn canonicalize_nan(column: &ArrayRef) -> ArrayRef {
     match column.data_type() {
         arrow_schema::DataType::Float32 => {
@@ -433,6 +555,14 @@ fn strict_leaf_mask(
     op: PredicateOperator,
     literals: &[Datum],
 ) -> Result<BooleanArray> {
+    // Decimals compare by value across scales, which no Arrow scalar expresses,
+    // so without this every decimal policy would error. The exact evaluator
+    // keeps nulls, so Kleene combination is unchanged.
+    if matches!(column.data_type(), arrow_schema::DataType::Decimal128(_, _))
+        && !matches!(op, PredicateOperator::IsNull | PredicateOperator::IsNotNull)
+    {
+        return kleene(evaluate_decimal_leaf(column, op, literals));
+    }
     let scalar = |literal: &Datum| -> Result<arrow_array::Scalar<ArrayRef>> {
         literal_scalar_for_arrow_filter(literal, data_type)?.ok_or_else(|| {
             unsupported(format!(
@@ -483,6 +613,13 @@ fn strict_leaf_mask(
             })?;
             kleene(evaluate_column_predicate(column, &scalar(literal)?, op))
         }
+        // Array predicates arrived after this filter was written. A strict
+        // filter must not silently pass rows it cannot evaluate.
+        PredicateOperator::ArrayContains
+        | PredicateOperator::ArraysOverlap
+        | PredicateOperator::ArrayContainsAll => Err(unsupported(format!(
+            "query-auth filter operator {op:?} is not supported"
+        ))),
         PredicateOperator::Between | PredicateOperator::NotBetween => {
             let (Some(low), Some(high)) = (literals.first(), literals.get(1)) else {
                 return Err(unsupported(
@@ -506,13 +643,6 @@ fn strict_leaf_mask(
                 Ok(between)
             }
         }
-        // A server filter over an array column has no raw-row equivalent here;
-        // refuse rather than let the rows through unfiltered.
-        PredicateOperator::ArrayContains
-        | PredicateOperator::ArraysOverlap
-        | PredicateOperator::ArrayContainsAll => Err(unsupported(format!(
-            "query-auth row filter uses the unsupported operator {op:?}"
-        ))),
     }
 }
 
@@ -542,13 +672,21 @@ pub(crate) fn parse_column_masking(
         let target = fields
             .iter()
             .position(|f| f.name() == column)
-            .ok_or_else(|| mask_err(format!("unknown field `{column}`")))?;
+            .ok_or_else(|| {
+                if is_reserved_system_field_name(column) {
+                    // Masking is defined against a table column and a system
+                    // column has none, so say that, not "unknown column".
+                    mask_err(format!(
+                        "masking the system column `{column}` is not supported"
+                    ))
+                } else {
+                    mask_err(format!("unknown field `{column}`"))
+                }
+            })?;
         let transform = Transform::from_rest_json(json, fields)?;
-        // The masked value replaces the column in place, so its type must match
-        // the column's; a type-changing transform (e.g. `CAST(id AS STRING)` on
-        // an INT column) cannot be represented and must fail closed rather than
-        // be cast back to the raw type. Types are compared via their arrow
-        // representation (nullability-agnostic).
+        // The masked value replaces the column in place, so a type-changing
+        // transform (`CAST(id AS STRING)` on an INT column) cannot be
+        // represented. Compared via the arrow type (nullability-agnostic).
         if let Some(out) = mask_output_type(&transform, fields) {
             let target_type = crate::arrow::paimon_type_to_arrow(fields[target].data_type())?;
             if out != target_type {
@@ -573,10 +711,9 @@ pub(crate) fn parse_column_masking(
     // Deterministic order regardless of map iteration.
     masks.sort_by_key(|m| m.column);
 
-    // Masks read their inputs from the RAW batch (like Java), so one mask that
-    // references ANOTHER mask's target would copy that column's unmasked value
-    // into its own output — defeating the second mask. Referencing your own
-    // target is the normal case (`name := UPPER(name)`) and stays valid.
+    // Masks read their inputs from the RAW batch (like Java), so a mask
+    // referencing ANOTHER mask's target would copy its unmasked value out.
+    // Referencing your own target (`name := UPPER(name)`) stays valid.
     let targets: HashSet<usize> = masks.iter().map(|m| m.column).collect();
     for mask in &masks {
         let mut inputs = HashSet::new();
@@ -659,10 +796,9 @@ pub(crate) fn mask_batch(
                 "query-auth mask references unknown field #{schema_index}"
             ))
         })?;
-        // Match on field id alone: the read type may carry the column under a
-        // different name (projection aliasing, or a renamed column read from an
-        // older file schema). Also matching the name would silently find no
-        // position and skip the mask, emitting the raw value.
+        // By field id alone: the read type may carry the column under another
+        // name (aliasing, or a rename seen from an older file schema), and
+        // matching the name too would skip the mask and emit the raw value.
         Ok(batch_fields
             .iter()
             .enumerate()
@@ -696,7 +832,11 @@ pub(crate) fn mask_batch(
             Transform::FieldRef(index) => input_column(*index)?,
             Transform::Cast(index, to) => {
                 let to_arrow = crate::arrow::paimon_type_to_arrow(to)?;
-                cast_masked(&input_column(*index)?, &to_arrow)?
+                let cast = cast_masked(&input_column(*index)?, &to_arrow)?;
+                // Arrow erases the logical width — VARCHAR(3) and VARCHAR(255)
+                // are both `Utf8` — so a narrowing mask would return the value in
+                // full. Apply the logical part, as Java does.
+                apply_logical_cast(&cast, to)?
             }
             Transform::Upper(inputs) => string_mask(batch, inputs, &input_column, |v| {
                 Some(v.first()?.as_ref().map(|s| s.to_uppercase()))
@@ -738,6 +878,74 @@ pub(crate) fn mask_batch(
         message: format!("failed to apply query-auth column masking: {e}"),
         source: Some(Box::new(e)),
     })
+}
+
+/// Apply the part of a cast Arrow's physical types cannot express: the declared
+/// width of CHAR/VARCHAR and BINARY/VARBINARY. Mirrors Java
+/// `BinaryStringUtils` — truncate when longer, pad the fixed-width forms when
+/// shorter. A width the mask cannot enforce must not pass silently.
+fn apply_logical_cast(array: &ArrayRef, to: &crate::spec::DataType) -> Result<ArrayRef> {
+    use crate::spec::DataType as P;
+    match to {
+        P::VarChar(t) => truncate_strings(array, t.length() as usize, false),
+        P::Char(t) => truncate_strings(array, t.length(), true),
+        P::VarBinary(t) => truncate_bytes(array, t.length() as usize, false),
+        P::Binary(t) => truncate_bytes(array, t.length(), true),
+        _ => Ok(array.clone()),
+    }
+}
+
+fn truncate_strings(array: &ArrayRef, length: usize, pad: bool) -> Result<ArrayRef> {
+    use arrow_array::{Array, StringArray};
+    let Some(strings) = array.as_any().downcast_ref::<StringArray>() else {
+        return Ok(array.clone());
+    };
+    let out: StringArray = (0..strings.len())
+        .map(|i| {
+            if strings.is_null(i) {
+                return None;
+            }
+            let value = strings.value(i);
+            // By CHARACTERS, not bytes: Java counts `numChars`.
+            let chars = value.chars().count();
+            Some(if chars > length {
+                value.chars().take(length).collect::<String>()
+            } else if pad && chars < length {
+                format!("{value}{}", " ".repeat(length - chars))
+            } else {
+                value.to_string()
+            })
+        })
+        .collect();
+    Ok(Arc::new(out))
+}
+
+fn truncate_bytes(array: &ArrayRef, length: usize, pad: bool) -> Result<ArrayRef> {
+    use arrow_array::{Array, BinaryArray};
+    let Some(bytes) = array.as_any().downcast_ref::<BinaryArray>() else {
+        return Ok(array.clone());
+    };
+    let owned: Vec<Option<Vec<u8>>> = (0..bytes.len())
+        .map(|i| {
+            if bytes.is_null(i) {
+                return None;
+            }
+            let value = bytes.value(i);
+            Some(if value.len() > length || pad {
+                let mut v = value.to_vec();
+                v.resize(length, 0);
+                v
+            } else {
+                value.to_vec()
+            })
+        })
+        .collect();
+    let out: BinaryArray = owned
+        .iter()
+        .map(|v| v.as_deref())
+        .collect::<Vec<_>>()
+        .into();
+    Ok(Arc::new(out))
 }
 
 fn cast_masked(array: &ArrayRef, to: &arrow_schema::DataType) -> Result<ArrayRef> {
@@ -801,6 +1009,34 @@ fn string_mask(
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn test_a_system_column_policy_says_why_it_is_refused() {
+        let fields = vec![DataField::new(
+            0,
+            "id".to_string(),
+            crate::spec::DataType::Int(crate::spec::IntType::new()),
+        )];
+
+        let mask = std::collections::HashMap::from([(
+            crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            "{}".to_string(),
+        )]);
+        let err = parse_column_masking(&mask, &fields)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("system column"), "{err}");
+        assert!(!err.contains("unknown field"), "{err}");
+
+        let filter = vec![format!(
+            r#"{{"field":"{}","type":"leaf"}}"#,
+            crate::spec::ROW_ID_FIELD_NAME
+        )];
+        let err = parse_auth_filters(&filter, &fields)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("system column"), "{err}");
+    }
     use super::*;
     use crate::spec::{IntType, VarCharType};
     use arrow_array::{Int32Array, StringArray};
@@ -1090,6 +1326,46 @@ mod tests {
     }
 
     #[test]
+    fn test_a_narrowing_cast_mask_truncates_logically() {
+        use arrow_array::Array;
+        let fields = vec![
+            DataField::new(0, "id".to_string(), DataType::Int(IntType::new())),
+            DataField::new(
+                1,
+                "secret".to_string(),
+                DataType::VarChar(VarCharType::new(255).unwrap()),
+            ),
+        ];
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, true),
+            ArrowField::new("secret", ArrowDataType::Utf8, true),
+        ]));
+        let b = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![Some(1)])),
+                Arc::new(StringArray::from(vec![Some("supersecret")])),
+            ],
+        )
+        .unwrap();
+
+        // 服务端策略:CAST(secret AS VARCHAR(3)) —— 应只留 "sup"
+        let json = r#"{"name":"CAST","type":"VARCHAR(3)","fieldRef":{"index":1,"name":"secret","type":"VARCHAR(255)"}}"#;
+        match parse_column_masking(&masking("secret", json), &fields) {
+            Ok(masks) => {
+                let masked = mask_batch(&b, &masks, &fields, &fields).unwrap();
+                let v = masked
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .unwrap();
+                println!("PROBE 掩码后 = {:?}  (期望 \"sup\")", v.value(0));
+            }
+            Err(e) => println!("PROBE 解析失败: {e}"),
+        }
+    }
+
+    #[test]
     fn test_mask_batch_null_and_string_transforms() {
         use arrow_array::Array;
         let fields = fields();
@@ -1151,6 +1427,134 @@ mod tests {
     }
 
     #[test]
+    fn test_implicit_system_fields_are_scope_checked() {
+        // The audit schema prepends `rowkind` (and may prepend
+        // `_SEQUENCE_NUMBER`) on top of the read type, so neither reaches the
+        // auth request via the projection and both need a by-name check.
+        let grant = QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+            Some(HashSet::from(
+                [crate::spec::ROW_KIND_FIELD_NAME.to_string()],
+            )),
+            GrantBinding::default(),
+        );
+        assert!(grant
+            .check_system_scope_by_name(&[crate::spec::ROW_KIND_FIELD_NAME])
+            .is_ok());
+        assert!(grant
+            .check_system_scope_by_name(&[
+                crate::spec::ROW_KIND_FIELD_NAME,
+                crate::spec::SEQUENCE_NUMBER_FIELD_NAME,
+            ])
+            .is_err());
+        // An unscoped grant covers everything.
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, None, GrantBinding::default());
+        assert!(all
+            .check_system_scope_by_name(&[crate::spec::SEQUENCE_NUMBER_FIELD_NAME])
+            .is_ok());
+    }
+
+    #[test]
+    fn test_whitespace_only_filter_fails_closed() {
+        use crate::spec::{DataType, IntType};
+        let fields = vec![DataField::new(
+            0,
+            "id".to_string(),
+            DataType::Int(IntType::new()),
+        )];
+        // Java skips only length-0 entries, so " " reaches the parser and throws.
+        // Dropping it here would leave a grant with no filter at all.
+        assert!(parse_auth_filters(&[" ".to_string()], &fields).is_err());
+        assert!(parse_auth_filters(&["\n".to_string()], &fields).is_err());
+        // A genuinely empty entry is still skipped (Java parity).
+        assert_eq!(
+            parse_auth_filters(&[String::new()], &fields).unwrap().len(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_system_scope_does_not_make_a_grant_restricted() {
+        // `is_unrestricted` answers whether the SERVER restricted anything. The
+        // system scope answers a different question, and letting it gate this
+        // made every write and build path on a query-auth table fail.
+        let scoped_system = QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            None,
+            Some(HashSet::new()),
+            GrantBinding::default(),
+        );
+        assert!(
+            scoped_system.is_unrestricted(),
+            "an empty system scope with no rules is still unrestricted"
+        );
+        assert!(!scoped_system.has_server_restrictions());
+
+        // Internal raw reads carry no system scoping at all.
+        let internal =
+            QueryAuthGrant::new(Vec::new(), Vec::new(), None, None, GrantBinding::default());
+        assert!(internal.is_unrestricted());
+    }
+
+    #[test]
+    fn test_full_projection_is_not_blanket_system_approval() {
+        use crate::spec::{DataType, IntType};
+        // `select = None` means "every table column", never "every reserved
+        // system field": the request only carries the system names the read
+        // needs, so anything else was never shown to the server.
+        let grant = QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            None,
+            Some(HashSet::new()),
+            GrantBinding::default(),
+        );
+        let row_id = DataField::new(
+            crate::spec::ROW_ID_FIELD_ID,
+            crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            DataType::Int(IntType::new()),
+        );
+        assert!(grant.check_system_scope(&[row_id]).is_err());
+        assert!(grant
+            .check_system_scope_by_name(&[crate::spec::ROW_KIND_FIELD_NAME])
+            .is_err());
+    }
+
+    #[test]
+    fn test_system_field_scope_is_enforced_by_name() {
+        use crate::spec::{DataType, IntType};
+        let row_id = DataField::new(
+            crate::spec::ROW_ID_FIELD_ID,
+            crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            DataType::Int(IntType::new()),
+        );
+        let seq = DataField::new(
+            crate::spec::SEQUENCE_NUMBER_FIELD_ID,
+            crate::spec::SEQUENCE_NUMBER_FIELD_NAME.to_string(),
+            DataType::Int(IntType::new()),
+        );
+        // Authorized for _ROW_ID only: system fields have no table index, so the
+        // positional scope cannot cover them and they need their own check.
+        let grant = QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+            Some(HashSet::from([crate::spec::ROW_ID_FIELD_NAME.to_string()])),
+            GrantBinding::default(),
+        );
+        assert!(grant
+            .check_system_scope(std::slice::from_ref(&row_id))
+            .is_ok());
+        assert!(grant.check_system_scope(&[seq]).is_err());
+        // An unscoped grant covers everything.
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, None, GrantBinding::default());
+        assert!(all.check_system_scope(&[row_id]).is_ok());
+    }
+
+    #[test]
     fn test_canonical_projection_system_and_dropped_fields() {
         use crate::spec::{DataType, IntType};
         let fields = vec![DataField::new(
@@ -1195,13 +1599,14 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            None,
             GrantBinding::default(),
         );
         assert!(!grant.is_unrestricted());
         assert!(grant.authorizes_columns([0]));
         assert!(!grant.authorizes_columns([1]));
         // `None` (all columns) with no filter/mask is fully unrestricted.
-        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, GrantBinding::default());
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, None, GrantBinding::default());
         assert!(all.is_unrestricted());
         assert!(all.authorizes_columns([0, 1, 99]));
     }

--- a/crates/paimon/src/table/query_auth.rs
+++ b/crates/paimon/src/table/query_auth.rs
@@ -42,31 +42,49 @@ pub(crate) struct QueryAuthGrant {
     filters: Vec<Predicate>,
     masks: Vec<ColumnMask>,
     authorized: Option<HashSet<usize>>,
-    /// Schema this grant's positional filter/mask indices were parsed against.
-    /// Enforcing it on a different schema would bind them to other columns.
+    /// Where this grant's positional indices are meaningful. The schema id
+    /// alone would not do: it is a per-table counter, so two fresh tables
+    /// both sit at 0.
+    binding: GrantBinding,
+}
+
+/// Identity a grant is bound to.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct GrantBinding {
+    location: String,
+    branch: String,
     schema_id: i64,
 }
 
+impl GrantBinding {
+    pub(crate) fn of(table: &super::Table) -> Self {
+        Self {
+            location: table.location().to_string(),
+            branch: table.branch().to_string(),
+            schema_id: table.schema().id(),
+        }
+    }
+}
+
 impl QueryAuthGrant {
-    /// `schema_id` binds the grant to the schema its column indices were
-    /// resolved against; it is required so the binding cannot be forgotten.
+    /// `binding` is required so it cannot be forgotten.
     pub(crate) fn new(
         filters: Vec<Predicate>,
         masks: Vec<ColumnMask>,
         authorized: Option<HashSet<usize>>,
-        schema_id: i64,
+        binding: GrantBinding,
     ) -> Self {
         Self {
             filters,
             masks,
             authorized,
-            schema_id,
+            binding,
         }
     }
 
-    /// Whether this grant may be enforced against `schema_id`.
-    pub(crate) fn matches_schema(&self, schema_id: i64) -> bool {
-        self.schema_id == schema_id
+    /// Whether this grant may be enforced on `table`.
+    pub(crate) fn matches_table(&self, table: &super::Table) -> bool {
+        self.binding == GrantBinding::of(table)
     }
 
     /// Fully unrestricted: every column approved, no filter, no masking.
@@ -175,15 +193,39 @@ pub(crate) fn unauthorized_column_error(fields: &[DataField], column: usize) -> 
     ))
 }
 
+/// Reserved system fields a read type may project. The reader produces them, so
+/// they are not table columns and carry no grant scope. Both id and name must
+/// match, so a forged field cannot borrow a system id. Mirrors Java
+/// `SpecialFields.SYSTEM_FIELD_NAMES`.
+const RESERVED_SYSTEM_FIELDS: [(i32, &str); 4] = [
+    (crate::spec::ROW_ID_FIELD_ID, crate::spec::ROW_ID_FIELD_NAME),
+    (
+        crate::spec::SEQUENCE_NUMBER_FIELD_ID,
+        crate::spec::SEQUENCE_NUMBER_FIELD_NAME,
+    ),
+    (
+        crate::spec::VALUE_KIND_FIELD_ID,
+        crate::spec::VALUE_KIND_FIELD_NAME,
+    ),
+    (
+        crate::spec::ROW_KIND_FIELD_ID,
+        crate::spec::ROW_KIND_FIELD_NAME,
+    ),
+];
+
+pub(crate) fn is_reserved_system_field(field: &DataField) -> bool {
+    RESERVED_SYSTEM_FIELDS
+        .iter()
+        .any(|(id, name)| *id == field.id() && *name == field.name())
+}
+
 /// Table-schema indices a read type touches, rejecting any field that is not a
 /// canonical `(id, name)` pair of `fields`.
 ///
-/// Authorization and mask selection resolve columns by id, but the physical read
-/// resolves them by name, so a read type pairing an authorized id with another
-/// column's name would be scoped by id while reading the other column.
-/// `TableRead::new` / `with_read_type` are public, so this is reachable — fail
-/// closed. A field matching neither an id nor a name is a system column (row id,
-/// etc.), which carries no grant scope and maps to no index.
+/// Scoping and masking resolve by id while the physical read resolves by name,
+/// so a read type pairing an authorized id with another column's name would be
+/// scoped by id and read by name. `TableRead::new` / `with_read_type` are
+/// public, so this is reachable — fail closed.
 pub(crate) fn canonical_projection(
     fields: &[DataField],
     read_type: &[DataField],
@@ -193,9 +235,12 @@ pub(crate) fn canonical_projection(
         let by_id = fields.iter().position(|s| s.id() == field.id());
         let by_name = fields.iter().position(|s| s.name() == field.name());
         match (by_id, by_name) {
-            // Both lookups land on the same schema field.
             (Some(i), Some(n)) if i == n => indices.push(i),
-            (None, None) => {}
+            // Absent from the schema. Anything but a reserved system field is
+            // a column dropped by schema evolution, which the reader still
+            // resolves by field id in older files and returns raw. Java rejects
+            // it in `TableQueryAuthResult.checkFieldExists`.
+            (None, None) if is_reserved_system_field(field) => {}
             _ => {
                 return Err(unsupported(format!(
                     "query-auth read type field #{} `{}` is not a column of this table",
@@ -1106,15 +1151,57 @@ mod tests {
     }
 
     #[test]
+    fn test_canonical_projection_system_and_dropped_fields() {
+        use crate::spec::{DataType, IntType};
+        let fields = vec![DataField::new(
+            0,
+            "id".to_string(),
+            DataType::Int(IntType::new()),
+        )];
+
+        // Produced by the reader, so it maps to no index and is allowed.
+        let row_id = DataField::new(
+            crate::spec::ROW_ID_FIELD_ID,
+            crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            DataType::Int(IntType::new()),
+        );
+        assert_eq!(
+            canonical_projection(&fields, std::slice::from_ref(&row_id)).unwrap(),
+            Vec::<usize>::new()
+        );
+
+        // Matches neither an id nor a name, but is still readable by field id
+        // from older files — must not pass as a system field.
+        let dropped = DataField::new(7, "dropped".to_string(), DataType::Int(IntType::new()));
+        assert!(
+            canonical_projection(&fields, &[dropped]).is_err(),
+            "a dropped column must not be waved through as a system field"
+        );
+
+        // A system id under another name is not a system field.
+        let forged = DataField::new(
+            crate::spec::ROW_ID_FIELD_ID,
+            "not_row_id".to_string(),
+            DataType::Int(IntType::new()),
+        );
+        assert!(canonical_projection(&fields, &[forged]).is_err());
+    }
+
+    #[test]
     fn test_grant_authorized_column_scope() {
         // A grant scoped to a subset is not globally unrestricted and rejects
         // columns outside the approved set.
-        let grant = QueryAuthGrant::new(Vec::new(), Vec::new(), Some(HashSet::from([0])), 0);
+        let grant = QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+            GrantBinding::default(),
+        );
         assert!(!grant.is_unrestricted());
         assert!(grant.authorizes_columns([0]));
         assert!(!grant.authorizes_columns([1]));
         // `None` (all columns) with no filter/mask is fully unrestricted.
-        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, 0);
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, GrantBinding::default());
         assert!(all.is_unrestricted());
         assert!(all.authorizes_columns([0, 1, 99]));
     }

--- a/crates/paimon/src/table/query_auth.rs
+++ b/crates/paimon/src/table/query_auth.rs
@@ -44,33 +44,29 @@ pub(crate) struct QueryAuthGrant {
     authorized: Option<HashSet<usize>>,
     /// Schema this grant's positional filter/mask indices were parsed against.
     /// Enforcing it on a different schema would bind them to other columns.
-    schema_id: Option<i64>,
+    schema_id: i64,
 }
 
 impl QueryAuthGrant {
+    /// `schema_id` binds the grant to the schema its column indices were
+    /// resolved against; it is required so the binding cannot be forgotten.
     pub(crate) fn new(
         filters: Vec<Predicate>,
         masks: Vec<ColumnMask>,
         authorized: Option<HashSet<usize>>,
+        schema_id: i64,
     ) -> Self {
         Self {
             filters,
             masks,
             authorized,
-            schema_id: None,
+            schema_id,
         }
     }
 
-    /// Bind this grant to the schema its indices were resolved against.
-    pub(crate) fn with_schema_id(mut self, schema_id: i64) -> Self {
-        self.schema_id = Some(schema_id);
-        self
-    }
-
-    /// Whether this grant may be enforced against `schema_id`. A grant with no
-    /// binding (test-constructed) matches anything.
+    /// Whether this grant may be enforced against `schema_id`.
     pub(crate) fn matches_schema(&self, schema_id: i64) -> bool {
-        self.schema_id.is_none_or(|bound| bound == schema_id)
+        self.schema_id == schema_id
     }
 
     /// Fully unrestricted: every column approved, no filter, no masking.
@@ -177,6 +173,39 @@ pub(crate) fn unauthorized_column_error(fields: &[DataField], column: usize) -> 
         "query-auth read touches column `{}` outside the authorized set",
         field_name(fields, column)
     ))
+}
+
+/// Table-schema indices a read type touches, rejecting any field that is not a
+/// canonical `(id, name)` pair of `fields`.
+///
+/// Authorization and mask selection resolve columns by id, but the physical read
+/// resolves them by name, so a read type pairing an authorized id with another
+/// column's name would be scoped by id while reading the other column.
+/// `TableRead::new` / `with_read_type` are public, so this is reachable — fail
+/// closed. A field matching neither an id nor a name is a system column (row id,
+/// etc.), which carries no grant scope and maps to no index.
+pub(crate) fn canonical_projection(
+    fields: &[DataField],
+    read_type: &[DataField],
+) -> crate::Result<Vec<usize>> {
+    let mut indices = Vec::with_capacity(read_type.len());
+    for field in read_type {
+        let by_id = fields.iter().position(|s| s.id() == field.id());
+        let by_name = fields.iter().position(|s| s.name() == field.name());
+        match (by_id, by_name) {
+            // Both lookups land on the same schema field.
+            (Some(i), Some(n)) if i == n => indices.push(i),
+            (None, None) => {}
+            _ => {
+                return Err(unsupported(format!(
+                    "query-auth read type field #{} `{}` is not a column of this table",
+                    field.id(),
+                    field.name()
+                )))
+            }
+        }
+    }
+    Ok(indices)
 }
 
 /// Live query-auth scope check shared by the read/scan gates: fail closed when
@@ -1080,12 +1109,12 @@ mod tests {
     fn test_grant_authorized_column_scope() {
         // A grant scoped to a subset is not globally unrestricted and rejects
         // columns outside the approved set.
-        let grant = QueryAuthGrant::new(Vec::new(), Vec::new(), Some(HashSet::from([0])));
+        let grant = QueryAuthGrant::new(Vec::new(), Vec::new(), Some(HashSet::from([0])), 0);
         assert!(!grant.is_unrestricted());
         assert!(grant.authorizes_columns([0]));
         assert!(!grant.authorizes_columns([1]));
         // `None` (all columns) with no filter/mask is fully unrestricted.
-        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None);
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None, 0);
         assert!(all.is_unrestricted());
         assert!(all.authorizes_columns([0, 1, 99]));
     }

--- a/crates/paimon/src/table/query_auth.rs
+++ b/crates/paimon/src/table/query_auth.rs
@@ -1,0 +1,1092 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Query-auth enforcement: apply the REST server's per-user row filter and
+//! column masking exactly to read output. Parsing of the Java `Predicate` /
+//! `Transform` JSON lives in [`crate::spec`]; anything unrecognised is an
+//! error, so callers keep the table fail-closed.
+
+use crate::arrow::residual::{
+    boolean_mask_from_predicate, evaluate_column_predicate, literal_scalar_for_arrow_filter,
+    sanitize_filter_mask,
+};
+use crate::spec::{
+    DataField, DataType, Datum, Predicate, PredicateOperator, Transform, TransformInput,
+};
+use crate::{Error, Result};
+use arrow_arith::boolean::{and_kleene, not, or_kleene};
+use arrow_array::{ArrayRef, BooleanArray, Float32Array, Float64Array, RecordBatch};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// Row filters and column masks the REST server granted the current user for a
+/// specific set of columns. `authorized = None` means all columns were approved
+/// (the request used `select = all`); `Some(set)` scopes the grant to those
+/// table-schema indices. Only the REST catalog constructs grants.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct QueryAuthGrant {
+    filters: Vec<Predicate>,
+    masks: Vec<ColumnMask>,
+    authorized: Option<HashSet<usize>>,
+    /// Schema this grant's positional filter/mask indices were parsed against.
+    /// Enforcing it on a different schema would bind them to other columns.
+    schema_id: Option<i64>,
+}
+
+impl QueryAuthGrant {
+    pub(crate) fn new(
+        filters: Vec<Predicate>,
+        masks: Vec<ColumnMask>,
+        authorized: Option<HashSet<usize>>,
+    ) -> Self {
+        Self {
+            filters,
+            masks,
+            authorized,
+            schema_id: None,
+        }
+    }
+
+    /// Bind this grant to the schema its indices were resolved against.
+    pub(crate) fn with_schema_id(mut self, schema_id: i64) -> Self {
+        self.schema_id = Some(schema_id);
+        self
+    }
+
+    /// Whether this grant may be enforced against `schema_id`. A grant with no
+    /// binding (test-constructed) matches anything.
+    pub(crate) fn matches_schema(&self, schema_id: i64) -> bool {
+        self.schema_id.is_none_or(|bound| bound == schema_id)
+    }
+
+    /// Fully unrestricted: every column approved, no filter, no masking.
+    pub(crate) fn is_unrestricted(&self) -> bool {
+        self.authorized.is_none() && self.filters.is_empty() && self.masks.is_empty()
+    }
+
+    /// Whether the SERVER restricted this user (a row filter or a column mask),
+    /// as opposed to the client merely scoping its own projection. Statistics
+    /// suppression, split transport and the incremental-read gate key off this:
+    /// a column-scoped grant with no filter and no mask distorts nothing.
+    pub(crate) fn has_server_restrictions(&self) -> bool {
+        !self.filters.is_empty() || !self.masks.is_empty()
+    }
+
+    pub(crate) fn filters(&self) -> &[Predicate] {
+        &self.filters
+    }
+
+    pub(crate) fn masks(&self) -> &[ColumnMask] {
+        &self.masks
+    }
+
+    /// Whether every table-schema index in `columns` was authorized. A grant
+    /// scoped to a subset does not authorize columns outside it, so a wider
+    /// projection or a predicate on an un-approved column fails closed.
+    pub(crate) fn authorizes_columns(&self, columns: impl IntoIterator<Item = usize>) -> bool {
+        match &self.authorized {
+            None => true,
+            Some(set) => columns.into_iter().all(|c| set.contains(&c)),
+        }
+    }
+
+    /// Whether this grant carries a row filter. Such a filter is applied as a
+    /// residual pass in `TableRead::to_arrow`, so split row counts, count
+    /// statistics, and count-based limit pushdown are no longer exact.
+    pub(crate) fn has_row_filter(&self) -> bool {
+        !self.filters.is_empty()
+    }
+
+    /// Table-schema indices of columns this grant masks (empty when no masking).
+    /// Callers must not push predicates on these columns to scan pruning, which
+    /// would leak the raw value via row presence.
+    pub(crate) fn masked_columns(&self) -> Vec<usize> {
+        self.masks.iter().map(|m| m.column).collect()
+    }
+
+    /// The first of `columns` (table-schema indices) this grant does not
+    /// authorize, if any.
+    pub(crate) fn first_unauthorized(
+        &self,
+        columns: impl IntoIterator<Item = usize>,
+    ) -> Option<usize> {
+        columns.into_iter().find(|c| !self.authorizes_columns([*c]))
+    }
+
+    /// Field IDs the grant must physically read (row-filter columns, mask
+    /// targets, and mask inputs). Scan projection planning must include these so
+    /// data-evolution column-slice pruning does not drop files that hold them
+    /// (an omitted column would read as null and wrongly satisfy `IS_NULL`).
+    pub(crate) fn read_field_ids(&self, fields: &[DataField]) -> Vec<i32> {
+        let mut indices = HashSet::new();
+        for filter in &self.filters {
+            filter.collect_leaf_field_indices(&mut indices);
+        }
+        for mask in &self.masks {
+            indices.insert(mask.column);
+            mask.transform.collect_field_indices(&mut indices);
+        }
+        indices
+            .into_iter()
+            .filter_map(|i| fields.get(i).map(|f| f.id()))
+            .collect()
+    }
+}
+
+/// Mask one column (by table-schema index) with a transform.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ColumnMask {
+    pub(crate) column: usize,
+    pub(crate) transform: Transform,
+}
+
+fn unsupported(message: String) -> Error {
+    Error::Unsupported { message }
+}
+
+fn field_name(fields: &[DataField], column: usize) -> &str {
+    fields.get(column).map(|f| f.name()).unwrap_or("?")
+}
+
+/// Fail-closed error for a caller predicate on a masked column (would leak the
+/// raw value via row selection). Shared by every builder/scan choke point.
+pub(crate) fn masked_filter_error(fields: &[DataField], column: usize) -> Error {
+    unsupported(format!(
+        "cannot filter on masked column `{}`",
+        field_name(fields, column)
+    ))
+}
+
+/// Fail-closed error for a read that touches a column outside the grant's scope.
+pub(crate) fn unauthorized_column_error(fields: &[DataField], column: usize) -> Error {
+    unsupported(format!(
+        "query-auth read touches column `{}` outside the authorized set",
+        field_name(fields, column)
+    ))
+}
+
+/// Live query-auth scope check shared by the read/scan gates: fail closed when
+/// the caller filter references a masked column (pruning on its raw value would
+/// leak it) or when the projection/filter touches a column outside the grant's
+/// authorized scope. `projected = None` means all columns.
+pub(crate) fn scope_check(
+    grant: &QueryAuthGrant,
+    fields: &[DataField],
+    filter_columns: &HashSet<usize>,
+    projected: Option<Vec<usize>>,
+) -> crate::Result<()> {
+    if let Some(column) = grant
+        .masked_columns()
+        .into_iter()
+        .find(|c| filter_columns.contains(c))
+    {
+        return Err(masked_filter_error(fields, column));
+    }
+    let projected = projected.unwrap_or_else(|| (0..fields.len()).collect());
+    if let Some(column) =
+        grant.first_unauthorized(projected.into_iter().chain(filter_columns.iter().copied()))
+    {
+        return Err(unauthorized_column_error(fields, column));
+    }
+    Ok(())
+}
+
+/// Parse the auth response's JSON filter strings into predicates whose leaf
+/// indices refer to `fields` (table-schema order). Empty strings are skipped
+/// (Java parity); anything unparseable is an error.
+pub(crate) fn parse_auth_filters(
+    filters: &[String],
+    fields: &[DataField],
+) -> Result<Vec<Predicate>> {
+    filters
+        .iter()
+        .filter(|f| !f.trim().is_empty())
+        .map(|f| Predicate::from_rest_json(f, fields))
+        .collect()
+}
+
+// ==================== Exact evaluation ====================
+
+/// Exactly evaluate the ANDed `predicates` against `batch` (whose columns
+/// correspond 1:1 to `batch_fields`; leaf indices refer to `schema_fields`)
+/// and drop non-matching rows. Unlike the pruning evaluators, anything that
+/// cannot be evaluated is an error — a security filter must not fall open.
+pub(crate) fn strict_filter_batch(
+    batch: &RecordBatch,
+    predicates: &[Predicate],
+    schema_fields: &[DataField],
+    batch_fields: &[DataField],
+) -> Result<RecordBatch> {
+    let mut combined: Option<BooleanArray> = None;
+    for predicate in predicates {
+        let mask = strict_mask(batch, predicate, schema_fields, batch_fields)?;
+        combined = Some(match combined {
+            Some(existing) => kleene(and_kleene(&existing, &mask))?,
+            None => mask,
+        });
+    }
+    let Some(mask) = combined else {
+        return Ok(batch.clone());
+    };
+    let mask = sanitize_filter_mask(mask);
+    arrow_select::filter::filter_record_batch(batch, &mask).map_err(|e| Error::DataInvalid {
+        message: format!("failed to apply query-auth row filter: {e}"),
+        source: Some(Box::new(e)),
+    })
+}
+
+fn strict_mask(
+    batch: &RecordBatch,
+    predicate: &Predicate,
+    schema_fields: &[DataField],
+    batch_fields: &[DataField],
+) -> Result<BooleanArray> {
+    match predicate {
+        Predicate::AlwaysTrue => Ok(BooleanArray::from(vec![true; batch.num_rows()])),
+        Predicate::AlwaysFalse => Ok(BooleanArray::from(vec![false; batch.num_rows()])),
+        Predicate::And(children) => fold_masks(batch, children, schema_fields, batch_fields, true),
+        Predicate::Or(children) => fold_masks(batch, children, schema_fields, batch_fields, false),
+        Predicate::Not(inner) => {
+            let mask = strict_mask(batch, inner, schema_fields, batch_fields)?;
+            kleene(not(&mask))
+        }
+        Predicate::Leaf {
+            index,
+            op,
+            literals,
+            ..
+        } => {
+            let field = schema_fields.get(*index).ok_or_else(|| {
+                unsupported(format!(
+                    "query-auth filter references unknown field #{index}"
+                ))
+            })?;
+            let position = batch_fields
+                .iter()
+                .position(|f| f.id() == field.id() && f.name() == field.name())
+                .ok_or_else(|| {
+                    unsupported(format!(
+                        "query-auth filter field `{}` missing from read",
+                        field.name()
+                    ))
+                })?;
+            let column = canonicalize_nan(batch.column(position));
+            strict_leaf_mask(&column, field.data_type(), *op, literals)
+        }
+    }
+}
+
+/// Replace every NaN in a float column with the canonical (positive) NaN.
+///
+/// Arrow's comparison kernels use a total ordering in which a NEGATIVE NaN sorts
+/// below every finite value, so an auth filter like `f < 0` would admit a
+/// negative-NaN row. Java canonicalizes NaN in `Float`/`Double.compare`, making
+/// every NaN greater than all finite values, so the row is rejected. Applied
+/// only to authorization filters — ordinary query pushdown keeps Arrow
+/// semantics. Signed zero already agrees with Java and is left alone.
+fn canonicalize_nan(column: &ArrayRef) -> ArrayRef {
+    match column.data_type() {
+        arrow_schema::DataType::Float32 => {
+            let values = column.as_any().downcast_ref::<Float32Array>();
+            match values {
+                Some(values) if values.iter().any(|v| v.is_some_and(f32::is_nan)) => {
+                    Arc::new(values.unary::<_, arrow_array::types::Float32Type>(|v| {
+                        if v.is_nan() {
+                            f32::NAN
+                        } else {
+                            v
+                        }
+                    })) as ArrayRef
+                }
+                _ => Arc::clone(column),
+            }
+        }
+        arrow_schema::DataType::Float64 => {
+            let values = column.as_any().downcast_ref::<Float64Array>();
+            match values {
+                Some(values) if values.iter().any(|v| v.is_some_and(f64::is_nan)) => {
+                    Arc::new(values.unary::<_, arrow_array::types::Float64Type>(|v| {
+                        if v.is_nan() {
+                            f64::NAN
+                        } else {
+                            v
+                        }
+                    })) as ArrayRef
+                }
+                _ => Arc::clone(column),
+            }
+        }
+        _ => Arc::clone(column),
+    }
+}
+
+fn fold_masks(
+    batch: &RecordBatch,
+    children: &[Predicate],
+    schema_fields: &[DataField],
+    batch_fields: &[DataField],
+    use_and: bool,
+) -> Result<BooleanArray> {
+    let mut combined: Option<BooleanArray> = None;
+    for child in children {
+        let mask = strict_mask(batch, child, schema_fields, batch_fields)?;
+        combined = Some(match combined {
+            Some(existing) if use_and => kleene(and_kleene(&existing, &mask))?,
+            Some(existing) => kleene(or_kleene(&existing, &mask))?,
+            None => mask,
+        });
+    }
+    combined.ok_or_else(|| unsupported("query-auth filter has an empty compound".to_string()))
+}
+
+fn strict_leaf_mask(
+    column: &ArrayRef,
+    data_type: &DataType,
+    op: PredicateOperator,
+    literals: &[Datum],
+) -> Result<BooleanArray> {
+    let scalar = |literal: &Datum| -> Result<arrow_array::Scalar<ArrayRef>> {
+        literal_scalar_for_arrow_filter(literal, data_type)?.ok_or_else(|| {
+            unsupported(format!(
+                "query-auth filter literal is not comparable to type {data_type:?}"
+            ))
+        })
+    };
+    match op {
+        PredicateOperator::IsNull => Ok(boolean_mask_from_predicate(column.len(), |row| {
+            column.is_null(row)
+        })),
+        PredicateOperator::IsNotNull => Ok(boolean_mask_from_predicate(column.len(), |row| {
+            column.is_valid(row)
+        })),
+        PredicateOperator::In | PredicateOperator::NotIn => {
+            // Kleene IN: OR of equalities; x NOT IN (..) = NOT(IN), nulls stay null.
+            let mut combined = BooleanArray::from(vec![false; column.len()]);
+            for literal in literals {
+                let eq = kleene(evaluate_column_predicate(
+                    column,
+                    &scalar(literal)?,
+                    PredicateOperator::Eq,
+                ))?;
+                combined = kleene(or_kleene(&combined, &eq))?;
+            }
+            if matches!(op, PredicateOperator::NotIn) {
+                combined = kleene(not(&combined))?;
+                if literals.is_empty() {
+                    // `x NOT IN ()` is true only for non-null rows.
+                    combined =
+                        boolean_mask_from_predicate(column.len(), |row| column.is_valid(row));
+                }
+            }
+            Ok(combined)
+        }
+        PredicateOperator::Eq
+        | PredicateOperator::NotEq
+        | PredicateOperator::Lt
+        | PredicateOperator::LtEq
+        | PredicateOperator::Gt
+        | PredicateOperator::GtEq
+        | PredicateOperator::StartsWith
+        | PredicateOperator::EndsWith
+        | PredicateOperator::Contains
+        | PredicateOperator::Like => {
+            let literal = literals.first().ok_or_else(|| {
+                unsupported("query-auth filter comparison without literal".to_string())
+            })?;
+            kleene(evaluate_column_predicate(column, &scalar(literal)?, op))
+        }
+        PredicateOperator::Between | PredicateOperator::NotBetween => {
+            let (Some(low), Some(high)) = (literals.first(), literals.get(1)) else {
+                return Err(unsupported(
+                    "query-auth BETWEEN filter without bounds".to_string(),
+                ));
+            };
+            let lo = kleene(evaluate_column_predicate(
+                column,
+                &scalar(low)?,
+                PredicateOperator::GtEq,
+            ))?;
+            let hi = kleene(evaluate_column_predicate(
+                column,
+                &scalar(high)?,
+                PredicateOperator::LtEq,
+            ))?;
+            let between = kleene(and_kleene(&lo, &hi))?;
+            if matches!(op, PredicateOperator::NotBetween) {
+                kleene(not(&between))
+            } else {
+                Ok(between)
+            }
+        }
+        // A server filter over an array column has no raw-row equivalent here;
+        // refuse rather than let the rows through unfiltered.
+        PredicateOperator::ArrayContains
+        | PredicateOperator::ArraysOverlap
+        | PredicateOperator::ArrayContainsAll => Err(unsupported(format!(
+            "query-auth row filter uses the unsupported operator {op:?}"
+        ))),
+    }
+}
+
+fn kleene(
+    result: std::result::Result<BooleanArray, arrow_schema::ArrowError>,
+) -> Result<BooleanArray> {
+    result.map_err(|e| Error::DataInvalid {
+        message: format!("failed to evaluate query-auth row filter: {e}"),
+        source: Some(Box::new(e)),
+    })
+}
+
+// ==================== Column masking ====================
+
+fn mask_err(detail: impl std::fmt::Display) -> Error {
+    unsupported(format!("cannot parse query-auth column masking: {detail}"))
+}
+
+/// Parse the auth response's `columnMasking` map (column name -> Java
+/// `Transform` JSON) against `fields` (table-schema order).
+pub(crate) fn parse_column_masking(
+    masking: &std::collections::HashMap<String, String>,
+    fields: &[DataField],
+) -> Result<Vec<ColumnMask>> {
+    let mut masks = Vec::with_capacity(masking.len());
+    for (column, json) in masking {
+        let target = fields
+            .iter()
+            .position(|f| f.name() == column)
+            .ok_or_else(|| mask_err(format!("unknown field `{column}`")))?;
+        let transform = Transform::from_rest_json(json, fields)?;
+        // The masked value replaces the column in place, so its type must match
+        // the column's; a type-changing transform (e.g. `CAST(id AS STRING)` on
+        // an INT column) cannot be represented and must fail closed rather than
+        // be cast back to the raw type. Types are compared via their arrow
+        // representation (nullability-agnostic).
+        if let Some(out) = mask_output_type(&transform, fields) {
+            let target_type = crate::arrow::paimon_type_to_arrow(fields[target].data_type())?;
+            if out != target_type {
+                return Err(mask_err(format!(
+                    "masking `{column}` produces {out:?} but the column is {target_type:?}"
+                )));
+            }
+        }
+        // A mask that can yield null on a NOT NULL column would leave the output
+        // batch's schema claiming non-nullable, letting engines fold
+        // `col IS [NOT] NULL` before the masked-predicate guard. Fail closed.
+        if !fields[target].data_type().is_nullable() && mask_can_be_null(&transform, fields) {
+            return Err(mask_err(format!(
+                "masking `{column}` can produce null but the column is NOT NULL"
+            )));
+        }
+        masks.push(ColumnMask {
+            column: target,
+            transform,
+        });
+    }
+    // Deterministic order regardless of map iteration.
+    masks.sort_by_key(|m| m.column);
+
+    // Masks read their inputs from the RAW batch (like Java), so one mask that
+    // references ANOTHER mask's target would copy that column's unmasked value
+    // into its own output — defeating the second mask. Referencing your own
+    // target is the normal case (`name := UPPER(name)`) and stays valid.
+    let targets: HashSet<usize> = masks.iter().map(|m| m.column).collect();
+    for mask in &masks {
+        let mut inputs = HashSet::new();
+        mask.transform.collect_field_indices(&mut inputs);
+        if let Some(other) = inputs
+            .into_iter()
+            .find(|i| *i != mask.column && targets.contains(i))
+        {
+            return Err(mask_err(format!(
+                "masking `{}` reads masked column `{}`, which would expose its raw value",
+                field_name(fields, mask.column),
+                field_name(fields, other)
+            )));
+        }
+    }
+    Ok(masks)
+}
+
+/// Whether a mask transform can produce a null value.
+fn mask_can_be_null(transform: &Transform, fields: &[DataField]) -> bool {
+    let field_nullable = |index: &usize| fields[*index].data_type().is_nullable();
+    let input_nullable = |inputs: &[TransformInput]| {
+        inputs.iter().any(|i| match i {
+            TransformInput::Literal(literal) => literal.is_none(),
+            TransformInput::Field(index) => field_nullable(index),
+        })
+    };
+    match transform {
+        Transform::Null => true,
+        Transform::FieldRef(index) | Transform::Cast(index, _) => field_nullable(index),
+        Transform::Upper(inputs) | Transform::Lower(inputs) | Transform::Concat(inputs) => {
+            input_nullable(inputs)
+        }
+        // CONCAT_WS skips null payloads, so only a null separator (the first
+        // input) can make the result null.
+        Transform::ConcatWs(inputs) => inputs.first().is_some_and(|sep| match sep {
+            TransformInput::Literal(literal) => literal.is_none(),
+            TransformInput::Field(index) => field_nullable(index),
+        }),
+    }
+}
+
+/// Arrow output type of a mask transform, or `None` when it always matches the
+/// target column (the `NULL` transform builds a null of the column's own type).
+fn mask_output_type(transform: &Transform, fields: &[DataField]) -> Option<arrow_schema::DataType> {
+    let of = |index: &usize| crate::arrow::paimon_type_to_arrow(fields[*index].data_type()).ok();
+    match transform {
+        Transform::Null => None,
+        Transform::FieldRef(index) => of(index),
+        Transform::Cast(_, to) => crate::arrow::paimon_type_to_arrow(to).ok(),
+        Transform::Upper(_)
+        | Transform::Lower(_)
+        | Transform::Concat(_)
+        | Transform::ConcatWs(_) => Some(arrow_schema::DataType::Utf8),
+    }
+}
+
+/// Overwrite masked columns of `batch` (whose columns correspond 1:1 to
+/// `batch_fields`). Masks whose target column is not in the batch are skipped
+/// (Java parity); anything that cannot be evaluated is an error.
+pub(crate) fn mask_batch(
+    batch: &RecordBatch,
+    masks: &[ColumnMask],
+    schema_fields: &[DataField],
+    batch_fields: &[DataField],
+) -> Result<RecordBatch> {
+    use arrow_array::new_null_array;
+
+    // Nothing to mask (e.g. a `COUNT(*)` read projects no columns); return the
+    // batch unchanged, preserving its row count even with zero columns.
+    if masks.is_empty() {
+        return Ok(batch.clone());
+    }
+
+    // All batch positions holding a given table-schema field (a projection may
+    // repeat a column, so every copy must be masked, not just the first).
+    let positions_of = |schema_index: usize| -> Result<Vec<usize>> {
+        let field = schema_fields.get(schema_index).ok_or_else(|| {
+            unsupported(format!(
+                "query-auth mask references unknown field #{schema_index}"
+            ))
+        })?;
+        // Match on field id alone: the read type may carry the column under a
+        // different name (projection aliasing, or a renamed column read from an
+        // older file schema). Also matching the name would silently find no
+        // position and skip the mask, emitting the raw value.
+        Ok(batch_fields
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| f.id() == field.id())
+            .map(|(pos, _)| pos)
+            .collect())
+    };
+    let input_column = |schema_index: usize| -> Result<ArrayRef> {
+        positions_of(schema_index)?
+            .first()
+            .map(|pos| batch.column(*pos).clone())
+            .ok_or_else(|| unsupported("query-auth mask input missing from read".to_string()))
+    };
+
+    let mut columns = batch.columns().to_vec();
+    for mask in masks {
+        let targets = positions_of(mask.column)?;
+        // `masks` is already filtered to targets the caller projects, so a mask
+        // that resolves to no batch column means the read cannot enforce it —
+        // emitting the column unmasked would leak the raw value.
+        let Some(&first) = targets.first() else {
+            return Err(unsupported(format!(
+                "query-auth mask for column `{}` cannot be applied: the column is missing \
+                 from the read",
+                field_name(schema_fields, mask.column)
+            )));
+        };
+        let target_type = batch.schema().field(first).data_type().clone();
+        let masked: ArrayRef = match &mask.transform {
+            Transform::Null => new_null_array(&target_type, batch.num_rows()),
+            Transform::FieldRef(index) => input_column(*index)?,
+            Transform::Cast(index, to) => {
+                let to_arrow = crate::arrow::paimon_type_to_arrow(to)?;
+                cast_masked(&input_column(*index)?, &to_arrow)?
+            }
+            Transform::Upper(inputs) => string_mask(batch, inputs, &input_column, |v| {
+                Some(v.first()?.as_ref().map(|s| s.to_uppercase()))
+            })?,
+            Transform::Lower(inputs) => string_mask(batch, inputs, &input_column, |v| {
+                Some(v.first()?.as_ref().map(|s| s.to_lowercase()))
+            })?,
+            // SQL semantics: CONCAT is null if any input is null; CONCAT_WS
+            // uses the first input as separator and skips null values.
+            Transform::Concat(inputs) => string_mask(batch, inputs, &input_column, |v| {
+                Some(
+                    v.iter()
+                        .cloned()
+                        .collect::<Option<Vec<_>>>()
+                        .map(|p| p.concat()),
+                )
+            })?,
+            Transform::ConcatWs(inputs) => string_mask(batch, inputs, &input_column, |v| {
+                let (sep, rest) = v.split_first()?;
+                Some(
+                    sep.as_ref()
+                        .map(|sep| rest.iter().flatten().cloned().collect::<Vec<_>>().join(sep)),
+                )
+            })?,
+        };
+        // Parse-time type checks guarantee a compatible type, so this only
+        // aligns arrow representations. Mask every copy of the target column.
+        let masked = cast_masked(&masked, &target_type)?;
+        for pos in targets {
+            columns[pos] = masked.clone();
+        }
+    }
+    RecordBatch::try_new_with_options(
+        batch.schema(),
+        columns,
+        &arrow_array::RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+    )
+    .map_err(|e| Error::DataInvalid {
+        message: format!("failed to apply query-auth column masking: {e}"),
+        source: Some(Box::new(e)),
+    })
+}
+
+fn cast_masked(array: &ArrayRef, to: &arrow_schema::DataType) -> Result<ArrayRef> {
+    if array.data_type() == to {
+        return Ok(array.clone());
+    }
+    arrow_cast::cast(array, to).map_err(|e| {
+        unsupported(format!(
+            "query-auth mask value of type {:?} cannot be cast to column type {to:?}: {e}",
+            array.data_type()
+        ))
+    })
+}
+
+/// Evaluate a string transform row by row. `combine` receives the resolved
+/// inputs (None = SQL NULL) and returns the masked value; a `None` from
+/// `combine` means the transform is malformed for this input arity.
+fn string_mask(
+    batch: &RecordBatch,
+    inputs: &[TransformInput],
+    input_column: &dyn Fn(usize) -> Result<ArrayRef>,
+    combine: impl Fn(&[Option<String>]) -> Option<Option<String>>,
+) -> Result<ArrayRef> {
+    use arrow_array::{Array, StringArray};
+    use std::sync::Arc;
+
+    // Resolve field inputs once, as string arrays (None = literal slot).
+    let resolved: Vec<Option<ArrayRef>> = inputs
+        .iter()
+        .map(|input| match input {
+            TransformInput::Literal(_) => Ok(None),
+            TransformInput::Field(index) => {
+                cast_masked(&input_column(*index)?, &arrow_schema::DataType::Utf8).map(Some)
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut values: Vec<Option<String>> = Vec::with_capacity(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        let row_inputs = inputs
+            .iter()
+            .zip(&resolved)
+            .map(|(input, array)| match (input, array) {
+                (TransformInput::Literal(s), _) => Ok(s.clone()),
+                (TransformInput::Field(_), Some(array)) => {
+                    let strings = array
+                        .as_any()
+                        .downcast_ref::<StringArray>()
+                        .ok_or_else(|| unsupported("mask input is not a string".to_string()))?;
+                    Ok((!strings.is_null(row)).then(|| strings.value(row).to_string()))
+                }
+                (TransformInput::Field(_), None) => unreachable!("field inputs are resolved above"),
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let value = combine(&row_inputs)
+            .ok_or_else(|| unsupported("query-auth string mask is malformed".to_string()))?;
+        values.push(value);
+    }
+    Ok(Arc::new(StringArray::from(values)) as ArrayRef)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::{IntType, VarCharType};
+    use arrow_array::{Int32Array, StringArray};
+    use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+    use std::sync::Arc;
+
+    fn fields() -> Vec<DataField> {
+        vec![
+            DataField::new(0, "id".to_string(), DataType::Int(IntType::new())),
+            DataField::new(
+                1,
+                "name".to_string(),
+                DataType::VarChar(VarCharType::new(255).unwrap()),
+            ),
+        ]
+    }
+
+    fn leaf_json(function: &str, field: &str, literals: &str) -> String {
+        format!(
+            r#"{{"kind":"LEAF","transform":{{"name":"FIELD_REF","fieldRef":{{"index":0,"name":"{field}","type":"INT"}}}},"function":"{function}","literals":{literals}}}"#
+        )
+    }
+
+    fn batch() -> RecordBatch {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, true),
+            ArrowField::new("name", ArrowDataType::Utf8, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![Some(1), Some(2), None, Some(4)])),
+                Arc::new(StringArray::from(vec![
+                    Some("a"),
+                    Some("b"),
+                    Some("c"),
+                    Some("d"),
+                ])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_strict_filter_batch_filters_rows() {
+        let fields = fields();
+        let filters =
+            parse_auth_filters(&[leaf_json("GREATER_THAN", "id", "[1]")], &fields).unwrap();
+        let filtered = strict_filter_batch(&batch(), &filters, &fields, &fields).unwrap();
+        // id > 1 keeps rows 2 and 4; the NULL row is excluded.
+        assert_eq!(filtered.num_rows(), 2);
+    }
+
+    #[test]
+    fn test_strict_filter_matches_java_nan_ordering() {
+        use crate::spec::{DoubleType, PredicateBuilder};
+        use arrow_array::Float64Array;
+        use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+
+        // Java `Double.compare` canonicalizes NaN above every finite value, so
+        // `f < 0` must reject NaN — including a NEGATIVE NaN, which Arrow's
+        // total ordering would otherwise sort below finite values and admit.
+        let fields = vec![DataField::new(
+            0,
+            "f".to_string(),
+            DataType::Double(DoubleType::new()),
+        )];
+        let neg_nan = f64::from_bits(0xFFF8_0000_0000_0000);
+        let batch = RecordBatch::try_new(
+            std::sync::Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                "f",
+                ArrowDataType::Float64,
+                true,
+            )])),
+            vec![std::sync::Arc::new(Float64Array::from(vec![
+                neg_nan,
+                f64::NAN,
+                -1.0,
+                1.0,
+            ]))],
+        )
+        .unwrap();
+
+        let less = PredicateBuilder::new(&fields)
+            .less_than("f", crate::spec::Datum::Double(0.0))
+            .unwrap();
+        let filtered = strict_filter_batch(&batch, &[less], &fields, &fields).unwrap();
+        assert_eq!(
+            filtered.num_rows(),
+            1,
+            "only -1.0 may pass `f < 0`; neither NaN sign may"
+        );
+
+        let greater = PredicateBuilder::new(&fields)
+            .greater_than("f", crate::spec::Datum::Double(0.0))
+            .unwrap();
+        let filtered = strict_filter_batch(&batch, &[greater], &fields, &fields).unwrap();
+        assert_eq!(
+            filtered.num_rows(),
+            3,
+            "both NaNs and 1.0 pass `f > 0` (NaN is greatest, like Java)"
+        );
+    }
+
+    #[test]
+    fn test_strict_filter_not_excludes_nulls() {
+        let fields = fields();
+        // NOT (id = 2): NULL rows must stay excluded (SQL three-valued logic).
+        let json = format!(
+            r#"{{"kind":"COMPOUND","function":"AND","children":[{}]}}"#,
+            leaf_json("NOT_EQUAL", "id", "[2]")
+        );
+        let filters = parse_auth_filters(&[json], &fields).unwrap();
+        let filtered = strict_filter_batch(&batch(), &filters, &fields, &fields).unwrap();
+        assert_eq!(
+            filtered.num_rows(),
+            2,
+            "rows 1 and 4 only, not the NULL row"
+        );
+    }
+
+    /// Java #7034 baseline: filter each supported literal type exactly.
+    #[test]
+    fn test_strict_filter_batch_typed_matrix() {
+        use crate::spec::{BigIntType, BooleanType, DoubleType, FloatType};
+        use arrow_array::{BooleanArray, Float32Array, Float64Array, Int64Array};
+
+        let fields = vec![
+            DataField::new(0, "id".to_string(), DataType::Int(IntType::new())),
+            DataField::new(1, "age".to_string(), DataType::BigInt(BigIntType::new())),
+            DataField::new(2, "salary".to_string(), DataType::Double(DoubleType::new())),
+            DataField::new(
+                3,
+                "is_active".to_string(),
+                DataType::Boolean(BooleanType::new()),
+            ),
+            DataField::new(4, "score".to_string(), DataType::Float(FloatType::new())),
+            DataField::new(
+                5,
+                "name".to_string(),
+                DataType::VarChar(VarCharType::new(255).unwrap()),
+            ),
+        ];
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, true),
+            ArrowField::new("age", ArrowDataType::Int64, true),
+            ArrowField::new("salary", ArrowDataType::Float64, true),
+            ArrowField::new("is_active", ArrowDataType::Boolean, true),
+            ArrowField::new("score", ArrowDataType::Float32, true),
+            ArrowField::new("name", ArrowDataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+                Arc::new(Int64Array::from(vec![25, 30, 35, 28])),
+                Arc::new(Float64Array::from(vec![50000.0, 60000.0, 70000.0, 55000.0])),
+                Arc::new(BooleanArray::from(vec![true, false, true, true])),
+                Arc::new(Float32Array::from(vec![85.5, 90.0, 95.5, 88.0])),
+                Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie", "David"])),
+            ],
+        )
+        .unwrap();
+        fn typed_leaf(function: &str, field: &str, ftype: &str, literals: &str) -> String {
+            format!(
+                r#"{{"kind":"LEAF","transform":{{"name":"FIELD_REF","fieldRef":{{"index":0,"name":"{field}","type":"{ftype}"}}}},"function":"{function}","literals":{literals}}}"#
+            )
+        }
+        // (filter, expected surviving ids) — mirrors Java MockRESTCatalogTest.
+        let cases: Vec<(String, Vec<i32>)> = vec![
+            (typed_leaf("GREATER_THAN", "id", "INT", "[2]"), vec![3, 4]),
+            (
+                typed_leaf("GREATER_OR_EQUAL", "age", "BIGINT", "[30]"),
+                vec![2, 3],
+            ),
+            (
+                typed_leaf("GREATER_THAN", "salary", "DOUBLE", "[55000.0]"),
+                vec![2, 3],
+            ),
+            (
+                typed_leaf("EQUAL", "is_active", "BOOLEAN", "[true]"),
+                vec![1, 3, 4],
+            ),
+            (
+                typed_leaf("GREATER_OR_EQUAL", "score", "FLOAT", "[90.0]"),
+                vec![2, 3],
+            ),
+            (
+                typed_leaf("EQUAL", "name", "STRING", "[\"Alice\"]"),
+                vec![1],
+            ),
+            (
+                // Two predicates ANDed by the grant list semantics.
+                format!(
+                    r#"{{"kind":"COMPOUND","function":"AND","children":[{},{}]}}"#,
+                    typed_leaf("GREATER_OR_EQUAL", "age", "BIGINT", "[30]"),
+                    typed_leaf("EQUAL", "is_active", "BOOLEAN", "[true]")
+                ),
+                vec![3],
+            ),
+        ];
+        for (json, expected) in cases {
+            let filters = parse_auth_filters(std::slice::from_ref(&json), &fields).unwrap();
+            let filtered = strict_filter_batch(&batch, &filters, &fields, &fields).unwrap();
+            let ids = filtered
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .values()
+                .to_vec();
+            assert_eq!(ids, expected, "for {json}");
+        }
+    }
+
+    fn masking(column: &str, json: &str) -> std::collections::HashMap<String, String> {
+        std::collections::HashMap::from([(column.to_string(), json.to_string())])
+    }
+
+    #[test]
+    fn test_reject_mask_reading_another_masked_column() {
+        // `name := UPPER(name)` is the normal self-reference and stays valid.
+        let fields = fields();
+        assert!(parse_column_masking(
+            &masking(
+                "name",
+                r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#
+            ),
+            &fields
+        )
+        .is_ok());
+
+        // But a mask that reads ANOTHER masked column would copy that column's
+        // raw value out (masks read the unmasked batch), defeating its mask.
+        let both = std::collections::HashMap::from([
+            ("id".to_string(), r#"{"name":"NULL"}"#.to_string()),
+            (
+                "name".to_string(),
+                r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#
+                    .to_string(),
+            ),
+        ]);
+        assert!(
+            parse_column_masking(&both, &fields).is_ok(),
+            "unrelated masks are fine"
+        );
+
+        let cross = std::collections::HashMap::from([
+            ("name".to_string(), r#"{"name":"NULL"}"#.to_string()),
+            (
+                "alias".to_string(),
+                r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#
+                    .to_string(),
+            ),
+        ]);
+        let mut fields_with_alias = fields.clone();
+        fields_with_alias.push(DataField::new(
+            2,
+            "alias".to_string(),
+            DataType::VarChar(VarCharType::new(255).unwrap()),
+        ));
+        let Err(err) = parse_column_masking(&cross, &fields_with_alias) else {
+            panic!("a mask reading another masked column must fail closed");
+        };
+        assert!(err.to_string().contains("raw value"), "got: {err}");
+    }
+
+    #[test]
+    fn test_parse_column_masking() {
+        let fields = fields();
+        let masks = parse_column_masking(&masking("name", r#"{"name":"NULL"}"#), &fields).unwrap();
+        assert!(matches!(masks[0].transform, Transform::Null));
+        assert_eq!(masks[0].column, 1);
+
+        let upper = r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#;
+        let masks = parse_column_masking(&masking("name", upper), &fields).unwrap();
+        assert!(matches!(&masks[0].transform, Transform::Upper(inputs) if inputs.len() == 1));
+
+        // Unknown transform / unknown column / bad JSON: all fail closed.
+        for (column, json) in [
+            ("name", r#"{"name":"ROT13"}"#),
+            ("missing", r#"{"name":"NULL"}"#),
+            ("name", "not json"),
+        ] {
+            assert!(parse_column_masking(&masking(column, json), &fields).is_err());
+        }
+    }
+
+    #[test]
+    fn test_mask_batch_null_and_string_transforms() {
+        use arrow_array::Array;
+        let fields = fields();
+
+        // NULL mask: the whole column becomes null.
+        let masks = parse_column_masking(&masking("name", r#"{"name":"NULL"}"#), &fields).unwrap();
+        let masked = mask_batch(&batch(), &masks, &fields, &fields).unwrap();
+        assert_eq!(masked.column(1).null_count(), 4);
+        assert_eq!(masked.column(0).null_count(), 1, "other columns untouched");
+
+        // CONCAT_WS("-", literal, field): "x-a", "x-b", ...
+        let concat =
+            r#"{"name":"CONCAT_WS","inputs":["-","x",{"index":1,"name":"name","type":"STRING"}]}"#;
+        let masks = parse_column_masking(&masking("name", concat), &fields).unwrap();
+        let masked = mask_batch(&batch(), &masks, &fields, &fields).unwrap();
+        let names = masked
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(names.value(0), "x-a");
+
+        // Masked column absent from the batch: fail closed. The caller filters
+        // masks to projected targets, so this means the read cannot enforce the
+        // mask — emitting the column unmasked would leak the raw value.
+        let one_col = batch().project(&[0]).unwrap();
+        let one_field = vec![fields[0].clone()];
+        let masks = parse_column_masking(&masking("name", r#"{"name":"NULL"}"#), &fields).unwrap();
+        let Err(err) = mask_batch(&one_col, &masks, &fields, &one_field) else {
+            panic!("a mask whose target is missing from the read must fail closed");
+        };
+        assert!(err.to_string().contains("cannot be applied"), "got: {err}");
+    }
+
+    #[test]
+    fn test_reject_type_changing_cast_mask() {
+        let fields = fields();
+        // CAST(id AS STRING) on an INT column changes type -> fail closed.
+        let cast =
+            r#"{"name":"CAST","fieldRef":{"index":0,"name":"id","type":"INT"},"type":"STRING"}"#;
+        assert!(parse_column_masking(&masking("id", cast), &fields).is_err());
+        // A string transform on a non-string column also fails closed.
+        let upper = r#"{"name":"UPPER","inputs":[{"index":0,"name":"id","type":"INT"}]}"#;
+        assert!(parse_column_masking(&masking("id", upper), &fields).is_err());
+    }
+
+    #[test]
+    fn test_mask_batch_masks_every_duplicate_target() {
+        use arrow_array::Array;
+        let fields = fields();
+        let masks = parse_column_masking(&masking("name", r#"{"name":"NULL"}"#), &fields).unwrap();
+        // A projection that repeats the masked column: both copies must be masked.
+        let base = batch();
+        let dup = base.project(&[1, 1]).unwrap();
+        let dup_fields = vec![fields[1].clone(), fields[1].clone()];
+        let masked = mask_batch(&dup, &masks, &fields, &dup_fields).unwrap();
+        assert_eq!(masked.column(0).null_count(), 4);
+        assert_eq!(masked.column(1).null_count(), 4);
+    }
+
+    #[test]
+    fn test_grant_authorized_column_scope() {
+        // A grant scoped to a subset is not globally unrestricted and rejects
+        // columns outside the approved set.
+        let grant = QueryAuthGrant::new(Vec::new(), Vec::new(), Some(HashSet::from([0])));
+        assert!(!grant.is_unrestricted());
+        assert!(grant.authorizes_columns([0]));
+        assert!(!grant.authorizes_columns([1]));
+        // `None` (all columns) with no filter/mask is fully unrestricted.
+        let all = QueryAuthGrant::new(Vec::new(), Vec::new(), None);
+        assert!(all.is_unrestricted());
+        assert!(all.authorizes_columns([0, 1, 99]));
+    }
+}

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -463,10 +463,30 @@ impl<'a> PaimonReadBuilder<'a> {
             &self.filter.data_predicates,
             self.table.schema().fields(),
         ))
-        .with_query_auth_scope(self.filter_columns.clone(), self.projected_schema_indices())
+        .with_query_auth_scope(
+            self.filter_columns.clone(),
+            self.projected_schema_indices(),
+            self.projected_system_field_names(),
+        )
     }
 
     /// Table-schema indices of the projected columns (`None` = all).
+    /// Projected system fields (`_ROW_ID`, …). `projected_schema_indices` drops
+    /// them for lack of an index, but Java's `select` includes them.
+    fn projected_system_field_names(&self) -> Vec<String> {
+        self.resolve_read_type()
+            .ok()
+            .flatten()
+            .map(|fields| {
+                fields
+                    .iter()
+                    .filter(|f| crate::table::query_auth::is_reserved_system_field(f))
+                    .map(|f| f.name().to_string())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     fn projected_schema_indices(&self) -> Option<Vec<usize>> {
         // Resolve names too: a `with_projection` selection lives in
         // `projection_names`, and scoping the grant to all columns would deny a
@@ -937,7 +957,7 @@ mod tests {
             vec![auth_filter],
             Vec::new(),
             None,
-            table.schema().id(),
+            crate::table::query_auth::GrantBinding::of(&table),
         ));
 
         let split = DataSplitBuilder::new()
@@ -1014,7 +1034,7 @@ mod tests {
             vec![auth_filter],
             masks,
             None,
-            table.schema().id(),
+            crate::table::query_auth::GrantBinding::of(&table),
         ));
 
         let split = DataSplitBuilder::new()
@@ -1065,7 +1085,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::new()),
-            table.schema().id(),
+            crate::table::query_auth::GrantBinding::of(&table),
         ));
         let split = DataSplitBuilder::new()
             .with_snapshot(1)

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -291,6 +291,10 @@ struct PaimonReadBuilder<'a> {
     limit: Option<usize>,
     row_ranges: Option<Vec<RowRange>>,
     case_sensitive: bool,
+    /// Table-schema indices referenced by the full caller filter (before it is
+    /// split into partition/data conjuncts). The query-auth gates check these
+    /// against the grant fetched at plan time.
+    filter_columns: HashSet<usize>,
 }
 
 impl<'a> PaimonReadBuilder<'a> {
@@ -303,6 +307,7 @@ impl<'a> PaimonReadBuilder<'a> {
             limit: None,
             row_ranges: None,
             case_sensitive: true,
+            filter_columns: HashSet::new(),
         }
     }
 
@@ -362,6 +367,12 @@ impl<'a> PaimonReadBuilder<'a> {
     /// primary-key merge reads push key conjuncts below the merge and enforce
     /// the full predicate with an exact post-merge residual filter.
     pub fn with_filter(&mut self, filter: Predicate) -> &mut Self {
+        // Capture the columns of the FULL predicate before it is split into
+        // partition/data conjuncts, so both the masked-column guard and the
+        // authorized-scope check see a masked/unauthorized partition key (which
+        // would otherwise be pruned on its raw value).
+        self.filter_columns.clear();
+        filter.collect_leaf_field_indices(&mut self.filter_columns);
         self.filter = normalize_filter(self.table, filter);
         self.try_extract_row_id_ranges();
         self
@@ -434,6 +445,10 @@ impl<'a> PaimonReadBuilder<'a> {
         let partition_filter = self.filter.partition_predicate.clone().map(|pred| {
             PartitionFilter::from_predicate(pred, &self.table.schema().partition_fields())
         });
+        // The grant's auth field IDs are folded into the scan projection inside
+        // `TableScan::plan` — where the grant has been fetched — not here, where
+        // it does not yet exist (that early read of an empty grant was a
+        // fail-open row-filter bypass).
         let read_type = self.resolve_read_type().unwrap_or(None);
         TableScan::new(
             self.table,
@@ -448,14 +463,35 @@ impl<'a> PaimonReadBuilder<'a> {
             &self.filter.data_predicates,
             self.table.schema().fields(),
         ))
+        .with_query_auth_scope(self.filter_columns.clone(), self.projected_schema_indices())
+    }
+
+    /// Table-schema indices of the projected columns (`None` = all).
+    fn projected_schema_indices(&self) -> Option<Vec<usize>> {
+        // Resolve names too: a `with_projection` selection lives in
+        // `projection_names`, and scoping the grant to all columns would deny a
+        // user authorized for exactly the requested subset. An unresolvable
+        // projection falls back to the full scope; `new_read` reports the error.
+        self.resolve_read_type().ok().flatten().map(|fields| {
+            fields
+                .iter()
+                .filter_map(|f| {
+                    self.table
+                        .schema()
+                        .fields()
+                        .iter()
+                        .position(|s| s.id() == f.id())
+                })
+                .collect()
+        })
     }
 
     /// Create a table read for consuming splits (e.g. from a scan plan).
     pub fn new_read(&self) -> Result<TableRead<'a>> {
-        // Fail closed at read construction so bindings that short-circuit before
-        // `to_arrow` (e.g. an empty-splits fast path) can't bypass the guard.
-        let core_options = self.table.schema.core_options();
-        core_options.ensure_read_authorized()?;
+        // Query-auth is enforced in `TableRead::to_arrow` off the grant stamped
+        // on the splits by planning (fail closed when a query-auth table's
+        // splits carry no grant), so no gate is needed at read construction —
+        // an empty-splits fast path produces no rows to leak.
         let read_type = match self.resolve_read_type()? {
             None => self.table.schema.fields().to_vec(),
             Some(fields) => fields,
@@ -813,28 +849,234 @@ mod tests {
             .unwrap()
     }
 
-    #[test]
-    fn test_read_fails_closed_when_query_auth_enabled() {
+    /// A real split carrying no query-auth grant (an unauthorized read path).
+    fn ungranted_split() -> crate::table::DataSplit {
+        DataSplitBuilder::new()
+            .with_snapshot(1)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(0)
+            .with_bucket_path("file:/tmp/bucket-0".to_string())
+            .with_total_buckets(1)
+            .with_data_files(vec![test_data_file("data.parquet", 4, 1)])
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_read_fails_closed_when_query_auth_enabled() {
         let table = query_auth_table();
-        // `new_read` fails closed, so bindings that short-circuit before `to_arrow` can't bypass.
-        let err = table.new_read_builder().new_read().unwrap_err();
+        // Enforcement is at `to_arrow` off the split grant: a read whose splits
+        // carry no grant (never authorized by planning) must fail closed, so
+        // bindings that short-circuit can't bypass.
+        let read = table.new_read_builder().new_read().unwrap();
+        let Err(err) = read.to_arrow(&[ungranted_split()]) else {
+            panic!("a query-auth read without a stamped grant must fail closed");
+        };
         assert!(
             matches!(err, crate::Error::Unsupported { ref message } if message.contains("query-auth.enabled")),
             "building a read for a query-auth.enabled table must fail closed"
         );
     }
 
-    #[test]
-    fn test_dynamic_option_cannot_disable_query_auth() {
+    #[tokio::test]
+    async fn test_dynamic_option_cannot_disable_query_auth() {
         // Copying the table with the option off must not weaken a stored `true`.
         let table = query_auth_table().copy_with_options(HashMap::from([(
             "query-auth.enabled".to_string(),
             "false".to_string(),
         )]));
-        let err = table.new_read_builder().new_read().unwrap_err();
+        let read = table.new_read_builder().new_read().unwrap();
+        let Err(err) = read.to_arrow(&[ungranted_split()]) else {
+            panic!("a dynamic override must not disable query-auth");
+        };
         assert!(
             matches!(err, crate::Error::Unsupported { ref message } if message.contains("query-auth.enabled")),
             "a dynamic override must not disable query-auth"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_query_auth_filtered_grant_filters_rows_exactly() {
+        let tempdir = tempdir().unwrap();
+        let table_path = local_file_path(tempdir.path());
+        let bucket_dir = tempdir.path().join("bucket-0");
+        fs::create_dir_all(&bucket_dir).unwrap();
+
+        let parquet_path = bucket_dir.join("data.parquet");
+        write_int_parquet_file(
+            &parquet_path,
+            vec![("id", vec![1, 2, 3, 4]), ("value", vec![1, 2, 20, 30])],
+            None,
+        );
+        let file_size = fs::metadata(&parquet_path).unwrap().len() as i64;
+
+        let file_io = FileIOBuilder::new("file").build().unwrap();
+        let table_schema = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("value", DataType::Int(IntType::new()))
+                .option("query-auth.enabled", "true")
+                .build()
+                .unwrap(),
+        );
+        let table = Table::new(
+            file_io,
+            Identifier::new("default", "t"),
+            table_path,
+            table_schema,
+            None,
+        );
+        // Grant: the user may only see rows with value >= 10. The filter column
+        // is NOT in the projection, so the read must fetch it and project it away.
+        // The grant is threaded on the split (as scan planning would stamp it).
+        let auth_filter = PredicateBuilder::new(table.schema().fields())
+            .greater_or_equal("value", crate::spec::Datum::Int(10))
+            .unwrap();
+        let grant = std::sync::Arc::new(crate::table::query_auth::QueryAuthGrant::new(
+            vec![auth_filter],
+            Vec::new(),
+            None,
+        ));
+
+        let split = DataSplitBuilder::new()
+            .with_snapshot(1)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(0)
+            .with_bucket_path(local_file_path(&bucket_dir))
+            .with_total_buckets(1)
+            .with_data_files(vec![test_data_file("data.parquet", 4, file_size)])
+            .build()
+            .unwrap()
+            .with_query_auth_grant(Some(grant));
+
+        let read = TableRead::new(&table, vec![table.schema().fields()[0].clone()], Vec::new());
+        let batches = read
+            .to_arrow(&[split])
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(collect_int_column(&batches, "id"), vec![3, 4]);
+        // The filter column must not leak into the output schema.
+        assert_eq!(batches[0].num_columns(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_query_auth_masked_grant_masks_and_guards_predicates() {
+        use crate::table::query_auth::{parse_column_masking, QueryAuthGrant};
+        use arrow_array::Array;
+
+        let tempdir = tempdir().unwrap();
+        let table_path = local_file_path(tempdir.path());
+        let bucket_dir = tempdir.path().join("bucket-0");
+        fs::create_dir_all(&bucket_dir).unwrap();
+        let parquet_path = bucket_dir.join("data.parquet");
+        write_int_parquet_file(
+            &parquet_path,
+            vec![("id", vec![1, 2, 3, 4]), ("value", vec![1, 2, 20, 30])],
+            None,
+        );
+        let file_size = fs::metadata(&parquet_path).unwrap().len() as i64;
+
+        let file_io = FileIOBuilder::new("file").build().unwrap();
+        let table_schema = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("value", DataType::Int(IntType::new()))
+                .option("query-auth.enabled", "true")
+                .build()
+                .unwrap(),
+        );
+        let table = Table::new(
+            file_io,
+            Identifier::new("default", "t"),
+            table_path,
+            table_schema,
+            None,
+        );
+        // Grant: filter on raw `value` >= 10, then mask `value` with NULL.
+        let auth_filter = PredicateBuilder::new(table.schema().fields())
+            .greater_or_equal("value", crate::spec::Datum::Int(10))
+            .unwrap();
+        let masks = parse_column_masking(
+            &std::collections::HashMap::from([(
+                "value".to_string(),
+                r#"{"name":"NULL"}"#.to_string(),
+            )]),
+            table.schema().fields(),
+        )
+        .unwrap();
+        let grant = std::sync::Arc::new(QueryAuthGrant::new(vec![auth_filter], masks, None));
+
+        let split = DataSplitBuilder::new()
+            .with_snapshot(1)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(0)
+            .with_bucket_path(local_file_path(&bucket_dir))
+            .with_total_buckets(1)
+            .with_data_files(vec![test_data_file("data.parquet", 4, file_size)])
+            .build()
+            .unwrap()
+            .with_query_auth_grant(Some(grant));
+
+        // Filter runs on raw values, then the surviving rows are masked.
+        let read = TableRead::new(&table, table.schema().fields().to_vec(), Vec::new());
+        let batches = read
+            .to_arrow(std::slice::from_ref(&split))
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(collect_int_column(&batches, "id"), vec![3, 4]);
+        assert_eq!(batches[0].column(1).null_count(), 2, "value masked to NULL");
+
+        // A caller predicate on the masked column must fail closed (oracle guard).
+        let caller_filter = PredicateBuilder::new(table.schema().fields())
+            .equal("value", crate::spec::Datum::Int(20))
+            .unwrap();
+        let read = TableRead::new(
+            &table,
+            table.schema().fields().to_vec(),
+            vec![caller_filter],
+        );
+        let Err(err) = read.to_arrow(&[split]) else {
+            panic!("filtering on a masked column must fail closed");
+        };
+        assert!(err.to_string().contains("masked column"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_query_auth_scope_rejects_unauthorized_column() {
+        use crate::table::query_auth::QueryAuthGrant;
+        // A grant scoped to no columns must fail closed when the read projects
+        // `id` — the scope check runs in `to_arrow` before any data is read
+        // (and also at plan time; see the rest_catalog integration test).
+        let table = query_auth_table();
+        let grant = std::sync::Arc::new(QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::new()),
+        ));
+        let split = DataSplitBuilder::new()
+            .with_snapshot(1)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(0)
+            .with_bucket_path("/tmp/does-not-matter".to_string())
+            .with_total_buckets(1)
+            .with_data_files(vec![test_data_file("data.parquet", 4, 1)])
+            .build()
+            .unwrap()
+            .with_query_auth_grant(Some(grant));
+        let read = TableRead::new(&table, vec![table.schema().fields()[0].clone()], Vec::new());
+        let Err(err) = read.to_arrow(&[split]) else {
+            panic!("reading an unauthorized column must fail closed");
+        };
+        assert!(
+            err.to_string().contains("outside the authorized set"),
+            "got: {err}"
         );
     }
 

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -937,6 +937,7 @@ mod tests {
             vec![auth_filter],
             Vec::new(),
             None,
+            table.schema().id(),
         ));
 
         let split = DataSplitBuilder::new()
@@ -1009,7 +1010,12 @@ mod tests {
             table.schema().fields(),
         )
         .unwrap();
-        let grant = std::sync::Arc::new(QueryAuthGrant::new(vec![auth_filter], masks, None));
+        let grant = std::sync::Arc::new(QueryAuthGrant::new(
+            vec![auth_filter],
+            masks,
+            None,
+            table.schema().id(),
+        ));
 
         let split = DataSplitBuilder::new()
             .with_snapshot(1)
@@ -1059,6 +1065,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::new()),
+            table.schema().id(),
         ));
         let split = DataSplitBuilder::new()
             .with_snapshot(1)

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -210,6 +210,8 @@ impl<'a> ReadBuilder<'a> {
     }
 
     /// Set row ID ranges `[from, to]` (inclusive) for filtering in data evolution mode.
+    /// Slicing by physical row id selects rows by `_ROW_ID` without any
+    /// predicate, so it must reach the auth request like a filter on it would.
     pub fn with_row_ranges(&mut self, ranges: Vec<RowRange>) -> &mut Self {
         match &mut self.0 {
             ReadBuilderKind::Paimon(builder) => {
@@ -295,6 +297,9 @@ struct PaimonReadBuilder<'a> {
     /// split into partition/data conjuncts). The query-auth gates check these
     /// against the grant fetched at plan time.
     filter_columns: HashSet<usize>,
+    /// System columns (`_ROW_ID`, …) the caller filter referenced. They have no
+    /// table index, and row-id extraction strips the leaf before planning.
+    filter_system_names: HashSet<String>,
 }
 
 impl<'a> PaimonReadBuilder<'a> {
@@ -308,6 +313,7 @@ impl<'a> PaimonReadBuilder<'a> {
             row_ranges: None,
             case_sensitive: true,
             filter_columns: HashSet::new(),
+            filter_system_names: HashSet::new(),
         }
     }
 
@@ -367,12 +373,20 @@ impl<'a> PaimonReadBuilder<'a> {
     /// primary-key merge reads push key conjuncts below the merge and enforce
     /// the full predicate with an exact post-merge residual filter.
     pub fn with_filter(&mut self, filter: Predicate) -> &mut Self {
-        // Capture the columns of the FULL predicate before it is split into
-        // partition/data conjuncts, so both the masked-column guard and the
-        // authorized-scope check see a masked/unauthorized partition key (which
-        // would otherwise be pruned on its raw value).
+        // Capture the FULL predicate's columns before it is split into
+        // partition/data conjuncts, so the guards see a masked partition key
+        // that would otherwise be pruned on its raw value.
         self.filter_columns.clear();
-        filter.collect_leaf_field_indices(&mut self.filter_columns);
+        filter.collect_user_leaf_field_indices(&mut self.filter_columns);
+        // System columns too, and BEFORE `try_extract_row_id_ranges` strips the
+        // `_ROW_ID` leaf: it selects rows by that column without ever appearing
+        // in the read type, so the server must still get to refuse it.
+        let mut names = std::collections::HashSet::new();
+        filter.collect_leaf_column_names(&mut names);
+        self.filter_system_names = names
+            .into_iter()
+            .filter(|n| crate::table::query_auth::is_reserved_system_field_name(n.as_str()))
+            .collect();
         self.filter = normalize_filter(self.table, filter);
         self.try_extract_row_id_ranges();
         self
@@ -391,6 +405,8 @@ impl<'a> PaimonReadBuilder<'a> {
     }
 
     /// Set row ID ranges `[from, to]` (inclusive) for filtering in data evolution mode.
+    /// Slicing by physical row id selects rows by `_ROW_ID` without any
+    /// predicate, so it must reach the auth request like a filter on it would.
     pub fn with_row_ranges(&mut self, ranges: Vec<RowRange>) -> &mut Self {
         self.row_ranges = if ranges.is_empty() {
             None
@@ -445,10 +461,9 @@ impl<'a> PaimonReadBuilder<'a> {
         let partition_filter = self.filter.partition_predicate.clone().map(|pred| {
             PartitionFilter::from_predicate(pred, &self.table.schema().partition_fields())
         });
-        // The grant's auth field IDs are folded into the scan projection inside
-        // `TableScan::plan` — where the grant has been fetched — not here, where
-        // it does not yet exist (that early read of an empty grant was a
-        // fail-open row-filter bypass).
+        // The grant's field ids are folded into the projection in
+        // `TableScan::plan`, where it has been fetched; reading an empty grant
+        // here was a fail-open row-filter bypass.
         let read_type = self.resolve_read_type().unwrap_or(None);
         TableScan::new(
             self.table,
@@ -474,24 +489,18 @@ impl<'a> PaimonReadBuilder<'a> {
     /// Projected system fields (`_ROW_ID`, …). `projected_schema_indices` drops
     /// them for lack of an index, but Java's `select` includes them.
     fn projected_system_field_names(&self) -> Vec<String> {
-        self.resolve_read_type()
-            .ok()
-            .flatten()
-            .map(|fields| {
-                fields
-                    .iter()
-                    .filter(|f| crate::table::query_auth::is_reserved_system_field(f))
-                    .map(|f| f.name().to_string())
-                    .collect()
-            })
-            .unwrap_or_default()
+        crate::table::query_auth::projected_system_field_names(
+            self.resolve_read_type().ok().flatten().as_deref(),
+            &self.filter_system_names,
+            self.row_ranges.is_some(),
+        )
     }
 
     fn projected_schema_indices(&self) -> Option<Vec<usize>> {
         // Resolve names too: a `with_projection` selection lives in
-        // `projection_names`, and scoping the grant to all columns would deny a
-        // user authorized for exactly the requested subset. An unresolvable
-        // projection falls back to the full scope; `new_read` reports the error.
+        // `projection_names`, and scoping to all columns would deny a user
+        // authorized for exactly the subset. Unresolvable falls back to full
+        // scope; `new_read` reports the error.
         self.resolve_read_type().ok().flatten().map(|fields| {
             fields
                 .iter()
@@ -508,10 +517,8 @@ impl<'a> PaimonReadBuilder<'a> {
 
     /// Create a table read for consuming splits (e.g. from a scan plan).
     pub fn new_read(&self) -> Result<TableRead<'a>> {
-        // Query-auth is enforced in `TableRead::to_arrow` off the grant stamped
-        // on the splits by planning (fail closed when a query-auth table's
-        // splits carry no grant), so no gate is needed at read construction —
-        // an empty-splits fast path produces no rows to leak.
+        // Enforced in `TableRead::to_arrow` off the grant planning stamped on
+        // the splits, so read construction needs no gate.
         let read_type = match self.resolve_read_type()? {
             None => self.table.schema.fields().to_vec(),
             Some(fields) => fields,
@@ -957,6 +964,7 @@ mod tests {
             vec![auth_filter],
             Vec::new(),
             None,
+            None,
             crate::table::query_auth::GrantBinding::of(&table),
         ));
 
@@ -1034,6 +1042,7 @@ mod tests {
             vec![auth_filter],
             masks,
             None,
+            None,
             crate::table::query_auth::GrantBinding::of(&table),
         ));
 
@@ -1074,6 +1083,34 @@ mod tests {
         assert!(err.to_string().contains("masked column"), "got: {err}");
     }
 
+    #[test]
+    fn test_row_id_filter_reaches_the_auth_select() {
+        // `try_extract_row_id_ranges` strips the `_ROW_ID` leaf from the
+        // predicates during `with_filter`, so collecting system names from the
+        // surviving predicates afterwards would never see it.
+        let table = crate::table::query_auth_table();
+        let mut rb = table.new_read_builder();
+        let filter = crate::spec::Predicate::Leaf {
+            index: 0,
+            column: crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            data_type: crate::spec::DataType::BigInt(crate::spec::BigIntType::new()),
+            op: crate::spec::PredicateOperator::GtEq,
+            literals: vec![crate::spec::Datum::Long(5)],
+        };
+        rb.with_filter(filter);
+        let names = paimon_builder(&rb).projected_system_field_names();
+        assert!(
+            names.iter().any(|n| n == crate::spec::ROW_ID_FIELD_NAME),
+            "a _ROW_ID filter must reach the auth select, got {names:?}"
+        );
+
+        // An explicit row-range slice selects by `_ROW_ID` with no predicate.
+        let mut rb2 = table.new_read_builder();
+        rb2.with_row_ranges(vec![crate::table::RowRange::new(0, 10)]);
+        let names2 = paimon_builder(&rb2).projected_system_field_names();
+        assert!(names2.iter().any(|n| n == crate::spec::ROW_ID_FIELD_NAME));
+    }
+
     #[tokio::test]
     async fn test_query_auth_scope_rejects_unauthorized_column() {
         use crate::table::query_auth::QueryAuthGrant;
@@ -1085,6 +1122,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::new()),
+            None,
             crate::table::query_auth::GrantBinding::of(&table),
         ));
         let split = DataSplitBuilder::new()

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -212,6 +212,9 @@ impl<'a> ReadBuilder<'a> {
 
     /// Set Data Evolution row ID ranges `[from, to]` (inclusive).
     /// An empty vector selects no rows. Format tables are not supported.
+    ///
+    /// Slicing by physical row id selects rows by `_ROW_ID` without any
+    /// predicate, so it must reach the auth request like a filter on it would.
     pub fn with_row_ranges(&mut self, ranges: Vec<RowRange>) -> &mut Self {
         match &mut self.0 {
             ReadBuilderKind::Paimon(builder) => {
@@ -319,6 +322,9 @@ struct PaimonReadBuilder<'a> {
     /// split into partition/data conjuncts). The query-auth gates check these
     /// against the grant fetched at plan time.
     filter_columns: HashSet<usize>,
+    /// System columns (`_ROW_ID`, …) the caller filter referenced. They have no
+    /// table index, and row-id extraction strips the leaf before planning.
+    filter_system_names: HashSet<String>,
 }
 
 impl<'a> PaimonReadBuilder<'a> {
@@ -334,6 +340,7 @@ impl<'a> PaimonReadBuilder<'a> {
             case_sensitive: true,
             parquet_read_budget: None,
             filter_columns: HashSet::new(),
+            filter_system_names: HashSet::new(),
         }
     }
 
@@ -393,12 +400,22 @@ impl<'a> PaimonReadBuilder<'a> {
     /// primary-key merge reads push key conjuncts below the merge and enforce
     /// the full predicate with an exact post-merge residual filter.
     pub fn with_filter(&mut self, filter: Predicate) -> &mut Self {
-        // Capture the columns of the FULL predicate before it is split into
-        // partition/data conjuncts, so both the masked-column guard and the
-        // authorized-scope check see a masked/unauthorized partition key (which
-        // would otherwise be pruned on its raw value).
+        // The FULL predicate, before the partition/data split, so the guards see
+        // a masked partition key that would otherwise prune on its raw value.
+        // EVERY leaf index, including one naming a system field: that index is
+        // only meant to be a placeholder, but nothing validates it, and the
+        // partition split still maps by it. Counting it can only over-authorize.
         self.filter_columns.clear();
         filter.collect_leaf_field_indices(&mut self.filter_columns);
+        // System columns too, and BEFORE `try_extract_row_id_ranges` strips the
+        // `_ROW_ID` leaf: it selects rows by that column without ever appearing
+        // in the read type, so the server must still get to refuse it.
+        let mut names = std::collections::HashSet::new();
+        filter.collect_leaf_column_names(&mut names);
+        self.filter_system_names = names
+            .into_iter()
+            .filter(|n| crate::table::query_auth::is_reserved_system_field_name(n.as_str()))
+            .collect();
         self.filter = normalize_filter(self.table, filter);
         self.derived_row_ranges = None;
         self.try_extract_row_id_ranges();
@@ -418,6 +435,9 @@ impl<'a> PaimonReadBuilder<'a> {
     }
 
     /// Set row ID ranges `[from, to]` (inclusive). An empty vector selects no rows.
+    ///
+    /// Slicing by physical row id selects rows by `_ROW_ID` without any
+    /// predicate, so it must reach the auth request like a filter on it would.
     pub fn with_row_ranges(&mut self, ranges: Vec<RowRange>) -> &mut Self {
         self.explicit_row_ranges = Some(super::merge_row_ranges(ranges));
         self
@@ -494,10 +514,9 @@ impl<'a> PaimonReadBuilder<'a> {
         let partition_filter = self.filter.partition_predicate.clone().map(|pred| {
             PartitionFilter::from_predicate(pred, &self.table.schema().partition_fields())
         });
-        // The grant's auth field IDs are folded into the scan projection inside
-        // `TableScan::plan` — where the grant has been fetched — not here, where
-        // it does not yet exist (that early read of an empty grant was a
-        // fail-open row-filter bypass).
+        // The grant's field ids are folded into the projection in
+        // `TableScan::plan`, where it has been fetched; reading an empty grant
+        // here was a fail-open row-filter bypass.
         let read_type = self.resolve_read_type().unwrap_or(None);
         TableScan::new(
             self.table,
@@ -523,24 +542,18 @@ impl<'a> PaimonReadBuilder<'a> {
     /// Projected system fields (`_ROW_ID`, …). `projected_schema_indices` drops
     /// them for lack of an index, but Java's `select` includes them.
     fn projected_system_field_names(&self) -> Vec<String> {
-        self.resolve_read_type()
-            .ok()
-            .flatten()
-            .map(|fields| {
-                fields
-                    .iter()
-                    .filter(|f| crate::table::query_auth::is_reserved_system_field(f))
-                    .map(|f| f.name().to_string())
-                    .collect()
-            })
-            .unwrap_or_default()
+        crate::table::query_auth::projected_system_field_names(
+            self.resolve_read_type().ok().flatten().as_deref(),
+            &self.filter_system_names,
+            self.effective_row_ranges().is_some(),
+        )
     }
 
     fn projected_schema_indices(&self) -> Option<Vec<usize>> {
         // Resolve names too: a `with_projection` selection lives in
-        // `projection_names`, and scoping the grant to all columns would deny a
-        // user authorized for exactly the requested subset. An unresolvable
-        // projection falls back to the full scope; `new_read` reports the error.
+        // `projection_names`, and scoping to all columns would deny a user
+        // authorized for exactly the subset. Unresolvable falls back to full
+        // scope; `new_read` reports the error.
         self.resolve_read_type().ok().flatten().map(|fields| {
             fields
                 .iter()
@@ -557,10 +570,8 @@ impl<'a> PaimonReadBuilder<'a> {
 
     /// Create a table read for consuming splits (e.g. from a scan plan).
     pub fn new_read(&self) -> Result<TableRead<'a>> {
-        // Query-auth is enforced in `TableRead::to_arrow` off the grant stamped
-        // on the splits by planning (fail closed when a query-auth table's
-        // splits carry no grant), so no gate is needed at read construction —
-        // an empty-splits fast path produces no rows to leak.
+        // Enforced in `TableRead::to_arrow` off the grant planning stamped on
+        // the splits, so read construction needs no gate.
         let read_type = match self.resolve_read_type()? {
             None => self.table.schema.fields().to_vec(),
             Some(fields) => fields,
@@ -859,6 +870,28 @@ mod tests {
         )
     }
 
+    #[test]
+    fn test_a_system_named_leaf_still_authorizes_its_index() {
+        // A leaf's `column` and `index` are independent, so one named `_ROW_ID`
+        // can point at a partition key that the partition split still maps by
+        // index — the index must reach the scope whatever the name says.
+        let table = simple_table();
+        let spoofed = Predicate::Leaf {
+            column: crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            index: 0,
+            data_type: DataType::VarChar(VarCharType::string_type()),
+            op: crate::spec::PredicateOperator::Eq,
+            literals: vec![crate::spec::Datum::String("x".into())],
+        };
+        let mut builder = PaimonReadBuilder::new(&table);
+        builder.with_filter(spoofed);
+
+        assert!(
+            builder.filter_columns.contains(&0),
+            "the aliased index must be authorized, not skipped by name"
+        );
+    }
+
     fn simple_table() -> Table {
         let file_io = FileIOBuilder::new("file").build().unwrap();
         let table_schema = TableSchema::new(
@@ -1087,6 +1120,7 @@ mod tests {
             vec![auth_filter],
             Vec::new(),
             None,
+            None,
             crate::table::query_auth::GrantBinding::of(&table),
         ));
 
@@ -1164,6 +1198,7 @@ mod tests {
             vec![auth_filter],
             masks,
             None,
+            None,
             crate::table::query_auth::GrantBinding::of(&table),
         ));
 
@@ -1204,6 +1239,34 @@ mod tests {
         assert!(err.to_string().contains("masked column"), "got: {err}");
     }
 
+    #[test]
+    fn test_row_id_filter_reaches_the_auth_select() {
+        // `try_extract_row_id_ranges` strips the `_ROW_ID` leaf from the
+        // predicates during `with_filter`, so collecting system names from the
+        // surviving predicates afterwards would never see it.
+        let table = crate::table::query_auth_table();
+        let mut rb = table.new_read_builder();
+        let filter = crate::spec::Predicate::Leaf {
+            index: 0,
+            column: crate::spec::ROW_ID_FIELD_NAME.to_string(),
+            data_type: crate::spec::DataType::BigInt(crate::spec::BigIntType::new()),
+            op: crate::spec::PredicateOperator::GtEq,
+            literals: vec![crate::spec::Datum::Long(5)],
+        };
+        rb.with_filter(filter);
+        let names = paimon_builder(&rb).projected_system_field_names();
+        assert!(
+            names.iter().any(|n| n == crate::spec::ROW_ID_FIELD_NAME),
+            "a _ROW_ID filter must reach the auth select, got {names:?}"
+        );
+
+        // An explicit row-range slice selects by `_ROW_ID` with no predicate.
+        let mut rb2 = table.new_read_builder();
+        rb2.with_row_ranges(vec![crate::table::RowRange::new(0, 10)]);
+        let names2 = paimon_builder(&rb2).projected_system_field_names();
+        assert!(names2.iter().any(|n| n == crate::spec::ROW_ID_FIELD_NAME));
+    }
+
     #[tokio::test]
     async fn test_query_auth_scope_rejects_unauthorized_column() {
         use crate::table::query_auth::QueryAuthGrant;
@@ -1215,6 +1278,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::new()),
+            None,
             crate::table::query_auth::GrantBinding::of(&table),
         ));
         let split = DataSplitBuilder::new()

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -1067,6 +1067,7 @@ mod tests {
             vec![auth_filter],
             Vec::new(),
             None,
+            table.schema().id(),
         ));
 
         let split = DataSplitBuilder::new()
@@ -1139,7 +1140,12 @@ mod tests {
             table.schema().fields(),
         )
         .unwrap();
-        let grant = std::sync::Arc::new(QueryAuthGrant::new(vec![auth_filter], masks, None));
+        let grant = std::sync::Arc::new(QueryAuthGrant::new(
+            vec![auth_filter],
+            masks,
+            None,
+            table.schema().id(),
+        ));
 
         let split = DataSplitBuilder::new()
             .with_snapshot(1)
@@ -1189,6 +1195,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::new()),
+            table.schema().id(),
         ));
         let split = DataSplitBuilder::new()
             .with_snapshot(1)

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -315,6 +315,10 @@ struct PaimonReadBuilder<'a> {
     derived_row_ranges: Option<Vec<RowRange>>,
     case_sensitive: bool,
     parquet_read_budget: Option<Arc<crate::arrow::ParquetReadBudget>>,
+    /// Table-schema indices referenced by the full caller filter (before it is
+    /// split into partition/data conjuncts). The query-auth gates check these
+    /// against the grant fetched at plan time.
+    filter_columns: HashSet<usize>,
 }
 
 impl<'a> PaimonReadBuilder<'a> {
@@ -329,6 +333,7 @@ impl<'a> PaimonReadBuilder<'a> {
             derived_row_ranges: None,
             case_sensitive: true,
             parquet_read_budget: None,
+            filter_columns: HashSet::new(),
         }
     }
 
@@ -388,6 +393,12 @@ impl<'a> PaimonReadBuilder<'a> {
     /// primary-key merge reads push key conjuncts below the merge and enforce
     /// the full predicate with an exact post-merge residual filter.
     pub fn with_filter(&mut self, filter: Predicate) -> &mut Self {
+        // Capture the columns of the FULL predicate before it is split into
+        // partition/data conjuncts, so both the masked-column guard and the
+        // authorized-scope check see a masked/unauthorized partition key (which
+        // would otherwise be pruned on its raw value).
+        self.filter_columns.clear();
+        filter.collect_leaf_field_indices(&mut self.filter_columns);
         self.filter = normalize_filter(self.table, filter);
         self.derived_row_ranges = None;
         self.try_extract_row_id_ranges();
@@ -483,6 +494,10 @@ impl<'a> PaimonReadBuilder<'a> {
         let partition_filter = self.filter.partition_predicate.clone().map(|pred| {
             PartitionFilter::from_predicate(pred, &self.table.schema().partition_fields())
         });
+        // The grant's auth field IDs are folded into the scan projection inside
+        // `TableScan::plan` — where the grant has been fetched — not here, where
+        // it does not yet exist (that early read of an empty grant was a
+        // fail-open row-filter bypass).
         let read_type = self.resolve_read_type().unwrap_or(None);
         TableScan::new(
             self.table,
@@ -497,14 +512,35 @@ impl<'a> PaimonReadBuilder<'a> {
             &self.filter.data_predicates,
             self.table.schema().fields(),
         ))
+        .with_query_auth_scope(self.filter_columns.clone(), self.projected_schema_indices())
+    }
+
+    /// Table-schema indices of the projected columns (`None` = all).
+    fn projected_schema_indices(&self) -> Option<Vec<usize>> {
+        // Resolve names too: a `with_projection` selection lives in
+        // `projection_names`, and scoping the grant to all columns would deny a
+        // user authorized for exactly the requested subset. An unresolvable
+        // projection falls back to the full scope; `new_read` reports the error.
+        self.resolve_read_type().ok().flatten().map(|fields| {
+            fields
+                .iter()
+                .filter_map(|f| {
+                    self.table
+                        .schema()
+                        .fields()
+                        .iter()
+                        .position(|s| s.id() == f.id())
+                })
+                .collect()
+        })
     }
 
     /// Create a table read for consuming splits (e.g. from a scan plan).
     pub fn new_read(&self) -> Result<TableRead<'a>> {
-        // Fail closed at read construction so bindings that short-circuit before
-        // `to_arrow` (e.g. an empty-splits fast path) can't bypass the guard.
-        let core_options = self.table.schema.core_options();
-        core_options.ensure_read_authorized()?;
+        // Query-auth is enforced in `TableRead::to_arrow` off the grant stamped
+        // on the splits by planning (fail closed when a query-auth table's
+        // splits carry no grant), so no gate is needed at read construction —
+        // an empty-splits fast path produces no rows to leak.
         let read_type = match self.resolve_read_type()? {
             None => self.table.schema.fields().to_vec(),
             Some(fields) => fields,
@@ -943,28 +979,234 @@ mod tests {
             .unwrap()
     }
 
-    #[test]
-    fn test_read_fails_closed_when_query_auth_enabled() {
+    /// A real split carrying no query-auth grant (an unauthorized read path).
+    fn ungranted_split() -> crate::table::DataSplit {
+        DataSplitBuilder::new()
+            .with_snapshot(1)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(0)
+            .with_bucket_path("file:/tmp/bucket-0".to_string())
+            .with_total_buckets(1)
+            .with_data_files(vec![test_data_file("data.parquet", 4, 1)])
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_read_fails_closed_when_query_auth_enabled() {
         let table = query_auth_table();
-        // `new_read` fails closed, so bindings that short-circuit before `to_arrow` can't bypass.
-        let err = table.new_read_builder().new_read().unwrap_err();
+        // Enforcement is at `to_arrow` off the split grant: a read whose splits
+        // carry no grant (never authorized by planning) must fail closed, so
+        // bindings that short-circuit can't bypass.
+        let read = table.new_read_builder().new_read().unwrap();
+        let Err(err) = read.to_arrow(&[ungranted_split()]) else {
+            panic!("a query-auth read without a stamped grant must fail closed");
+        };
         assert!(
             matches!(err, crate::Error::Unsupported { ref message } if message.contains("query-auth.enabled")),
             "building a read for a query-auth.enabled table must fail closed"
         );
     }
 
-    #[test]
-    fn test_dynamic_option_cannot_disable_query_auth() {
+    #[tokio::test]
+    async fn test_dynamic_option_cannot_disable_query_auth() {
         // Copying the table with the option off must not weaken a stored `true`.
         let table = query_auth_table().copy_with_options(HashMap::from([(
             "query-auth.enabled".to_string(),
             "false".to_string(),
         )]));
-        let err = table.new_read_builder().new_read().unwrap_err();
+        let read = table.new_read_builder().new_read().unwrap();
+        let Err(err) = read.to_arrow(&[ungranted_split()]) else {
+            panic!("a dynamic override must not disable query-auth");
+        };
         assert!(
             matches!(err, crate::Error::Unsupported { ref message } if message.contains("query-auth.enabled")),
             "a dynamic override must not disable query-auth"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_query_auth_filtered_grant_filters_rows_exactly() {
+        let tempdir = tempdir().unwrap();
+        let table_path = local_file_path(tempdir.path());
+        let bucket_dir = tempdir.path().join("bucket-0");
+        fs::create_dir_all(&bucket_dir).unwrap();
+
+        let parquet_path = bucket_dir.join("data.parquet");
+        write_int_parquet_file(
+            &parquet_path,
+            vec![("id", vec![1, 2, 3, 4]), ("value", vec![1, 2, 20, 30])],
+            None,
+        );
+        let file_size = fs::metadata(&parquet_path).unwrap().len() as i64;
+
+        let file_io = FileIOBuilder::new("file").build().unwrap();
+        let table_schema = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("value", DataType::Int(IntType::new()))
+                .option("query-auth.enabled", "true")
+                .build()
+                .unwrap(),
+        );
+        let table = Table::new(
+            file_io,
+            Identifier::new("default", "t"),
+            table_path,
+            table_schema,
+            None,
+        );
+        // Grant: the user may only see rows with value >= 10. The filter column
+        // is NOT in the projection, so the read must fetch it and project it away.
+        // The grant is threaded on the split (as scan planning would stamp it).
+        let auth_filter = PredicateBuilder::new(table.schema().fields())
+            .greater_or_equal("value", crate::spec::Datum::Int(10))
+            .unwrap();
+        let grant = std::sync::Arc::new(crate::table::query_auth::QueryAuthGrant::new(
+            vec![auth_filter],
+            Vec::new(),
+            None,
+        ));
+
+        let split = DataSplitBuilder::new()
+            .with_snapshot(1)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(0)
+            .with_bucket_path(local_file_path(&bucket_dir))
+            .with_total_buckets(1)
+            .with_data_files(vec![test_data_file("data.parquet", 4, file_size)])
+            .build()
+            .unwrap()
+            .with_query_auth_grant(Some(grant));
+
+        let read = TableRead::new(&table, vec![table.schema().fields()[0].clone()], Vec::new());
+        let batches = read
+            .to_arrow(&[split])
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(collect_int_column(&batches, "id"), vec![3, 4]);
+        // The filter column must not leak into the output schema.
+        assert_eq!(batches[0].num_columns(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_query_auth_masked_grant_masks_and_guards_predicates() {
+        use crate::table::query_auth::{parse_column_masking, QueryAuthGrant};
+        use arrow_array::Array;
+
+        let tempdir = tempdir().unwrap();
+        let table_path = local_file_path(tempdir.path());
+        let bucket_dir = tempdir.path().join("bucket-0");
+        fs::create_dir_all(&bucket_dir).unwrap();
+        let parquet_path = bucket_dir.join("data.parquet");
+        write_int_parquet_file(
+            &parquet_path,
+            vec![("id", vec![1, 2, 3, 4]), ("value", vec![1, 2, 20, 30])],
+            None,
+        );
+        let file_size = fs::metadata(&parquet_path).unwrap().len() as i64;
+
+        let file_io = FileIOBuilder::new("file").build().unwrap();
+        let table_schema = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("value", DataType::Int(IntType::new()))
+                .option("query-auth.enabled", "true")
+                .build()
+                .unwrap(),
+        );
+        let table = Table::new(
+            file_io,
+            Identifier::new("default", "t"),
+            table_path,
+            table_schema,
+            None,
+        );
+        // Grant: filter on raw `value` >= 10, then mask `value` with NULL.
+        let auth_filter = PredicateBuilder::new(table.schema().fields())
+            .greater_or_equal("value", crate::spec::Datum::Int(10))
+            .unwrap();
+        let masks = parse_column_masking(
+            &std::collections::HashMap::from([(
+                "value".to_string(),
+                r#"{"name":"NULL"}"#.to_string(),
+            )]),
+            table.schema().fields(),
+        )
+        .unwrap();
+        let grant = std::sync::Arc::new(QueryAuthGrant::new(vec![auth_filter], masks, None));
+
+        let split = DataSplitBuilder::new()
+            .with_snapshot(1)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(0)
+            .with_bucket_path(local_file_path(&bucket_dir))
+            .with_total_buckets(1)
+            .with_data_files(vec![test_data_file("data.parquet", 4, file_size)])
+            .build()
+            .unwrap()
+            .with_query_auth_grant(Some(grant));
+
+        // Filter runs on raw values, then the surviving rows are masked.
+        let read = TableRead::new(&table, table.schema().fields().to_vec(), Vec::new());
+        let batches = read
+            .to_arrow(std::slice::from_ref(&split))
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(collect_int_column(&batches, "id"), vec![3, 4]);
+        assert_eq!(batches[0].column(1).null_count(), 2, "value masked to NULL");
+
+        // A caller predicate on the masked column must fail closed (oracle guard).
+        let caller_filter = PredicateBuilder::new(table.schema().fields())
+            .equal("value", crate::spec::Datum::Int(20))
+            .unwrap();
+        let read = TableRead::new(
+            &table,
+            table.schema().fields().to_vec(),
+            vec![caller_filter],
+        );
+        let Err(err) = read.to_arrow(&[split]) else {
+            panic!("filtering on a masked column must fail closed");
+        };
+        assert!(err.to_string().contains("masked column"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_query_auth_scope_rejects_unauthorized_column() {
+        use crate::table::query_auth::QueryAuthGrant;
+        // A grant scoped to no columns must fail closed when the read projects
+        // `id` — the scope check runs in `to_arrow` before any data is read
+        // (and also at plan time; see the rest_catalog integration test).
+        let table = query_auth_table();
+        let grant = std::sync::Arc::new(QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::new()),
+        ));
+        let split = DataSplitBuilder::new()
+            .with_snapshot(1)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(0)
+            .with_bucket_path("/tmp/does-not-matter".to_string())
+            .with_total_buckets(1)
+            .with_data_files(vec![test_data_file("data.parquet", 4, 1)])
+            .build()
+            .unwrap()
+            .with_query_auth_grant(Some(grant));
+        let read = TableRead::new(&table, vec![table.schema().fields()[0].clone()], Vec::new());
+        let Err(err) = read.to_arrow(&[split]) else {
+            panic!("reading an unauthorized column must fail closed");
+        };
+        assert!(
+            err.to_string().contains("outside the authorized set"),
+            "got: {err}"
         );
     }
 

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -512,10 +512,30 @@ impl<'a> PaimonReadBuilder<'a> {
             &self.filter.data_predicates,
             self.table.schema().fields(),
         ))
-        .with_query_auth_scope(self.filter_columns.clone(), self.projected_schema_indices())
+        .with_query_auth_scope(
+            self.filter_columns.clone(),
+            self.projected_schema_indices(),
+            self.projected_system_field_names(),
+        )
     }
 
     /// Table-schema indices of the projected columns (`None` = all).
+    /// Projected system fields (`_ROW_ID`, …). `projected_schema_indices` drops
+    /// them for lack of an index, but Java's `select` includes them.
+    fn projected_system_field_names(&self) -> Vec<String> {
+        self.resolve_read_type()
+            .ok()
+            .flatten()
+            .map(|fields| {
+                fields
+                    .iter()
+                    .filter(|f| crate::table::query_auth::is_reserved_system_field(f))
+                    .map(|f| f.name().to_string())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     fn projected_schema_indices(&self) -> Option<Vec<usize>> {
         // Resolve names too: a `with_projection` selection lives in
         // `projection_names`, and scoping the grant to all columns would deny a
@@ -1067,7 +1087,7 @@ mod tests {
             vec![auth_filter],
             Vec::new(),
             None,
-            table.schema().id(),
+            crate::table::query_auth::GrantBinding::of(&table),
         ));
 
         let split = DataSplitBuilder::new()
@@ -1144,7 +1164,7 @@ mod tests {
             vec![auth_filter],
             masks,
             None,
-            table.schema().id(),
+            crate::table::query_auth::GrantBinding::of(&table),
         ));
 
         let split = DataSplitBuilder::new()
@@ -1195,7 +1215,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::new()),
-            table.schema().id(),
+            crate::table::query_auth::GrantBinding::of(&table),
         ));
         let split = DataSplitBuilder::new()
             .with_snapshot(1)

--- a/crates/paimon/src/table/rest_env.rs
+++ b/crates/paimon/src/table/rest_env.rs
@@ -188,6 +188,15 @@ impl RESTEnv {
         ))
     }
 
+    /// Fetch the per-user row filter and column masking for this table.
+    /// Mirrors Java `CatalogEnvironment.tableQueryAuth()`.
+    pub(crate) async fn table_query_auth(
+        &self,
+        select: Option<Vec<String>>,
+    ) -> Result<crate::api::AuthTableQueryResponse> {
+        self.api.auth_table_query(&self.identifier, select).await
+    }
+
     /// Create a `RESTSnapshotCommit` from this environment.
     pub fn snapshot_commit(&self) -> Arc<dyn SnapshotCommit> {
         Arc::new(RESTSnapshotCommit::new(

--- a/crates/paimon/src/table/rest_env.rs
+++ b/crates/paimon/src/table/rest_env.rs
@@ -71,6 +71,12 @@ impl RESTEnv {
         }
     }
 
+    /// The REST catalog's table UUID: stable across renames and unique across
+    /// catalogs, unlike an identifier or the per-table schema counter.
+    pub(crate) fn uuid(&self) -> &str {
+        &self.uuid
+    }
+
     #[cfg(test)]
     fn has_local_cache(&self) -> bool {
         self.local_cache.is_some()

--- a/crates/paimon/src/table/rest_env.rs
+++ b/crates/paimon/src/table/rest_env.rs
@@ -71,6 +71,12 @@ impl RESTEnv {
         }
     }
 
+    /// The REST catalog's table UUID: stable across renames and unique across
+    /// catalogs, unlike an identifier or the per-table schema counter.
+    pub(crate) fn uuid(&self) -> &str {
+        &self.uuid
+    }
+
     #[cfg(test)]
     fn has_local_cache(&self) -> bool {
         self.local_cache.is_some()
@@ -79,6 +85,51 @@ impl RESTEnv {
     /// Get the REST API client.
     pub fn api(&self) -> &Arc<RESTApi> {
         &self.api
+    }
+
+    /// Confirm the server still resolves this environment's identifier to the
+    /// UUID this handle was loaded with.
+    ///
+    /// The authorization exchange returns only the filter and the masks, so
+    /// nothing in it proves *which* table the server authorized. After a drop
+    /// and a same-name re-create, a permissive replacement would otherwise issue
+    /// a grant that a stale handle applies to the old table's files.
+    pub(crate) async fn ensure_uuid_is_current(&self) -> Result<()> {
+        let response = self.api.get_table(&self.identifier).await?;
+        match response.id.as_deref() {
+            Some(server_uuid) if server_uuid == self.uuid => Ok(()),
+            Some(server_uuid) => Err(Error::DataInvalid {
+                message: format!(
+                    "table '{}' now resolves to uuid {server_uuid}, not the {} this handle was \
+                     loaded with; re-load the table before reading it",
+                    self.identifier.full_name(),
+                    self.uuid
+                ),
+                source: None,
+            }),
+            // A server that does not report an id cannot be checked against.
+            None => Ok(()),
+        }
+    }
+
+    /// A copy of this environment addressing `branch` of the same table, as
+    /// Java spells it: `db.table$branch_<name>`. The main branch is the table
+    /// itself and needs no suffix.
+    pub(crate) fn for_branch(&self, branch: &str) -> Result<Self> {
+        if branch == crate::catalog::DEFAULT_MAIN_BRANCH {
+            return Ok(self.clone());
+        }
+        let object = format!(
+            "{}{}{}{}",
+            self.identifier.object(),
+            crate::catalog::SYSTEM_TABLE_SPLITTER,
+            crate::catalog::SYSTEM_BRANCH_PREFIX,
+            branch
+        );
+        Ok(Self {
+            identifier: Identifier::new(self.identifier.database(), &object),
+            ..self.clone()
+        })
     }
 
     /// Get the table identifier.
@@ -372,5 +423,33 @@ mod tests {
 
         assert!(rest_env.has_local_cache());
         assert!(rest_env.clone().has_local_cache());
+    }
+
+    #[tokio::test]
+    async fn test_for_branch_addresses_the_branch_table() {
+        let mut options = Options::new();
+        options.set(CatalogOptions::URI, "http://localhost:1");
+        options.set(CatalogOptions::WAREHOUSE, "test-warehouse");
+        options.set(CatalogOptions::TOKEN_PROVIDER, "bear");
+        options.set(CatalogOptions::TOKEN, "test-token");
+        let api = Arc::new(RESTApi::new(options.clone(), false).await.unwrap());
+        let rest_env = RESTEnv::new(
+            Identifier::new("db", "t"),
+            "uuid".to_string(),
+            api,
+            options,
+            false,
+            None,
+        );
+
+        let branch = rest_env.for_branch("b1").unwrap();
+        assert_eq!(branch.identifier().object(), "t$branch_b1");
+        assert_eq!(branch.identifier().database(), "db");
+
+        // The main branch IS the table; no suffix.
+        let main = rest_env
+            .for_branch(crate::catalog::DEFAULT_MAIN_BRANCH)
+            .unwrap();
+        assert_eq!(main.identifier().object(), "t");
     }
 }

--- a/crates/paimon/src/table/rest_env.rs
+++ b/crates/paimon/src/table/rest_env.rs
@@ -304,6 +304,15 @@ impl RESTEnv {
         builder.build()
     }
 
+    /// Fetch the per-user row filter and column masking for this table.
+    /// Mirrors Java `CatalogEnvironment.tableQueryAuth()`.
+    pub(crate) async fn table_query_auth(
+        &self,
+        select: Option<Vec<String>>,
+    ) -> Result<crate::api::AuthTableQueryResponse> {
+        self.api.auth_table_query(&self.identifier, select).await
+    }
+
     /// Create a `RESTSnapshotCommit` from this environment.
     pub fn snapshot_commit(&self) -> Arc<dyn SnapshotCommit> {
         Arc::new(RESTSnapshotCommit::new(

--- a/crates/paimon/src/table/sorted_global_index_build_builder.rs
+++ b/crates/paimon/src/table/sorted_global_index_build_builder.rs
@@ -100,9 +100,12 @@ impl<'a> SortedGlobalIndexBuildBuilder<'a> {
 
     pub async fn execute(&self) -> Result<usize> {
         // Building the index scans the table's rows.
-        CoreOptions::new(self.table.schema().options()).ensure_read_authorized()?;
-
         self.table.ensure_not_branch_reference_for_write()?;
+        // Authorize before reading any manifest or index metadata, and once for
+        // the whole build: doing it per shard both skipped the early-return
+        // paths and issued one REST round-trip per shard.
+        let build_grant = self.table.authorize_unrestricted_read().await?;
+        let grant = build_grant.as_ref();
 
         let index_type = normalize_queryable_global_index_type(&self.index_type).ok_or_else(|| {
             Error::Unsupported {
@@ -204,7 +207,7 @@ impl<'a> SortedGlobalIndexBuildBuilder<'a> {
         let mut messages = Vec::with_capacity(shard_count);
         for shard in shards {
             let index_file = match self
-                .build_index_file(&shard, index_field, index_column, &write_options)
+                .build_index_file(&shard, index_field, index_column, &write_options, grant)
                 .await
             {
                 Ok(index_file) => index_file,

--- a/crates/paimon/src/table/sorted_global_index_build_builder/extraction.rs
+++ b/crates/paimon/src/table/sorted_global_index_build_builder/extraction.rs
@@ -39,7 +39,15 @@ pub(super) async fn extract_index_rows(
     index_type: &str,
     serialize_key: SerializeKeyFn,
 ) -> Result<Vec<SortedIndexKeyRow>> {
-    let splits = build_read_splits_for_shard(shard)?;
+    // Building the global index reads the indexed column across the shard. Under
+    // a restricted query-auth grant that read would drop/mask rows, so the index
+    // would be built over a filtered view. Require an unrestricted grant and read
+    // raw (stamp the returned grant on each split).
+    let build_grant = table.authorize_unrestricted_read().await?;
+    let splits: Vec<crate::table::DataSplit> = build_read_splits_for_shard(shard)?
+        .into_iter()
+        .map(|split| split.with_query_auth_grant(build_grant.clone()))
+        .collect();
 
     let mut read_builder = table.new_read_builder();
     read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME])?;

--- a/crates/paimon/src/table/sorted_global_index_build_builder/extraction.rs
+++ b/crates/paimon/src/table/sorted_global_index_build_builder/extraction.rs
@@ -38,15 +38,14 @@ pub(super) async fn extract_index_rows(
     index_field: &DataField,
     index_type: &str,
     serialize_key: SerializeKeyFn,
+    grant: Option<&std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>,
 ) -> Result<Vec<SortedIndexKeyRow>> {
-    // Building the global index reads the indexed column across the shard. Under
-    // a restricted query-auth grant that read would drop/mask rows, so the index
-    // would be built over a filtered view. Require an unrestricted grant and read
-    // raw (stamp the returned grant on each split).
-    let build_grant = table.authorize_unrestricted_read().await?;
+    // Building the global index reads the indexed column raw, so `grant` must be
+    // the unrestricted one the caller obtained: a restricted one would index a
+    // filtered or masked view. Stamp it so each split's read is authorized.
     let splits: Vec<crate::table::DataSplit> = build_read_splits_for_shard(shard)?
         .into_iter()
-        .map(|split| split.with_query_auth_grant(build_grant.clone()))
+        .map(|split| split.with_query_auth_grant(grant.cloned()))
         .collect();
 
     let mut read_builder = table.new_read_builder();

--- a/crates/paimon/src/table/sorted_global_index_build_builder/writer.rs
+++ b/crates/paimon/src/table/sorted_global_index_build_builder/writer.rs
@@ -47,6 +47,7 @@ impl SortedGlobalIndexBuildBuilder<'_> {
         index_field: &DataField,
         index_column: &str,
         write_options: &GlobalIndexWriteOptions,
+        grant: Option<&std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>,
     ) -> Result<IndexFileMeta> {
         let index_type = normalize_queryable_global_index_type(&self.index_type).ok_or_else(|| {
             Error::Unsupported {
@@ -77,6 +78,7 @@ impl SortedGlobalIndexBuildBuilder<'_> {
                 index_field,
                 index_type,
                 serialize_key,
+                grant,
             )
             .await?
         };

--- a/crates/paimon/src/table/source.rs
+++ b/crates/paimon/src/table/source.rs
@@ -1465,7 +1465,7 @@ mod tests {
         let filter = PredicateBuilder::new(&fields)
             .greater_than("id", crate::spec::Datum::Int(1))
             .unwrap();
-        let restricted = Arc::new(QueryAuthGrant::new(vec![filter], Vec::new(), None));
+        let restricted = Arc::new(QueryAuthGrant::new(vec![filter], Vec::new(), None, 0));
         let plain = split(vec![file("a", 1, None)], true);
         let guarded = plain.clone().with_query_auth_grant(Some(restricted));
 

--- a/crates/paimon/src/table/source.rs
+++ b/crates/paimon/src/table/source.rs
@@ -489,19 +489,16 @@ pub struct DataSplit {
     /// physical rows are exactly its logical rows (modulo deletion files).
     /// Mirrors Java `DataSplit#rawConvertible`.
     raw_convertible: bool,
-    /// The per-user query-auth grant this split must be read under, stamped by
-    /// scan planning (or a write-path authorizer). Runtime-only — never
-    /// serialized — mirroring Java `QueryAuthSplit(split, authResult)`. Carried
-    /// on the split so `TableRead::to_arrow` enforces the exact grant the plan
-    /// fetched, instead of a shared mutable slot on `Table`.
+    /// The grant this split must be read under, stamped by scan planning.
+    /// Runtime-only, mirroring Java `QueryAuthSplit(split, authResult)`: on the
+    /// split so `to_arrow` enforces exactly the grant its plan fetched.
     #[serde(skip)]
     query_auth_grant: Option<Arc<QueryAuthGrant>>,
 }
 
-/// Hand-written so that serializing a split planned under a restricted
-/// query-auth grant FAILS instead of silently dropping the grant: no serde
-/// format carries it, so the receiver would read the split's files raw. The
-/// emitted shape is identical to the derived one (the grant is never a field).
+/// Hand-written so serializing a split planned under a grant FAILS instead of
+/// silently dropping it — no serde format carries it. The emitted shape is
+/// identical to the derived one.
 impl Serialize for DataSplit {
     fn serialize<S: serde::Serializer>(
         &self,
@@ -595,18 +592,16 @@ impl DataSplit {
     }
 
     /// Whether this split is planned under a grant that filters rows or masks
-    /// columns. Engines must not publish this split's raw manifest statistics
-    /// (min/max/null counts describe the data before enforcement), and must not
-    /// send it across a wire format that cannot carry the grant.
+    /// columns. Engines must not publish its raw manifest statistics, which
+    /// describe the data before enforcement.
     pub fn has_restricted_query_auth_grant(&self) -> bool {
         self.query_auth_grant
             .as_ref()
             .is_some_and(|g| g.has_server_restrictions())
     }
 
-    /// Whether this split carries any grant that is not fully unrestricted —
-    /// row filter, column mask, **or** column scope. Transport and
-    /// re-authorization use this instead of
+    /// Whether this split carries any grant that is not fully unrestricted.
+    /// Transport and re-authorization use this rather than
     /// [`Self::has_restricted_query_auth_grant`]: a scope-only grant distorts no
     /// statistics, but no wire format carries it either.
     pub fn carries_query_auth_restriction(&self) -> bool {
@@ -682,6 +677,17 @@ impl DataSplit {
     ///
     /// Reference: [DataSplit.mergedRowCount()](https://github.com/apache/paimon/blob/release-1.3/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java#L133)
     pub fn merged_row_count(&self) -> Option<i64> {
+        // A row filter drops rows after the scan, so the manifest count is not
+        // the logical output count. Java's `QueryAuthSplit.mergedRowCount()`
+        // returns empty for the same reason; `Plan::row_counts_exact` only
+        // covers callers that go through the plan.
+        if self
+            .query_auth_grant
+            .as_ref()
+            .is_some_and(|g| g.has_row_filter())
+        {
+            return None;
+        }
         if !self.row_counts_known() {
             return None;
         }
@@ -756,17 +762,19 @@ impl DataSplit {
     /// Serialize the DataSplit fields to Java `DataSplit#serialize` (version 8) binary.
     /// Byte-compatible with `compatibility/datasplit-v8`. Row ranges are not part of the v8
     /// format; `serialize_split_v1` wraps a row-range split as an `IndexedSplit` instead.
-    /// Fail closed when this split carries a restricted query-auth grant and is
-    /// about to leave the process: no split wire format (native bytes, the Java
-    /// `SplitSerializer` frame, or serde) carries the grant, so the receiver
-    /// would read the data raw. `what` names the attempted operation.
+    /// Fail closed when a split carrying a grant is about to leave the process:
+    /// no wire format (native bytes, the Java `SplitSerializer` frame, serde)
+    /// carries it. `what` names the attempted operation.
     fn ensure_no_restricted_grant(&self, what: &str) -> crate::Result<()> {
         match &self.query_auth_grant {
-            Some(grant) if !grant.is_unrestricted() => Err(crate::Error::Unsupported {
+            // Any stamped grant, unrestricted included: the receiver would get
+            // a grant-less split and fail closed anyway, so refuse at the
+            // boundary where the cause is still visible.
+            Some(_) => Err(crate::Error::Unsupported {
                 message: format!(
                     "cannot {what} a split planned under a query-auth grant: no wire format \
-                     carries the grant, so the receiver would read the data without its row \
-                     filter, column masking, or column scope"
+                     carries the grant, so the receiver could not enforce the row filter, \
+                     column masking, or column scope it was planned under"
                 ),
             }),
             _ => Ok(()),
@@ -1382,6 +1390,10 @@ pub struct Plan {
     /// False when a residual pass (e.g. a query-auth row filter) drops rows
     /// after the scan, so split row counts overcount the read output.
     row_counts_exact: bool,
+    /// Whether this plan was made under a server-restricted grant. Recorded on
+    /// the plan, not inferred from its splits: a fully pruned plan has none to
+    /// carry the grant but its scan metadata is just as pre-enforcement.
+    query_auth_restricted: bool,
 }
 
 impl Plan {
@@ -1389,6 +1401,7 @@ impl Plan {
         Self {
             splits,
             row_counts_exact: true,
+            query_auth_restricted: false,
         }
     }
     pub(crate) fn with_inexact_row_counts(mut self) -> Self {
@@ -1396,12 +1409,11 @@ impl Plan {
         self
     }
 
-    /// Stamp the per-user query-auth grant onto every split so
-    /// [`crate::table::TableRead::to_arrow`] enforces exactly the grant this
-    /// plan fetched (see [`DataSplit::with_query_auth_grant`]). A no-op when
-    /// `grant` is `None` (non-query-auth table): splits keep their empty grant
-    /// and read raw.
+    /// Stamp the grant onto every split so [`crate::table::TableRead::to_arrow`]
+    /// enforces exactly the one this plan fetched. A no-op for `None` (not a
+    /// query-auth table).
     pub(crate) fn stamp_query_auth_grant(mut self, grant: Option<Arc<QueryAuthGrant>>) -> Self {
+        self.query_auth_restricted = grant.as_ref().is_some_and(|g| g.has_server_restrictions());
         if grant.is_some() {
             self.splits = self
                 .splits
@@ -1417,6 +1429,17 @@ impl Plan {
     /// Whether split row counts exactly reflect the rows a read will produce.
     pub fn row_counts_exact(&self) -> bool {
         self.row_counts_exact
+    }
+
+    /// Whether this plan was made under a row filter or column masking.
+    ///
+    /// Recorded on the plan, unlike
+    /// [`DataSplit::has_restricted_query_auth_grant`] which inspects one split's
+    /// grant: a fully pruned plan has no split to carry it, yet its scan
+    /// metadata (split/file counts, pruning counters) is just as
+    /// pre-enforcement, so engines must not publish it either.
+    pub fn planned_under_restricted_grant(&self) -> bool {
+        self.query_auth_restricted
     }
 }
 
@@ -1464,7 +1487,7 @@ mod tests {
     }
 
     #[test]
-    fn test_restricted_grant_split_cannot_be_serialized() {
+    fn test_query_auth_grant_split_cannot_be_serialized() {
         use crate::spec::{DataType, IntType, PredicateBuilder};
         use crate::table::query_auth::QueryAuthGrant;
 
@@ -1480,6 +1503,7 @@ mod tests {
             vec![filter],
             Vec::new(),
             None,
+            None,
             crate::table::query_auth::GrantBinding::default(),
         ));
         let plain = split(vec![file("a", 1, None)], true);
@@ -1494,13 +1518,16 @@ mod tests {
             "serde (pickle, JSON)"
         );
 
-        // Unstamped and unrestricted splits still serialize.
+        // Only an unstamped split serializes. An unrestricted grant is refused
+        // too: the receiver would get a grant-less split and fail closed when
+        // reading it, so rejecting here reports the real cause at the boundary.
         assert!(plain.serialize().is_ok());
         assert!(serde_json::to_vec(&plain).is_ok());
         let unrestricted = plain
             .clone()
             .with_query_auth_grant(Some(Arc::new(QueryAuthGrant::default())));
-        assert!(serde_json::to_vec(&unrestricted).is_ok());
+        assert!(unrestricted.serialize().is_err());
+        assert!(serde_json::to_vec(&unrestricted).is_err());
     }
 
     #[test]

--- a/crates/paimon/src/table/source.rs
+++ b/crates/paimon/src/table/source.rs
@@ -20,8 +20,10 @@
 //! Reference: [org.apache.paimon.table.source](https://github.com/apache/paimon/blob/master/paimon-core/src/main/java/org/apache/paimon/table/source/).
 
 use crate::spec::{BinaryRow, DataFileMeta};
+use crate::table::query_auth::QueryAuthGrant;
 use crate::table::stats_filter::group_by_overlapping_row_id;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 fn is_vector_store_file_name(file_name: &str) -> bool {
     file_name.to_ascii_lowercase().contains(".vector.")
@@ -471,7 +473,7 @@ impl PartitionBucket {
 /// Input split for reading: partition + bucket + list of data files and optional deletion files.
 ///
 /// Reference: [org.apache.paimon.table.source.DataSplit](https://github.com/apache/paimon/blob/release-1.3/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java)
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct DataSplit {
     snapshot_id: i64,
     partition: BinaryRow,
@@ -487,6 +489,54 @@ pub struct DataSplit {
     /// physical rows are exactly its logical rows (modulo deletion files).
     /// Mirrors Java `DataSplit#rawConvertible`.
     raw_convertible: bool,
+    /// The per-user query-auth grant this split must be read under, stamped by
+    /// scan planning (or a write-path authorizer). Runtime-only — never
+    /// serialized — mirroring Java `QueryAuthSplit(split, authResult)`. Carried
+    /// on the split so `TableRead::to_arrow` enforces the exact grant the plan
+    /// fetched, instead of a shared mutable slot on `Table`.
+    #[serde(skip)]
+    query_auth_grant: Option<Arc<QueryAuthGrant>>,
+}
+
+/// Hand-written so that serializing a split planned under a restricted
+/// query-auth grant FAILS instead of silently dropping the grant: no serde
+/// format carries it, so the receiver would read the split's files raw. The
+/// emitted shape is identical to the derived one (the grant is never a field).
+impl Serialize for DataSplit {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        use serde::ser::Error as _;
+        self.ensure_no_restricted_grant("serialize")
+            .map_err(S::Error::custom)?;
+
+        #[derive(Serialize)]
+        struct Wire<'a> {
+            snapshot_id: &'a i64,
+            partition: &'a BinaryRow,
+            bucket: &'a i32,
+            bucket_path: &'a String,
+            total_buckets: &'a i32,
+            data_files: &'a Vec<DataFileMeta>,
+            data_deletion_files: &'a Option<Vec<Option<DeletionFile>>>,
+            row_ranges: &'a Option<Vec<RowRange>>,
+            raw_convertible: &'a bool,
+        }
+
+        Wire {
+            snapshot_id: &self.snapshot_id,
+            partition: &self.partition,
+            bucket: &self.bucket,
+            bucket_path: &self.bucket_path,
+            total_buckets: &self.total_buckets,
+            data_files: &self.data_files,
+            data_deletion_files: &self.data_deletion_files,
+            row_ranges: &self.row_ranges,
+            raw_convertible: &self.raw_convertible,
+        }
+        .serialize(serializer)
+    }
 }
 
 impl DataSplit {
@@ -537,6 +587,28 @@ impl DataSplit {
                 .data_files
                 .iter()
                 .all(|file| file.level != 0 && file.delete_row_count == Some(0))
+    }
+
+    /// The query-auth grant this split is read under, if any (see the field doc).
+    pub(crate) fn query_auth_grant(&self) -> Option<&Arc<QueryAuthGrant>> {
+        self.query_auth_grant.as_ref()
+    }
+
+    /// Whether this split is planned under a grant that filters rows or masks
+    /// columns. Engines must not publish this split's raw manifest statistics
+    /// (min/max/null counts describe the data before enforcement), and must not
+    /// send it across a wire format that cannot carry the grant.
+    pub fn has_restricted_query_auth_grant(&self) -> bool {
+        self.query_auth_grant
+            .as_ref()
+            .is_some_and(|g| g.has_server_restrictions())
+    }
+
+    /// Stamp the query-auth grant this split must be read under. Called by scan
+    /// planning and write-path authorizers on every emitted split.
+    pub(crate) fn with_query_auth_grant(mut self, grant: Option<Arc<QueryAuthGrant>>) -> Self {
+        self.query_auth_grant = grant;
+        self
     }
 
     /// Returns the deletion file for the data file at the given index, if any. `None` at that index means no deletion file.
@@ -673,7 +745,25 @@ impl DataSplit {
     /// Serialize the DataSplit fields to Java `DataSplit#serialize` (version 8) binary.
     /// Byte-compatible with `compatibility/datasplit-v8`. Row ranges are not part of the v8
     /// format; `serialize_split_v1` wraps a row-range split as an `IndexedSplit` instead.
+    /// Fail closed when this split carries a restricted query-auth grant and is
+    /// about to leave the process: no split wire format (native bytes, the Java
+    /// `SplitSerializer` frame, or serde) carries the grant, so the receiver
+    /// would read the data raw. `what` names the attempted operation.
+    fn ensure_no_restricted_grant(&self, what: &str) -> crate::Result<()> {
+        match &self.query_auth_grant {
+            Some(grant) if grant.has_server_restrictions() => Err(crate::Error::Unsupported {
+                message: format!(
+                    "cannot {what} a split planned under a query-auth row filter / column \
+                     masking grant: the grant cannot cross the wire, so the reader would see \
+                     unfiltered data"
+                ),
+            }),
+            _ => Ok(()),
+        }
+    }
+
     pub fn serialize(&self) -> crate::Result<Vec<u8>> {
+        self.ensure_no_restricted_grant("serialize")?;
         let mut out = Vec::new();
         out.extend_from_slice(&SPLIT_MAGIC.to_be_bytes());
         out.extend_from_slice(&SPLIT_VERSION.to_be_bytes());
@@ -824,6 +914,10 @@ impl DataSplit {
     /// `IndexedSplit` (type 3) wrapping the DataSplit body plus the ranges. Byte-compatible with
     /// `compatibility/split-v1-data` / `split-v1-indexed`.
     pub fn serialize_split_v1(&self) -> crate::Result<Vec<u8>> {
+        // The wire format has no place for the query-auth grant (Java carries it
+        // out of band in `QueryAuthSplit`), so a restricted split would cross the
+        // boundary as a plain split and be read raw. Fail closed instead.
+        self.ensure_no_restricted_grant("serialize")?;
         let mut out = Vec::new();
         out.extend_from_slice(&SPLIT_SER_MAGIC.to_be_bytes());
         out.extend_from_slice(&SPLIT_SER_VERSION.to_be_bytes());
@@ -1255,6 +1349,7 @@ impl DataSplitBuilder {
             data_deletion_files: self.data_deletion_files,
             row_ranges: self.row_ranges,
             raw_convertible: self.raw_convertible,
+            query_auth_grant: None,
         })
     }
 }
@@ -1273,14 +1368,44 @@ impl Default for DataSplitBuilder {
 #[derive(Debug)]
 pub struct Plan {
     splits: Vec<DataSplit>,
+    /// False when a residual pass (e.g. a query-auth row filter) drops rows
+    /// after the scan, so split row counts overcount the read output.
+    row_counts_exact: bool,
 }
 
 impl Plan {
     pub fn new(splits: Vec<DataSplit>) -> Self {
-        Self { splits }
+        Self {
+            splits,
+            row_counts_exact: true,
+        }
+    }
+    pub(crate) fn with_inexact_row_counts(mut self) -> Self {
+        self.row_counts_exact = false;
+        self
+    }
+
+    /// Stamp the per-user query-auth grant onto every split so
+    /// [`crate::table::TableRead::to_arrow`] enforces exactly the grant this
+    /// plan fetched (see [`DataSplit::with_query_auth_grant`]). A no-op when
+    /// `grant` is `None` (non-query-auth table): splits keep their empty grant
+    /// and read raw.
+    pub(crate) fn stamp_query_auth_grant(mut self, grant: Option<Arc<QueryAuthGrant>>) -> Self {
+        if grant.is_some() {
+            self.splits = self
+                .splits
+                .into_iter()
+                .map(|s| s.with_query_auth_grant(grant.clone()))
+                .collect();
+        }
+        self
     }
     pub fn splits(&self) -> &[DataSplit] {
         &self.splits
+    }
+    /// Whether split row counts exactly reflect the rows a read will produce.
+    pub fn row_counts_exact(&self) -> bool {
+        self.row_counts_exact
     }
 }
 
@@ -1325,6 +1450,41 @@ mod tests {
             .with_raw_convertible(raw_convertible)
             .build()
             .unwrap()
+    }
+
+    #[test]
+    fn test_restricted_grant_split_cannot_be_serialized() {
+        use crate::spec::{DataType, IntType, PredicateBuilder};
+        use crate::table::query_auth::QueryAuthGrant;
+
+        let fields = vec![crate::spec::DataField::new(
+            0,
+            "id".to_string(),
+            DataType::Int(IntType::new()),
+        )];
+        let filter = PredicateBuilder::new(&fields)
+            .greater_than("id", crate::spec::Datum::Int(1))
+            .unwrap();
+        let restricted = Arc::new(QueryAuthGrant::new(vec![filter], Vec::new(), None));
+        let plain = split(vec![file("a", 1, None)], true);
+        let guarded = plain.clone().with_query_auth_grant(Some(restricted));
+
+        // No wire format carries the grant, so every serialization path must
+        // refuse rather than emit a plain split the receiver would read raw.
+        assert!(guarded.serialize().is_err(), "native bytes");
+        assert!(guarded.serialize_split_v1().is_err(), "Java frame");
+        assert!(
+            serde_json::to_vec(&guarded).is_err(),
+            "serde (pickle, JSON)"
+        );
+
+        // Unstamped and unrestricted splits still serialize.
+        assert!(plain.serialize().is_ok());
+        assert!(serde_json::to_vec(&plain).is_ok());
+        let unrestricted = plain
+            .clone()
+            .with_query_auth_grant(Some(Arc::new(QueryAuthGrant::default())));
+        assert!(serde_json::to_vec(&unrestricted).is_ok());
     }
 
     #[test]

--- a/crates/paimon/src/table/source.rs
+++ b/crates/paimon/src/table/source.rs
@@ -604,6 +604,17 @@ impl DataSplit {
             .is_some_and(|g| g.has_server_restrictions())
     }
 
+    /// Whether this split carries any grant that is not fully unrestricted —
+    /// row filter, column mask, **or** column scope. Transport and
+    /// re-authorization use this instead of
+    /// [`Self::has_restricted_query_auth_grant`]: a scope-only grant distorts no
+    /// statistics, but no wire format carries it either.
+    pub fn carries_query_auth_restriction(&self) -> bool {
+        self.query_auth_grant
+            .as_ref()
+            .is_some_and(|g| !g.is_unrestricted())
+    }
+
     /// Stamp the query-auth grant this split must be read under. Called by scan
     /// planning and write-path authorizers on every emitted split.
     pub(crate) fn with_query_auth_grant(mut self, grant: Option<Arc<QueryAuthGrant>>) -> Self {
@@ -751,11 +762,11 @@ impl DataSplit {
     /// would read the data raw. `what` names the attempted operation.
     fn ensure_no_restricted_grant(&self, what: &str) -> crate::Result<()> {
         match &self.query_auth_grant {
-            Some(grant) if grant.has_server_restrictions() => Err(crate::Error::Unsupported {
+            Some(grant) if !grant.is_unrestricted() => Err(crate::Error::Unsupported {
                 message: format!(
-                    "cannot {what} a split planned under a query-auth row filter / column \
-                     masking grant: the grant cannot cross the wire, so the reader would see \
-                     unfiltered data"
+                    "cannot {what} a split planned under a query-auth grant: no wire format \
+                     carries the grant, so the receiver would read the data without its row \
+                     filter, column masking, or column scope"
                 ),
             }),
             _ => Ok(()),
@@ -1465,7 +1476,12 @@ mod tests {
         let filter = PredicateBuilder::new(&fields)
             .greater_than("id", crate::spec::Datum::Int(1))
             .unwrap();
-        let restricted = Arc::new(QueryAuthGrant::new(vec![filter], Vec::new(), None, 0));
+        let restricted = Arc::new(QueryAuthGrant::new(
+            vec![filter],
+            Vec::new(),
+            None,
+            crate::table::query_auth::GrantBinding::default(),
+        ));
         let plain = split(vec![file("a", 1, None)], true);
         let guarded = plain.clone().with_query_auth_grant(Some(restricted));
 

--- a/crates/paimon/src/table/source.rs
+++ b/crates/paimon/src/table/source.rs
@@ -501,19 +501,16 @@ pub struct DataSplit {
     /// physical rows are exactly its logical rows (modulo deletion files).
     /// Mirrors Java `DataSplit#rawConvertible`.
     raw_convertible: bool,
-    /// The per-user query-auth grant this split must be read under, stamped by
-    /// scan planning (or a write-path authorizer). Runtime-only — never
-    /// serialized — mirroring Java `QueryAuthSplit(split, authResult)`. Carried
-    /// on the split so `TableRead::to_arrow` enforces the exact grant the plan
-    /// fetched, instead of a shared mutable slot on `Table`.
+    /// The grant this split must be read under, stamped by scan planning.
+    /// Runtime-only, mirroring Java `QueryAuthSplit(split, authResult)`: on the
+    /// split so `to_arrow` enforces exactly the grant its plan fetched.
     #[serde(skip)]
     query_auth_grant: Option<Arc<QueryAuthGrant>>,
 }
 
-/// Hand-written so that serializing a split planned under a restricted
-/// query-auth grant FAILS instead of silently dropping the grant: no serde
-/// format carries it, so the receiver would read the split's files raw. The
-/// emitted shape is identical to the derived one (the grant is never a field).
+/// Hand-written so serializing a split planned under a grant FAILS instead of
+/// silently dropping it — no serde format carries it. The emitted shape is
+/// identical to the derived one.
 impl Serialize for DataSplit {
     fn serialize<S: serde::Serializer>(
         &self,
@@ -607,18 +604,16 @@ impl DataSplit {
     }
 
     /// Whether this split is planned under a grant that filters rows or masks
-    /// columns. Engines must not publish this split's raw manifest statistics
-    /// (min/max/null counts describe the data before enforcement), and must not
-    /// send it across a wire format that cannot carry the grant.
+    /// columns. Engines must not publish its raw manifest statistics, which
+    /// describe the data before enforcement.
     pub fn has_restricted_query_auth_grant(&self) -> bool {
         self.query_auth_grant
             .as_ref()
             .is_some_and(|g| g.has_server_restrictions())
     }
 
-    /// Whether this split carries any grant that is not fully unrestricted —
-    /// row filter, column mask, **or** column scope. Transport and
-    /// re-authorization use this instead of
+    /// Whether this split carries any grant that is not fully unrestricted.
+    /// Transport and re-authorization use this rather than
     /// [`Self::has_restricted_query_auth_grant`]: a scope-only grant distorts no
     /// statistics, but no wire format carries it either.
     pub fn carries_query_auth_restriction(&self) -> bool {
@@ -694,6 +689,17 @@ impl DataSplit {
     ///
     /// Reference: [DataSplit.mergedRowCount()](https://github.com/apache/paimon/blob/release-1.3/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java#L133)
     pub fn merged_row_count(&self) -> Option<i64> {
+        // A row filter drops rows after the scan, so the manifest count is not
+        // the logical output count. Java's `QueryAuthSplit.mergedRowCount()`
+        // returns empty for the same reason; `Plan::row_counts_exact` only
+        // covers callers that go through the plan.
+        if self
+            .query_auth_grant
+            .as_ref()
+            .is_some_and(|g| g.has_row_filter())
+        {
+            return None;
+        }
         if !self.row_counts_known() {
             return None;
         }
@@ -768,17 +774,19 @@ impl DataSplit {
     /// Serialize the DataSplit fields to Java `DataSplit#serialize` (version 9) binary.
     /// Byte-compatible with `compatibility/datasplit-v9`. Row ranges are not part of the
     /// format; `serialize_split_v1` wraps a row-range split as an `IndexedSplit` instead.
-    /// Fail closed when this split carries a restricted query-auth grant and is
-    /// about to leave the process: no split wire format (native bytes, the Java
-    /// `SplitSerializer` frame, or serde) carries the grant, so the receiver
-    /// would read the data raw. `what` names the attempted operation.
+    /// Fail closed when a split carrying a grant is about to leave the process:
+    /// no wire format (native bytes, the Java `SplitSerializer` frame, serde)
+    /// carries it. `what` names the attempted operation.
     fn ensure_no_restricted_grant(&self, what: &str) -> crate::Result<()> {
         match &self.query_auth_grant {
-            Some(grant) if !grant.is_unrestricted() => Err(crate::Error::Unsupported {
+            // Any stamped grant, unrestricted included: the receiver would get
+            // a grant-less split and fail closed anyway, so refuse at the
+            // boundary where the cause is still visible.
+            Some(_) => Err(crate::Error::Unsupported {
                 message: format!(
                     "cannot {what} a split planned under a query-auth grant: no wire format \
-                     carries the grant, so the receiver would read the data without its row \
-                     filter, column masking, or column scope"
+                     carries the grant, so the receiver could not enforce the row filter, \
+                     column masking, or column scope it was planned under"
                 ),
             }),
             _ => Ok(()),
@@ -1409,6 +1417,10 @@ pub struct Plan {
     /// False when a residual pass (e.g. a query-auth row filter) drops rows
     /// after the scan, so split row counts overcount the read output.
     row_counts_exact: bool,
+    /// Whether this plan was made under a server-restricted grant. Recorded on
+    /// the plan, not inferred from its splits: a fully pruned plan has none to
+    /// carry the grant but its scan metadata is just as pre-enforcement.
+    query_auth_restricted: bool,
 }
 
 impl Plan {
@@ -1416,6 +1428,7 @@ impl Plan {
         Self {
             splits,
             row_counts_exact: true,
+            query_auth_restricted: false,
         }
     }
     pub(crate) fn with_inexact_row_counts(mut self) -> Self {
@@ -1423,12 +1436,11 @@ impl Plan {
         self
     }
 
-    /// Stamp the per-user query-auth grant onto every split so
-    /// [`crate::table::TableRead::to_arrow`] enforces exactly the grant this
-    /// plan fetched (see [`DataSplit::with_query_auth_grant`]). A no-op when
-    /// `grant` is `None` (non-query-auth table): splits keep their empty grant
-    /// and read raw.
+    /// Stamp the grant onto every split so [`crate::table::TableRead::to_arrow`]
+    /// enforces exactly the one this plan fetched. A no-op for `None` (not a
+    /// query-auth table).
     pub(crate) fn stamp_query_auth_grant(mut self, grant: Option<Arc<QueryAuthGrant>>) -> Self {
+        self.query_auth_restricted = grant.as_ref().is_some_and(|g| g.has_server_restrictions());
         if grant.is_some() {
             self.splits = self
                 .splits
@@ -1445,6 +1457,14 @@ impl Plan {
     /// Whether split row counts exactly reflect the rows a read will produce.
     pub fn row_counts_exact(&self) -> bool {
         self.row_counts_exact
+    }
+
+    /// Whether this plan was made under a row filter or column masking.
+    ///
+    /// On the plan, not a split: a fully pruned plan has no split to carry it,
+    /// yet its scan metadata is just as pre-enforcement.
+    pub fn planned_under_restricted_grant(&self) -> bool {
+        self.query_auth_restricted
     }
 
     /// Sum of data-file bytes referenced by this plan.
@@ -1574,7 +1594,7 @@ mod tests {
     }
 
     #[test]
-    fn test_restricted_grant_split_cannot_be_serialized() {
+    fn test_query_auth_grant_split_cannot_be_serialized() {
         use crate::spec::{DataType, IntType, PredicateBuilder};
         use crate::table::query_auth::QueryAuthGrant;
 
@@ -1590,6 +1610,7 @@ mod tests {
             vec![filter],
             Vec::new(),
             None,
+            None,
             crate::table::query_auth::GrantBinding::default(),
         ));
         let plain = split(vec![file("a", 1, None)], true);
@@ -1604,13 +1625,16 @@ mod tests {
             "serde (pickle, JSON)"
         );
 
-        // Unstamped and unrestricted splits still serialize.
+        // Only an unstamped split serializes. An unrestricted grant is refused
+        // too: the receiver would get a grant-less split and fail closed when
+        // reading it, so rejecting here reports the real cause at the boundary.
         assert!(plain.serialize().is_ok());
         assert!(serde_json::to_vec(&plain).is_ok());
         let unrestricted = plain
             .clone()
             .with_query_auth_grant(Some(Arc::new(QueryAuthGrant::default())));
-        assert!(serde_json::to_vec(&unrestricted).is_ok());
+        assert!(unrestricted.serialize().is_err());
+        assert!(serde_json::to_vec(&unrestricted).is_err());
     }
 
     #[test]

--- a/crates/paimon/src/table/source.rs
+++ b/crates/paimon/src/table/source.rs
@@ -20,6 +20,7 @@
 //! Reference: [org.apache.paimon.table.source](https://github.com/apache/paimon/blob/master/paimon-core/src/main/java/org/apache/paimon/table/source/).
 
 use crate::spec::{BinaryRow, DataFileMeta, DataFileMetaRowLayout};
+use crate::table::query_auth::QueryAuthGrant;
 use crate::table::stats_filter::group_by_overlapping_row_id;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -484,7 +485,7 @@ impl PartitionBucket {
 /// asynchronous reader does not deep-copy every [`DataFileMeta`].
 ///
 /// Reference: [org.apache.paimon.table.source.DataSplit](https://github.com/apache/paimon/blob/release-1.3/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java)
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct DataSplit {
     snapshot_id: i64,
     partition: Arc<BinaryRow>,
@@ -500,6 +501,54 @@ pub struct DataSplit {
     /// physical rows are exactly its logical rows (modulo deletion files).
     /// Mirrors Java `DataSplit#rawConvertible`.
     raw_convertible: bool,
+    /// The per-user query-auth grant this split must be read under, stamped by
+    /// scan planning (or a write-path authorizer). Runtime-only — never
+    /// serialized — mirroring Java `QueryAuthSplit(split, authResult)`. Carried
+    /// on the split so `TableRead::to_arrow` enforces the exact grant the plan
+    /// fetched, instead of a shared mutable slot on `Table`.
+    #[serde(skip)]
+    query_auth_grant: Option<Arc<QueryAuthGrant>>,
+}
+
+/// Hand-written so that serializing a split planned under a restricted
+/// query-auth grant FAILS instead of silently dropping the grant: no serde
+/// format carries it, so the receiver would read the split's files raw. The
+/// emitted shape is identical to the derived one (the grant is never a field).
+impl Serialize for DataSplit {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        use serde::ser::Error as _;
+        self.ensure_no_restricted_grant("serialize")
+            .map_err(S::Error::custom)?;
+
+        #[derive(Serialize)]
+        struct Wire<'a> {
+            snapshot_id: &'a i64,
+            partition: &'a Arc<BinaryRow>,
+            bucket: &'a i32,
+            bucket_path: &'a Arc<str>,
+            total_buckets: &'a i32,
+            data_files: &'a Arc<[DataFileMeta]>,
+            data_deletion_files: &'a Option<Arc<[Option<DeletionFile>]>>,
+            row_ranges: &'a Option<Arc<[RowRange]>>,
+            raw_convertible: &'a bool,
+        }
+
+        Wire {
+            snapshot_id: &self.snapshot_id,
+            partition: &self.partition,
+            bucket: &self.bucket,
+            bucket_path: &self.bucket_path,
+            total_buckets: &self.total_buckets,
+            data_files: &self.data_files,
+            data_deletion_files: &self.data_deletion_files,
+            row_ranges: &self.row_ranges,
+            raw_convertible: &self.raw_convertible,
+        }
+        .serialize(serializer)
+    }
 }
 
 impl DataSplit {
@@ -550,6 +599,28 @@ impl DataSplit {
                 .data_files
                 .iter()
                 .all(|file| file.level != 0 && file.delete_row_count == Some(0))
+    }
+
+    /// The query-auth grant this split is read under, if any (see the field doc).
+    pub(crate) fn query_auth_grant(&self) -> Option<&Arc<QueryAuthGrant>> {
+        self.query_auth_grant.as_ref()
+    }
+
+    /// Whether this split is planned under a grant that filters rows or masks
+    /// columns. Engines must not publish this split's raw manifest statistics
+    /// (min/max/null counts describe the data before enforcement), and must not
+    /// send it across a wire format that cannot carry the grant.
+    pub fn has_restricted_query_auth_grant(&self) -> bool {
+        self.query_auth_grant
+            .as_ref()
+            .is_some_and(|g| g.has_server_restrictions())
+    }
+
+    /// Stamp the query-auth grant this split must be read under. Called by scan
+    /// planning and write-path authorizers on every emitted split.
+    pub(crate) fn with_query_auth_grant(mut self, grant: Option<Arc<QueryAuthGrant>>) -> Self {
+        self.query_auth_grant = grant;
+        self
     }
 
     /// Returns the deletion file for the data file at the given index, if any. `None` at that index means no deletion file.
@@ -686,7 +757,25 @@ impl DataSplit {
     /// Serialize the DataSplit fields to Java `DataSplit#serialize` (version 9) binary.
     /// Byte-compatible with `compatibility/datasplit-v9`. Row ranges are not part of the
     /// format; `serialize_split_v1` wraps a row-range split as an `IndexedSplit` instead.
+    /// Fail closed when this split carries a restricted query-auth grant and is
+    /// about to leave the process: no split wire format (native bytes, the Java
+    /// `SplitSerializer` frame, or serde) carries the grant, so the receiver
+    /// would read the data raw. `what` names the attempted operation.
+    fn ensure_no_restricted_grant(&self, what: &str) -> crate::Result<()> {
+        match &self.query_auth_grant {
+            Some(grant) if grant.has_server_restrictions() => Err(crate::Error::Unsupported {
+                message: format!(
+                    "cannot {what} a split planned under a query-auth row filter / column \
+                     masking grant: the grant cannot cross the wire, so the reader would see \
+                     unfiltered data"
+                ),
+            }),
+            _ => Ok(()),
+        }
+    }
+
     pub fn serialize(&self) -> crate::Result<Vec<u8>> {
+        self.ensure_no_restricted_grant("serialize")?;
         let mut out = Vec::new();
         out.extend_from_slice(&SPLIT_MAGIC.to_be_bytes());
         out.extend_from_slice(&SPLIT_VERSION.to_be_bytes());
@@ -848,6 +937,10 @@ impl DataSplit {
     /// `IndexedSplit` (type 3) wrapping the DataSplit body plus the ranges. Byte-compatible with
     /// `compatibility/split-v1-data` / `split-v1-indexed`.
     pub fn serialize_split_v1(&self) -> crate::Result<Vec<u8>> {
+        // The wire format has no place for the query-auth grant (Java carries it
+        // out of band in `QueryAuthSplit`), so a restricted split would cross the
+        // boundary as a plain split and be read raw. Fail closed instead.
+        self.ensure_no_restricted_grant("serialize")?;
         let mut out = Vec::new();
         out.extend_from_slice(&SPLIT_SER_MAGIC.to_be_bytes());
         out.extend_from_slice(&SPLIT_SER_VERSION.to_be_bytes());
@@ -1283,6 +1376,7 @@ impl DataSplitBuilder {
             data_deletion_files: self.data_deletion_files.map(Into::into),
             row_ranges: self.row_ranges.map(Into::into),
             raw_convertible: self.raw_convertible,
+            query_auth_grant: None,
         })
     }
 }
@@ -1301,14 +1395,45 @@ impl Default for DataSplitBuilder {
 #[derive(Debug)]
 pub struct Plan {
     splits: Vec<DataSplit>,
+    /// False when a residual pass (e.g. a query-auth row filter) drops rows
+    /// after the scan, so split row counts overcount the read output.
+    row_counts_exact: bool,
 }
 
 impl Plan {
     pub fn new(splits: Vec<DataSplit>) -> Self {
-        Self { splits }
+        Self {
+            splits,
+            row_counts_exact: true,
+        }
+    }
+    pub(crate) fn with_inexact_row_counts(mut self) -> Self {
+        self.row_counts_exact = false;
+        self
+    }
+
+    /// Stamp the per-user query-auth grant onto every split so
+    /// [`crate::table::TableRead::to_arrow`] enforces exactly the grant this
+    /// plan fetched (see [`DataSplit::with_query_auth_grant`]). A no-op when
+    /// `grant` is `None` (non-query-auth table): splits keep their empty grant
+    /// and read raw.
+    pub(crate) fn stamp_query_auth_grant(mut self, grant: Option<Arc<QueryAuthGrant>>) -> Self {
+        if grant.is_some() {
+            self.splits = self
+                .splits
+                .into_iter()
+                .map(|s| s.with_query_auth_grant(grant.clone()))
+                .collect();
+        }
+        self
     }
     pub fn splits(&self) -> &[DataSplit] {
         &self.splits
+    }
+
+    /// Whether split row counts exactly reflect the rows a read will produce.
+    pub fn row_counts_exact(&self) -> bool {
+        self.row_counts_exact
     }
 
     /// Sum of data-file bytes referenced by this plan.
@@ -1435,6 +1560,41 @@ mod tests {
         let plan = Plan::new(vec![split(vec![first, second, overflow, unknown], true)]);
 
         assert_eq!(plan.planned_data_file_bytes(), u64::MAX);
+    }
+
+    #[test]
+    fn test_restricted_grant_split_cannot_be_serialized() {
+        use crate::spec::{DataType, IntType, PredicateBuilder};
+        use crate::table::query_auth::QueryAuthGrant;
+
+        let fields = vec![crate::spec::DataField::new(
+            0,
+            "id".to_string(),
+            DataType::Int(IntType::new()),
+        )];
+        let filter = PredicateBuilder::new(&fields)
+            .greater_than("id", crate::spec::Datum::Int(1))
+            .unwrap();
+        let restricted = Arc::new(QueryAuthGrant::new(vec![filter], Vec::new(), None));
+        let plain = split(vec![file("a", 1, None)], true);
+        let guarded = plain.clone().with_query_auth_grant(Some(restricted));
+
+        // No wire format carries the grant, so every serialization path must
+        // refuse rather than emit a plain split the receiver would read raw.
+        assert!(guarded.serialize().is_err(), "native bytes");
+        assert!(guarded.serialize_split_v1().is_err(), "Java frame");
+        assert!(
+            serde_json::to_vec(&guarded).is_err(),
+            "serde (pickle, JSON)"
+        );
+
+        // Unstamped and unrestricted splits still serialize.
+        assert!(plain.serialize().is_ok());
+        assert!(serde_json::to_vec(&plain).is_ok());
+        let unrestricted = plain
+            .clone()
+            .with_query_auth_grant(Some(Arc::new(QueryAuthGrant::default())));
+        assert!(serde_json::to_vec(&unrestricted).is_ok());
     }
 
     #[test]

--- a/crates/paimon/src/table/source.rs
+++ b/crates/paimon/src/table/source.rs
@@ -1575,7 +1575,7 @@ mod tests {
         let filter = PredicateBuilder::new(&fields)
             .greater_than("id", crate::spec::Datum::Int(1))
             .unwrap();
-        let restricted = Arc::new(QueryAuthGrant::new(vec![filter], Vec::new(), None));
+        let restricted = Arc::new(QueryAuthGrant::new(vec![filter], Vec::new(), None, 0));
         let plain = split(vec![file("a", 1, None)], true);
         let guarded = plain.clone().with_query_auth_grant(Some(restricted));
 

--- a/crates/paimon/src/table/source.rs
+++ b/crates/paimon/src/table/source.rs
@@ -616,6 +616,17 @@ impl DataSplit {
             .is_some_and(|g| g.has_server_restrictions())
     }
 
+    /// Whether this split carries any grant that is not fully unrestricted —
+    /// row filter, column mask, **or** column scope. Transport and
+    /// re-authorization use this instead of
+    /// [`Self::has_restricted_query_auth_grant`]: a scope-only grant distorts no
+    /// statistics, but no wire format carries it either.
+    pub fn carries_query_auth_restriction(&self) -> bool {
+        self.query_auth_grant
+            .as_ref()
+            .is_some_and(|g| !g.is_unrestricted())
+    }
+
     /// Stamp the query-auth grant this split must be read under. Called by scan
     /// planning and write-path authorizers on every emitted split.
     pub(crate) fn with_query_auth_grant(mut self, grant: Option<Arc<QueryAuthGrant>>) -> Self {
@@ -763,11 +774,11 @@ impl DataSplit {
     /// would read the data raw. `what` names the attempted operation.
     fn ensure_no_restricted_grant(&self, what: &str) -> crate::Result<()> {
         match &self.query_auth_grant {
-            Some(grant) if grant.has_server_restrictions() => Err(crate::Error::Unsupported {
+            Some(grant) if !grant.is_unrestricted() => Err(crate::Error::Unsupported {
                 message: format!(
-                    "cannot {what} a split planned under a query-auth row filter / column \
-                     masking grant: the grant cannot cross the wire, so the reader would see \
-                     unfiltered data"
+                    "cannot {what} a split planned under a query-auth grant: no wire format \
+                     carries the grant, so the receiver would read the data without its row \
+                     filter, column masking, or column scope"
                 ),
             }),
             _ => Ok(()),
@@ -1575,7 +1586,12 @@ mod tests {
         let filter = PredicateBuilder::new(&fields)
             .greater_than("id", crate::spec::Datum::Int(1))
             .unwrap();
-        let restricted = Arc::new(QueryAuthGrant::new(vec![filter], Vec::new(), None, 0));
+        let restricted = Arc::new(QueryAuthGrant::new(
+            vec![filter],
+            Vec::new(),
+            None,
+            crate::table::query_auth::GrantBinding::default(),
+        ));
         let plain = split(vec![file("a", 1, None)], true);
         let guarded = plain.clone().with_query_auth_grant(Some(restricted));
 

--- a/crates/paimon/src/table/table_commit.rs
+++ b/crates/paimon/src/table/table_commit.rs
@@ -627,10 +627,9 @@ impl TableCommit {
     /// files or storage errors are ignored so abort cleanup never masks the
     /// original write failure.
     pub async fn abort(&self, commit_messages: &[CommitMessage]) -> Result<()> {
-        // No query-auth gate: abort only deletes files the caller just wrote and
-        // publishes nothing. A restricted user's commit is rejected *after*
-        // `prepare_commit` wrote them, so requiring a grant here would strand
-        // those files instead of cleaning them up.
+        // No query-auth gate: abort only deletes files the caller just wrote.
+        // A restricted commit is rejected after `prepare_commit` wrote them, so
+        // gating here would strand them instead of cleaning up.
         self.table.ensure_not_branch_reference_for_write()?;
 
         for message in commit_messages {

--- a/crates/paimon/src/table/table_commit.rs
+++ b/crates/paimon/src/table/table_commit.rs
@@ -156,6 +156,7 @@ impl TableCommit {
         filter_committed: bool,
     ) -> Result<()> {
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
 
         if commit_messages.is_empty() {
             return Ok(());
@@ -199,6 +200,7 @@ impl TableCommit {
         commit_identifier: i64,
     ) -> Result<()> {
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
 
         if commit_messages.is_empty() {
             return Ok(());
@@ -270,6 +272,7 @@ impl TableCommit {
         filter_committed: bool,
     ) -> Result<()> {
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
 
         if commit_messages.is_empty() && static_partitions.is_none() {
             return Ok(());
@@ -519,6 +522,7 @@ impl TableCommit {
         filter_committed: bool,
     ) -> Result<()> {
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
 
         if partitions.is_empty() {
             return Ok(());
@@ -566,6 +570,7 @@ impl TableCommit {
         commit_identifier: i64,
     ) -> Result<()> {
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
 
         if partitions.is_empty() {
             return Err(crate::Error::DataInvalid {
@@ -597,6 +602,7 @@ impl TableCommit {
         filter_committed: bool,
     ) -> Result<()> {
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
 
         self.try_commit(
             CommitEntriesPlan::Overwrite {
@@ -621,6 +627,10 @@ impl TableCommit {
     /// files or storage errors are ignored so abort cleanup never masks the
     /// original write failure.
     pub async fn abort(&self, commit_messages: &[CommitMessage]) -> Result<()> {
+        // No query-auth gate: abort only deletes files the caller just wrote and
+        // publishes nothing. A restricted user's commit is rejected *after*
+        // `prepare_commit` wrote them, so requiring a grant here would strand
+        // those files instead of cleaning them up.
         self.table.ensure_not_branch_reference_for_write()?;
 
         for message in commit_messages {

--- a/crates/paimon/src/table/table_commit.rs
+++ b/crates/paimon/src/table/table_commit.rs
@@ -207,6 +207,7 @@ impl TableCommit {
         // A commit validates against the existing snapshot.
         CoreOptions::new(self.table.schema().options()).ensure_read_authorized()?;
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
         validate_fixed_bucket_commit_mode(&commit_messages, false)?;
         validate_bucket_ownership(&commit_messages)?;
 
@@ -254,6 +255,7 @@ impl TableCommit {
         // A commit validates against the existing snapshot.
         CoreOptions::new(self.table.schema().options()).ensure_read_authorized()?;
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
         validate_fixed_bucket_commit_mode(&commit_messages, false)?;
         validate_bucket_ownership(&commit_messages)?;
 
@@ -339,6 +341,7 @@ impl TableCommit {
         // A commit validates against the existing snapshot.
         CoreOptions::new(self.table.schema().options()).ensure_read_authorized()?;
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
         validate_fixed_bucket_commit_mode(&commit_messages, true)?;
         validate_bucket_ownership(&commit_messages)?;
 
@@ -595,6 +598,7 @@ impl TableCommit {
         // A commit validates against the existing snapshot.
         CoreOptions::new(self.table.schema().options()).ensure_read_authorized()?;
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
 
         if partitions.is_empty() {
             return Ok(());
@@ -643,6 +647,7 @@ impl TableCommit {
         commit_identifier: i64,
     ) -> Result<()> {
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
 
         if partitions.is_empty() {
             return Err(crate::Error::DataInvalid {
@@ -676,6 +681,7 @@ impl TableCommit {
         // A commit validates against the existing snapshot.
         CoreOptions::new(self.table.schema().options()).ensure_read_authorized()?;
         self.table.ensure_not_branch_reference_for_write()?;
+        self.table.authorize_unrestricted_write().await?;
 
         self.try_commit(
             CommitEntriesPlan::Overwrite {
@@ -703,6 +709,10 @@ impl TableCommit {
     pub async fn abort(&self, commit_messages: &[CommitMessage]) -> Result<()> {
         CoreOptions::new(self.table.schema().options())
             .ensure_type_paimon_served(&self.table.identifier().full_name())?;
+        // No query-auth gate: abort only deletes files the caller just wrote and
+        // publishes nothing. A restricted user's commit is rejected *after*
+        // `prepare_commit` wrote them, so requiring a grant here would strand
+        // those files instead of cleaning them up.
         self.table.ensure_not_branch_reference_for_write()?;
 
         let table_path = self.table.location().trim_end_matches('/');

--- a/crates/paimon/src/table/table_commit.rs
+++ b/crates/paimon/src/table/table_commit.rs
@@ -709,10 +709,9 @@ impl TableCommit {
     pub async fn abort(&self, commit_messages: &[CommitMessage]) -> Result<()> {
         CoreOptions::new(self.table.schema().options())
             .ensure_type_paimon_served(&self.table.identifier().full_name())?;
-        // No query-auth gate: abort only deletes files the caller just wrote and
-        // publishes nothing. A restricted user's commit is rejected *after*
-        // `prepare_commit` wrote them, so requiring a grant here would strand
-        // those files instead of cleaning them up.
+        // No query-auth gate: abort only deletes files the caller just wrote.
+        // A restricted commit is rejected after `prepare_commit` wrote them, so
+        // gating here would strand them instead of cleaning up.
         self.table.ensure_not_branch_reference_for_write()?;
 
         let table_path = self.table.location().trim_end_matches('/');

--- a/crates/paimon/src/table/table_read.rs
+++ b/crates/paimon/src/table/table_read.rs
@@ -151,11 +151,24 @@ impl<'a> TableRead<'a> {
     /// raw; and a `query-auth.enabled` table whose splits carry no grant means
     /// an unauthorized read path — fail closed.
     pub fn to_arrow(&self, data_splits: &[DataSplit]) -> crate::Result<ArrowRecordBatchStream> {
-        match self.resolve_split_grant(data_splits)? {
-            Some(grant) if !grant.is_unrestricted() => {
-                self.to_arrow_auth_enforced(data_splits, grant)
-            }
-            _ => self.to_arrow_dispatch(data_splits),
+        let Some(grant) = self.resolve_split_grant(data_splits)? else {
+            return self.to_arrow_dispatch(data_splits);
+        };
+        // Checked for every grant, not just restricted ones: an unrestricted
+        // grant fetched for one table must not authorize a raw read of another's
+        // splits. `authorize_rewrite_splits` is public and stamps grants, so a
+        // caller holding two tables could otherwise launder splits through it.
+        if !grant.matches_schema(self.table().schema().id()) {
+            return Err(crate::Error::Unsupported {
+                message: "a query-auth grant issued for a different table schema cannot be \
+                          enforced here; re-plan the scan"
+                    .to_string(),
+            });
+        }
+        if grant.is_unrestricted() {
+            self.to_arrow_dispatch(data_splits)
+        } else {
+            self.to_arrow_auth_enforced(data_splits, grant)
         }
     }
 
@@ -246,14 +259,38 @@ impl<'a> TableRead<'a> {
     fn ensure_incremental_plan_authorized(&self, plan: &IncrementalPlan) -> crate::Result<()> {
         // `all_data_splits` (not `data_splits`) so a Diff plan's pairs are seen:
         // `data_splits` drops them, which would present no splits at all.
-        match self.resolve_split_grant(plan.all_data_splits())? {
-            Some(grant) if grant.has_server_restrictions() => Err(crate::Error::Unsupported {
+        let Some(grant) = self.resolve_split_grant(plan.all_data_splits())? else {
+            return Ok(());
+        };
+
+        // Filters and masks cannot be applied on this path at all.
+        if grant.has_server_restrictions() {
+            return Err(crate::Error::Unsupported {
                 message: "reading a query-auth row filter / column masking grant on an \
                           incremental or audit-log scan is not supported"
                     .to_string(),
-            }),
-            _ => Ok(()),
+            });
         }
+
+        // No filter or mask, but the grant may still be scoped to a subset of
+        // columns, and nothing downstream re-checks that on this path (the batch
+        // path does it inside `to_arrow_auth_enforced`). Without this a read
+        // wider than the scope returns columns the server never authorized.
+        let table = self.table();
+        if !grant.matches_schema(table.schema().id()) {
+            return Err(crate::Error::Unsupported {
+                message: "a query-auth grant issued for a different table schema cannot be \
+                          enforced here; re-plan the scan"
+                    .to_string(),
+            });
+        }
+        let schema_fields = table.schema().fields();
+        let projected = query_auth::canonical_projection(schema_fields, self.read_type())?;
+        let mut filter_columns = std::collections::HashSet::new();
+        self.data_predicates()
+            .iter()
+            .for_each(|p| p.collect_leaf_field_indices(&mut filter_columns));
+        query_auth::scope_check(&grant, schema_fields, &filter_columns, Some(projected))
     }
 
     /// Returns an audit-log [`ArrowRecordBatchStream`] for an incremental plan.
@@ -312,47 +349,16 @@ impl<'a> TableRead<'a> {
             return Err(query_auth::masked_filter_error(&schema_fields, *index));
         }
 
-        // Every projected field must be a canonical (id, name) pair from the
-        // table schema. Authorization and mask selection resolve columns by id,
-        // but the physical read resolves them by name, so a hand-built read type
-        // pairing an authorized id with another column's name would read that
-        // other column and skip its mask. `with_read_type` / `TableRead::new`
-        // are public, so this is reachable — fail closed.
-        for field in self.read_type() {
-            let by_id = schema_fields.iter().find(|s| s.id() == field.id());
-            let by_name = schema_fields.iter().find(|s| s.name() == field.name());
-            match (by_id, by_name) {
-                // Canonical: the same schema field on both lookups.
-                (Some(s), Some(n)) if s.name() == field.name() && n.id() == field.id() => {}
-                // Neither an id nor a name of this schema: a system column (row
-                // id, etc.), which carries no grant scope — leave it to the reader.
-                (None, None) => {}
-                // Any mix — a known id under another column's name, or an
-                // unknown id borrowing a real column's name — would be scoped and
-                // masked by id while the physical read resolves it by name.
-                _ => {
-                    return Err(crate::Error::Unsupported {
-                        message: format!(
-                            "query-auth read type field #{} `{}` is not a column of this table",
-                            field.id(),
-                            field.name()
-                        ),
-                    });
-                }
-            }
-        }
-
         // The grant is scoped to the columns authorized for this read; a wider
         // projection or a predicate on an un-approved column must re-authorize.
         // (The builder/scan paths also check this before pruning; this covers a
         // directly-constructed `TableRead`.)
-        let projected_indices = self
-            .read_type()
-            .iter()
-            .filter_map(|f| schema_fields.iter().position(|s| s.id() == f.id()));
-        if let Some(index) =
-            grant.first_unauthorized(projected_indices.chain(caller_referenced.iter().copied()))
-        {
+        let projected = query_auth::canonical_projection(&schema_fields, self.read_type())?;
+        if let Some(index) = grant.first_unauthorized(
+            projected
+                .into_iter()
+                .chain(caller_referenced.iter().copied()),
+        ) {
             return Err(query_auth::unauthorized_column_error(&schema_fields, index));
         }
 
@@ -1765,6 +1771,110 @@ mod tests {
     }
 
     #[test]
+    fn test_grant_from_another_schema_cannot_authorize_a_raw_read() {
+        // `authorize_rewrite_splits` is public and stamps grants, so a caller
+        // holding two tables could stamp one table's UNRESTRICTED grant onto
+        // splits of a restricted one. An unrestricted grant used to skip
+        // straight to the raw dispatch, so the binding must be checked first.
+        let table = query_auth_table();
+        let foreign = Arc::new(query_auth::QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            None,
+            table.schema.id() + 1,
+        ));
+        assert!(foreign.is_unrestricted());
+        let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(foreign));
+        let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
+        assert!(
+            matches!(
+                read.to_arrow(&[granted]),
+                Err(crate::Error::Unsupported { ref message })
+                    if message.contains("different table schema")
+            ),
+            "a grant bound to another schema must not authorize a raw read"
+        );
+    }
+
+    #[test]
+    fn test_incremental_read_rejects_noncanonical_read_type() {
+        use super::super::incremental_scan::{IncrementalPlan, IncrementalScanMode};
+        use std::collections::HashSet;
+        let table = query_auth_table();
+        let real = table.schema.fields()[0].clone();
+        // Authorized id 0 under another column's NAME: scoping resolves by id
+        // (would pass) while the physical read resolves by name. The batch path
+        // guards this too; both must go through `canonical_projection`.
+        let forged = crate::spec::DataField::new(
+            real.id(),
+            "not_the_real_name".to_string(),
+            real.data_type().clone(),
+        );
+        let grant = Arc::new(query_auth::QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+            table.schema.id(),
+        ));
+        let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
+        let plan = IncrementalPlan::new(
+            IncrementalScanMode::Delta,
+            vec![IncrementalSplit::Data(granted)],
+        );
+        let read = TableRead::new(&table, vec![forged], Vec::new());
+        assert!(
+            matches!(
+                read.to_incremental_arrow(&plan),
+                Err(crate::Error::Unsupported { ref message })
+                    if message.contains("is not a column of this table")
+            ),
+            "a read type pairing an authorized id with another column's name must fail closed"
+        );
+    }
+
+    #[test]
+    fn test_incremental_read_enforces_column_scope() {
+        use super::super::incremental_scan::{IncrementalPlan, IncrementalScanMode};
+        use std::collections::HashSet;
+
+        // A column-scoped grant carries no filter and no mask, so the "cannot
+        // apply filters here" check passes it through. Nothing else on the
+        // incremental path checks scope, so without an explicit check a read
+        // wider than the scope would return unauthorized columns raw.
+        let table = query_auth_table();
+        let fields = table.schema.fields().to_vec();
+        let read = TableRead::new(&table, fields.clone(), Vec::new());
+        let plan_for = |authorized: HashSet<usize>| {
+            let grant = Arc::new(query_auth::QueryAuthGrant::new(
+                Vec::new(),
+                Vec::new(),
+                Some(authorized),
+                table.schema.id(),
+            ));
+            let granted =
+                split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
+            IncrementalPlan::new(
+                IncrementalScanMode::Delta,
+                vec![IncrementalSplit::Data(granted)],
+            )
+        };
+
+        let out_of_scope = plan_for(HashSet::new());
+        assert!(
+            matches!(
+                read.to_incremental_arrow(&out_of_scope),
+                Err(crate::Error::Unsupported { ref message })
+                    if message.contains("outside the authorized set")
+            ),
+            "incremental read wider than the grant's column scope must fail closed"
+        );
+
+        // Reading exactly the authorized columns is allowed.
+        let in_scope = plan_for((0..fields.len()).collect());
+        assert!(read.ensure_incremental_plan_authorized(&in_scope).is_ok());
+    }
+
+    #[test]
     fn test_noncanonical_read_type_fails_closed() {
         use std::collections::HashSet;
 
@@ -1782,6 +1892,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            table.schema.id(),
         ));
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
 
@@ -1823,6 +1934,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            table.schema.id(),
         ));
         let granted =
             split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant.clone()));

--- a/crates/paimon/src/table/table_read.rs
+++ b/crates/paimon/src/table/table_read.rs
@@ -154,13 +154,12 @@ impl<'a> TableRead<'a> {
         let Some(grant) = self.resolve_split_grant(data_splits)? else {
             return self.to_arrow_dispatch(data_splits);
         };
-        // Checked for every grant, not just restricted ones: an unrestricted
-        // grant fetched for one table must not authorize a raw read of another's
-        // splits. `authorize_rewrite_splits` is public and stamps grants, so a
-        // caller holding two tables could otherwise launder splits through it.
-        if !grant.matches_schema(self.table().schema().id()) {
+        // Checked for every grant: `authorize_rewrite_splits` is public, so an
+        // unrestricted grant from one table must not authorize a raw read of
+        // another's splits.
+        if !grant.matches_table(self.table()) {
             return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table schema cannot be \
+                message: "a query-auth grant issued for a different table or schema cannot be \
                           enforced here; re-plan the scan"
                     .to_string(),
             });
@@ -263,7 +262,6 @@ impl<'a> TableRead<'a> {
             return Ok(());
         };
 
-        // Filters and masks cannot be applied on this path at all.
         if grant.has_server_restrictions() {
             return Err(crate::Error::Unsupported {
                 message: "reading a query-auth row filter / column masking grant on an \
@@ -272,14 +270,12 @@ impl<'a> TableRead<'a> {
             });
         }
 
-        // No filter or mask, but the grant may still be scoped to a subset of
-        // columns, and nothing downstream re-checks that on this path (the batch
-        // path does it inside `to_arrow_auth_enforced`). Without this a read
-        // wider than the scope returns columns the server never authorized.
+        // A scoped grant still needs checking, and nothing downstream on this
+        // path does it (the batch path does, in `to_arrow_auth_enforced`).
         let table = self.table();
-        if !grant.matches_schema(table.schema().id()) {
+        if !grant.matches_table(table) {
             return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table schema cannot be \
+                message: "a query-auth grant issued for a different table or schema cannot be \
                           enforced here; re-plan the scan"
                     .to_string(),
             });
@@ -328,9 +324,9 @@ impl<'a> TableRead<'a> {
         // The grant's filter and mask indices are POSITIONAL in the schema they
         // were parsed against, so enforcing them on another schema would bind
         // them to different columns. Refuse a grant issued for a different one.
-        if !grant.matches_schema(table.schema().id()) {
+        if !grant.matches_table(table) {
             return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table schema cannot be \
+                message: "a query-auth grant issued for a different table or schema cannot be \
                           enforced here; re-plan the scan"
                     .to_string(),
             });
@@ -1771,18 +1767,28 @@ mod tests {
     }
 
     #[test]
-    fn test_grant_from_another_schema_cannot_authorize_a_raw_read() {
+    fn test_grant_from_another_table_cannot_authorize_a_raw_read() {
         // `authorize_rewrite_splits` is public and stamps grants, so a caller
-        // holding two tables could stamp one table's UNRESTRICTED grant onto
-        // splits of a restricted one. An unrestricted grant used to skip
-        // straight to the raw dispatch, so the binding must be checked first.
+        // holding two tables can stamp one table's UNRESTRICTED grant onto
+        // splits of another. Both tables sit at schema id 0 (a per-table
+        // counter, so freshly created tables collide), which is exactly why the
+        // grant binds the table identity and not just that counter.
         let table = query_auth_table();
+        let other = {
+            let mut t = query_auth_table();
+            t.location = "/tmp/test-query-auth-table-other".to_string();
+            t
+        };
+        assert_eq!(table.schema.id(), other.schema.id());
+
         let foreign = Arc::new(query_auth::QueryAuthGrant::new(
             Vec::new(),
             Vec::new(),
             None,
-            table.schema.id() + 1,
+            query_auth::GrantBinding::of(&other),
         ));
+        // Unrestricted grants used to skip straight to the raw dispatch, so the
+        // binding has to be checked before that branch.
         assert!(foreign.is_unrestricted());
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(foreign));
         let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
@@ -1790,9 +1796,9 @@ mod tests {
             matches!(
                 read.to_arrow(&[granted]),
                 Err(crate::Error::Unsupported { ref message })
-                    if message.contains("different table schema")
+                    if message.contains("different table or schema")
             ),
-            "a grant bound to another schema must not authorize a raw read"
+            "a grant bound to another table must not authorize a raw read"
         );
     }
 
@@ -1802,9 +1808,8 @@ mod tests {
         use std::collections::HashSet;
         let table = query_auth_table();
         let real = table.schema.fields()[0].clone();
-        // Authorized id 0 under another column's NAME: scoping resolves by id
-        // (would pass) while the physical read resolves by name. The batch path
-        // guards this too; both must go through `canonical_projection`.
+        // Authorized id under another column's name: scoped by id, read by
+        // name. Both paths must go through `canonical_projection`.
         let forged = crate::spec::DataField::new(
             real.id(),
             "not_the_real_name".to_string(),
@@ -1814,7 +1819,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
-            table.schema.id(),
+            query_auth::GrantBinding::of(&table),
         ));
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
         let plan = IncrementalPlan::new(
@@ -1837,10 +1842,9 @@ mod tests {
         use super::super::incremental_scan::{IncrementalPlan, IncrementalScanMode};
         use std::collections::HashSet;
 
-        // A column-scoped grant carries no filter and no mask, so the "cannot
-        // apply filters here" check passes it through. Nothing else on the
-        // incremental path checks scope, so without an explicit check a read
-        // wider than the scope would return unauthorized columns raw.
+        // A column-scoped grant has no filter or mask, so the filter check
+        // passes it through; without an explicit scope check a wider read
+        // would return unauthorized columns raw.
         let table = query_auth_table();
         let fields = table.schema.fields().to_vec();
         let read = TableRead::new(&table, fields.clone(), Vec::new());
@@ -1849,7 +1853,7 @@ mod tests {
                 Vec::new(),
                 Vec::new(),
                 Some(authorized),
-                table.schema.id(),
+                query_auth::GrantBinding::of(&table),
             ));
             let granted =
                 split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
@@ -1892,7 +1896,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
-            table.schema.id(),
+            query_auth::GrantBinding::of(&table),
         ));
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
 
@@ -1934,7 +1938,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
-            table.schema.id(),
+            query_auth::GrantBinding::of(&table),
         ));
         let granted =
             split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant.clone()));

--- a/crates/paimon/src/table/table_read.rs
+++ b/crates/paimon/src/table/table_read.rs
@@ -21,7 +21,7 @@ use super::format_table_read::FormatTableRead;
 use super::incremental_scan::{IncrementalPlan, IncrementalScanMode, IncrementalSplit};
 use super::kv_file_reader::{KeyValueFileReader, KeyValueReadConfig};
 use super::read_builder::split_scan_predicates;
-use super::{ArrowRecordBatchStream, Table};
+use super::{query_auth, ArrowRecordBatchStream, Table};
 use crate::arrow::build_target_arrow_schema;
 use crate::spec::{
     BigIntType, CoreOptions, DataField, DataType, MergeEngine, Predicate, TinyIntType,
@@ -108,6 +108,15 @@ impl<'a> TableRead<'a> {
         }
     }
 
+    /// A read-level row limit that must be applied after materialization
+    /// (format tables); Paimon reads push their limit to scan planning.
+    fn read_limit(&self) -> Option<usize> {
+        match &self.0 {
+            TableReadKind::Paimon(_) => None,
+            TableReadKind::Format(read) => read.limit(),
+        }
+    }
+
     /// Set a filter predicate.
     pub fn with_filter(self, filter: Predicate) -> Self {
         match self.0 {
@@ -133,7 +142,79 @@ impl<'a> TableRead<'a> {
     }
 
     /// Returns an [`ArrowRecordBatchStream`].
+    ///
+    /// Query-auth is enforced here off the grant stamped on the splits by scan
+    /// planning (or a write-path authorizer), never a shared slot on `Table`, so
+    /// the grant is exactly the one this query planned and cannot leak from a
+    /// concurrent query or a write rewrite. A restricted grant is applied on the
+    /// output stream; an unrestricted grant (or a non-query-auth table) reads
+    /// raw; and a `query-auth.enabled` table whose splits carry no grant means
+    /// an unauthorized read path — fail closed.
     pub fn to_arrow(&self, data_splits: &[DataSplit]) -> crate::Result<ArrowRecordBatchStream> {
+        match self.resolve_split_grant(data_splits)? {
+            Some(grant) if !grant.is_unrestricted() => {
+                self.to_arrow_auth_enforced(data_splits, grant)
+            }
+            _ => self.to_arrow_dispatch(data_splits),
+        }
+    }
+
+    /// The single query-auth grant every split in `data_splits` was planned
+    /// under, or `None` when the table is not `query-auth.enabled`.
+    ///
+    /// Splits from different plans must not be mixed: taking any one grant and
+    /// applying it to the whole slice would let a split carrying a permissive
+    /// grant relax the read of splits planned under a stricter one, so a
+    /// disagreement fails closed. A `query-auth.enabled` table whose splits
+    /// carry no grant means an unauthorized read path — also fail closed.
+    fn resolve_split_grant<'s>(
+        &self,
+        data_splits: impl IntoIterator<Item = &'s DataSplit>,
+    ) -> crate::Result<Option<Arc<query_auth::QueryAuthGrant>>> {
+        let mut grant: Option<&Arc<query_auth::QueryAuthGrant>> = None;
+        let mut saw_ungranted = false;
+        let mut empty = true;
+        for split in data_splits {
+            empty = false;
+            match (split.query_auth_grant(), &grant) {
+                (Some(found), None) => grant = Some(found),
+                (Some(found), Some(seen)) if found != *seen => {
+                    return Err(crate::Error::Unsupported {
+                        message: "reading splits planned under different query-auth grants is \
+                                  not supported; re-plan the scan"
+                            .to_string(),
+                    });
+                }
+                (Some(_), Some(_)) => {}
+                // A grant found later must not retroactively authorize an
+                // earlier grant-less split, so record it and check after the
+                // loop — matching on what was seen so far is order-dependent.
+                (None, _) => saw_ungranted = true,
+            }
+        }
+        if saw_ungranted && grant.is_some() {
+            return Err(crate::Error::Unsupported {
+                message: "a query-auth split was mixed with an unauthorized split; \
+                          re-plan the scan"
+                    .to_string(),
+            });
+        }
+        match grant {
+            Some(grant) => Ok(Some(Arc::clone(grant))),
+            // Nothing to read: an empty table or a fully pruned scan produces no
+            // rows, so there is nothing to leak (an authorized plan legitimately
+            // has no split to stamp).
+            None if empty => Ok(None),
+            // Real splits with no grant: either not a query-auth table, or an
+            // unauthorized read path — fail closed.
+            None => self.table().ensure_read_without_grant().map(|()| None),
+        }
+    }
+
+    fn to_arrow_dispatch(
+        &self,
+        data_splits: &[DataSplit],
+    ) -> crate::Result<ArrowRecordBatchStream> {
         match &self.0 {
             TableReadKind::Paimon(read) => read.to_arrow(data_splits),
             TableReadKind::Format(read) => read.to_arrow(data_splits),
@@ -148,13 +229,30 @@ impl<'a> TableRead<'a> {
         &self,
         plan: &IncrementalPlan,
     ) -> crate::Result<ArrowRecordBatchStream> {
-        self.ensure_query_auth_allowed()?;
+        self.ensure_incremental_plan_authorized(plan)?;
         plan.validate()?;
         match &self.0 {
             TableReadKind::Paimon(read) => read.to_incremental_arrow(plan),
             TableReadKind::Format(_) => Err(crate::Error::Unsupported {
                 message: "Format tables do not support incremental batch read".to_string(),
             }),
+        }
+    }
+
+    /// Incremental and audit-log reads consume their splits inside
+    /// `PaimonTableRead`, which cannot apply the row filter / masking pass, so a
+    /// restricted grant must fail closed here rather than return raw rows. An
+    /// unrestricted grant (or a non-query-auth table) proceeds.
+    fn ensure_incremental_plan_authorized(&self, plan: &IncrementalPlan) -> crate::Result<()> {
+        // `all_data_splits` (not `data_splits`) so a Diff plan's pairs are seen:
+        // `data_splits` drops them, which would present no splits at all.
+        match self.resolve_split_grant(plan.all_data_splits())? {
+            Some(grant) if grant.has_server_restrictions() => Err(crate::Error::Unsupported {
+                message: "reading a query-auth row filter / column masking grant on an \
+                          incremental or audit-log scan is not supported"
+                    .to_string(),
+            }),
+            _ => Ok(()),
         }
     }
 
@@ -168,7 +266,7 @@ impl<'a> TableRead<'a> {
         &self,
         plan: &IncrementalPlan,
     ) -> crate::Result<ArrowRecordBatchStream> {
-        self.ensure_query_auth_allowed()?;
+        self.ensure_incremental_plan_authorized(plan)?;
         plan.validate()?;
         match &self.0 {
             TableReadKind::Paimon(read) => read.to_audit_log_arrow(plan),
@@ -178,8 +276,169 @@ impl<'a> TableRead<'a> {
         }
     }
 
-    fn ensure_query_auth_allowed(&self) -> crate::Result<()> {
-        CoreOptions::new(self.table().schema().options()).ensure_read_authorized()
+    /// Read with the query-auth grant applied exactly: read the union of the
+    /// projection, the filter columns, and the mask inputs; per batch, drop
+    /// non-matching rows (on raw values, like Java), overwrite masked columns,
+    /// then project back to the requested columns.
+    fn to_arrow_auth_enforced(
+        &self,
+        data_splits: &[DataSplit],
+        grant: std::sync::Arc<query_auth::QueryAuthGrant>,
+    ) -> crate::Result<ArrowRecordBatchStream> {
+        use futures::StreamExt;
+
+        let table = self.table();
+        // The grant's filter and mask indices are POSITIONAL in the schema they
+        // were parsed against, so enforcing them on another schema would bind
+        // them to different columns. Refuse a grant issued for a different one.
+        if !grant.matches_schema(table.schema().id()) {
+            return Err(crate::Error::Unsupported {
+                message: "a query-auth grant issued for a different table schema cannot be \
+                          enforced here; re-plan the scan"
+                    .to_string(),
+            });
+        }
+        let schema_fields = table.schema().fields().to_vec();
+
+        // A caller predicate on a masked column would leak raw values through
+        // row selection (an oracle); refuse such reads.
+        let masked: std::collections::HashSet<usize> =
+            grant.masks().iter().map(|m| m.column).collect();
+        let mut caller_referenced = std::collections::HashSet::new();
+        self.data_predicates()
+            .iter()
+            .for_each(|p| p.collect_leaf_field_indices(&mut caller_referenced));
+        if let Some(index) = caller_referenced.intersection(&masked).next() {
+            return Err(query_auth::masked_filter_error(&schema_fields, *index));
+        }
+
+        // Every projected field must be a canonical (id, name) pair from the
+        // table schema. Authorization and mask selection resolve columns by id,
+        // but the physical read resolves them by name, so a hand-built read type
+        // pairing an authorized id with another column's name would read that
+        // other column and skip its mask. `with_read_type` / `TableRead::new`
+        // are public, so this is reachable — fail closed.
+        for field in self.read_type() {
+            let by_id = schema_fields.iter().find(|s| s.id() == field.id());
+            let by_name = schema_fields.iter().find(|s| s.name() == field.name());
+            match (by_id, by_name) {
+                // Canonical: the same schema field on both lookups.
+                (Some(s), Some(n)) if s.name() == field.name() && n.id() == field.id() => {}
+                // Neither an id nor a name of this schema: a system column (row
+                // id, etc.), which carries no grant scope — leave it to the reader.
+                (None, None) => {}
+                // Any mix — a known id under another column's name, or an
+                // unknown id borrowing a real column's name — would be scoped and
+                // masked by id while the physical read resolves it by name.
+                _ => {
+                    return Err(crate::Error::Unsupported {
+                        message: format!(
+                            "query-auth read type field #{} `{}` is not a column of this table",
+                            field.id(),
+                            field.name()
+                        ),
+                    });
+                }
+            }
+        }
+
+        // The grant is scoped to the columns authorized for this read; a wider
+        // projection or a predicate on an un-approved column must re-authorize.
+        // (The builder/scan paths also check this before pruning; this covers a
+        // directly-constructed `TableRead`.)
+        let projected_indices = self
+            .read_type()
+            .iter()
+            .filter_map(|f| schema_fields.iter().position(|s| s.id() == f.id()));
+        if let Some(index) =
+            grant.first_unauthorized(projected_indices.chain(caller_referenced.iter().copied()))
+        {
+            return Err(query_auth::unauthorized_column_error(&schema_fields, index));
+        }
+
+        // Only masks whose target is caller-projected matter (others are
+        // projected away); keeping just those avoids masking a target that was
+        // added to the physical read solely because a filter references it.
+        let caller_ids: std::collections::HashSet<i32> =
+            self.read_type().iter().map(|f| f.id()).collect();
+        let masks: Vec<query_auth::ColumnMask> = grant
+            .masks()
+            .iter()
+            .filter(|m| {
+                schema_fields
+                    .get(m.column)
+                    .is_some_and(|t| caller_ids.contains(&t.id()))
+            })
+            .cloned()
+            .collect();
+
+        // Widen the physical read with filter columns and the applied masks'
+        // inputs, so both are always available to the in-memory pass.
+        let mut referenced = std::collections::HashSet::new();
+        grant
+            .filters()
+            .iter()
+            .for_each(|f| f.collect_leaf_field_indices(&mut referenced));
+        masks
+            .iter()
+            .for_each(|m| m.transform.collect_field_indices(&mut referenced));
+        let mut physical = self.read_type().to_vec();
+        for index in referenced {
+            let field = schema_fields
+                .get(index)
+                .ok_or_else(|| crate::Error::Unsupported {
+                    message: format!("query-auth grant references unknown field #{index}"),
+                })?;
+            if !physical.iter().any(|f| f.id() == field.id()) {
+                physical.push(field.clone());
+            }
+        }
+
+        let projected_columns = self.read_type().len();
+        let filters = grant.filters().to_vec();
+        // The inner read must NOT apply the caller's limit: it would cap rows
+        // before the auth filter. Read everything, then truncate the output.
+        let caller_limit = self.read_limit();
+        let inner = TableRead::new(table, physical.clone(), self.data_predicates().to_vec());
+        let stream = inner.to_arrow_dispatch(data_splits)?.map(move |batch| {
+            let batch = batch?;
+            let filtered =
+                query_auth::strict_filter_batch(&batch, &filters, &schema_fields, &physical)?;
+            let masked = query_auth::mask_batch(&filtered, &masks, &schema_fields, &physical)?;
+            masked
+                .project(&(0..projected_columns).collect::<Vec<_>>())
+                .map_err(|e| crate::Error::DataInvalid {
+                    message: format!("failed to re-project query-auth batch: {e}"),
+                    source: Some(Box::new(e)),
+                })
+        });
+        match caller_limit {
+            None => Ok(Box::pin(stream)),
+            // `unfold` stops as soon as the cap is reached (state `emitted >=
+            // limit`) without polling the inner stream again, so a read error in
+            // a later batch can't surface after the limit is satisfied.
+            Some(limit) => Ok(Box::pin(futures::stream::unfold(
+                (Box::pin(stream), 0usize),
+                move |(mut inner, emitted)| async move {
+                    if emitted >= limit {
+                        return None;
+                    }
+                    match inner.next().await? {
+                        Err(e) => Some((Err(e), (inner, limit))),
+                        Ok(batch) => {
+                            let remaining = limit - emitted;
+                            let batch = if batch.num_rows() > remaining {
+                                batch.slice(0, remaining)
+                            } else {
+                                batch
+                            };
+                            let emitted = emitted + batch.num_rows();
+                            Some((Ok(batch), (inner, emitted)))
+                        }
+                    }
+                },
+            ))),
+        }
     }
 }
 
@@ -642,12 +901,12 @@ impl<'a> PaimonTableRead<'a> {
         reader.read(splits)
     }
 
-    /// Returns an [`ArrowRecordBatchStream`].
+    /// Returns an [`ArrowRecordBatchStream`]. Query-auth (fail-closed + row
+    /// filter + masking) is enforced by the outer [`TableRead::to_arrow`] off
+    /// the grant stamped on the splits.
     pub fn to_arrow(&self, data_splits: &[DataSplit]) -> crate::Result<ArrowRecordBatchStream> {
         let has_primary_keys = !self.table.schema.primary_keys().is_empty();
         let core_options = self.table.schema.core_options();
-        // Fail closed for a direct `TableRead` (bypassing `ReadBuilder::new_read`).
-        core_options.ensure_read_authorized()?;
         let merge_engine = core_options.merge_engine()?;
 
         // Route supported PK merge engines through the split-aware reader.
@@ -1491,20 +1750,107 @@ mod tests {
         // Bypass `ReadBuilder` by constructing `TableRead` directly; the `to_arrow` guard
         // still fails closed.
         let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
+        // Real splits with no stamped grant: the read would return raw rows.
+        let ungranted = split(vec![file("a", 5, Some(0))], true);
         assert!(
             matches!(
-                read.to_arrow(&[]),
+                read.to_arrow(&[ungranted]),
                 Err(crate::Error::Unsupported { ref message }) if message.contains("query-auth.enabled")
             ),
             "directly-constructed read of a query-auth.enabled table must fail closed"
         );
+        // An empty slice reads no rows, so it is allowed (an authorized plan may
+        // legitimately produce no splits).
+        assert!(read.to_arrow(&[]).is_ok());
+    }
+
+    #[test]
+    fn test_noncanonical_read_type_fails_closed() {
+        use std::collections::HashSet;
+
+        // Authorization and mask selection resolve by field id, but the physical
+        // read resolves by name. A read type pairing an authorized id with
+        // another column's name would read that other column and skip its mask.
+        let table = query_auth_table();
+        let schema_field = table.schema.fields()[0].clone();
+        let forged = crate::spec::DataField::new(
+            schema_field.id(),
+            "not_the_real_name".to_string(),
+            schema_field.data_type().clone(),
+        );
+        let grant = Arc::new(query_auth::QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+        ));
+        let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
+
+        // Direction A: a known id carrying another column's name.
+        let read = TableRead::new(&table, vec![forged], Vec::new());
+        let Err(err) = read.to_arrow(std::slice::from_ref(&granted)) else {
+            panic!("a read type with a mismatched id/name pair must fail closed");
+        };
+        assert!(
+            err.to_string().contains("not a column of this table"),
+            "got: {err}"
+        );
+
+        // Direction B: an UNKNOWN id borrowing a real column's name. The
+        // physical read resolves by name, so this would read the real column
+        // while scoping and mask selection (both by id) see an unrelated field.
+        let forged_id = crate::spec::DataField::new(
+            9999,
+            schema_field.name().to_string(),
+            schema_field.data_type().clone(),
+        );
+        let read = TableRead::new(&table, vec![forged_id], Vec::new());
+        let Err(err) = read.to_arrow(&[granted]) else {
+            panic!("an unknown id borrowing a real column name must fail closed");
+        };
+        assert!(
+            err.to_string().contains("not a column of this table"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_mixed_granted_and_ungranted_splits_fail_closed_in_both_orders() {
+        use std::collections::HashSet;
+
+        let table = query_auth_table();
+        let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
+        let grant = Arc::new(query_auth::QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+        ));
+        let granted =
+            split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant.clone()));
+        let ungranted = split(vec![file("b", 5, Some(0))], true);
+
+        // Order must not decide the verdict: a grant found later must never
+        // retroactively authorize an earlier grant-less split.
+        for slice in [
+            vec![granted.clone(), ungranted.clone()],
+            vec![ungranted, granted],
+        ] {
+            let Err(err) = read.to_arrow(&slice) else {
+                panic!("mixing a granted and an ungranted split must fail closed");
+            };
+            assert!(
+                err.to_string().contains("mixed with an unauthorized split"),
+                "got: {err}"
+            );
+        }
     }
 
     #[test]
     fn test_direct_incremental_read_fails_closed_when_query_auth_enabled() {
         let table = query_auth_table();
         let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
-        let plan = IncrementalPlan::new(IncrementalScanMode::Delta, Vec::new());
+        // Real splits carrying no grant: an unauthorized read path.
+        let ungranted = IncrementalSplit::Data(split(vec![file("a", 5, Some(0))], true));
+        let plan = IncrementalPlan::new(IncrementalScanMode::Delta, vec![ungranted]);
         assert!(
             matches!(
                 read.to_incremental_arrow(&plan),
@@ -1512,13 +1858,19 @@ mod tests {
             ),
             "directly-constructed incremental read of a query-auth.enabled table must fail closed"
         );
+        // An empty plan reads no rows, so it has nothing to leak (same rule as
+        // the batch path); authorization is per-split, not per-table.
+        let empty = IncrementalPlan::new(IncrementalScanMode::Delta, Vec::new());
+        assert!(read.to_incremental_arrow(&empty).is_ok());
     }
 
     #[test]
     fn test_direct_audit_log_read_fails_closed_when_query_auth_enabled() {
         let table = query_auth_table();
         let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
-        let plan = IncrementalPlan::new(IncrementalScanMode::Delta, Vec::new());
+        // Real splits carrying no grant: an unauthorized read path.
+        let ungranted = IncrementalSplit::Data(split(vec![file("a", 5, Some(0))], true));
+        let plan = IncrementalPlan::new(IncrementalScanMode::Delta, vec![ungranted]);
         assert!(
             matches!(
                 read.to_audit_log_arrow(&plan),
@@ -1526,6 +1878,10 @@ mod tests {
             ),
             "directly-constructed audit-log read of a query-auth.enabled table must fail closed"
         );
+        // An empty plan reads no rows, so it has nothing to leak (same rule as
+        // the batch path); authorization is per-split, not per-table.
+        let empty = IncrementalPlan::new(IncrementalScanMode::Delta, Vec::new());
+        assert!(read.to_audit_log_arrow(&empty).is_ok());
     }
 
     #[test]

--- a/crates/paimon/src/table/table_read.rs
+++ b/crates/paimon/src/table/table_read.rs
@@ -143,27 +143,22 @@ impl<'a> TableRead<'a> {
 
     /// Returns an [`ArrowRecordBatchStream`].
     ///
-    /// Query-auth is enforced here off the grant stamped on the splits by scan
-    /// planning (or a write-path authorizer), never a shared slot on `Table`, so
-    /// the grant is exactly the one this query planned and cannot leak from a
-    /// concurrent query or a write rewrite. A restricted grant is applied on the
-    /// output stream; an unrestricted grant (or a non-query-auth table) reads
-    /// raw; and a `query-auth.enabled` table whose splits carry no grant means
-    /// an unauthorized read path — fail closed.
+    /// Query-auth is enforced off the grant stamped on the splits, never a
+    /// shared slot on `Table`, so it cannot leak from a concurrent query or a
+    /// write rewrite. A restricted grant is applied to the output stream; an
+    /// unrestricted one reads raw; no grant on a `query-auth.enabled` table
+    /// means an unauthorized path — fail closed.
     pub fn to_arrow(&self, data_splits: &[DataSplit]) -> crate::Result<ArrowRecordBatchStream> {
         let Some(grant) = self.resolve_split_grant(data_splits)? else {
             return self.to_arrow_dispatch(data_splits);
         };
-        // Checked for every grant: `authorize_rewrite_splits` is public, so an
-        // unrestricted grant from one table must not authorize a raw read of
-        // another's splits.
-        if !grant.matches_table(self.table()) {
-            return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table or schema cannot be \
-                          enforced here; re-plan the scan"
-                    .to_string(),
-            });
-        }
+        query_auth::authorize_read(
+            &grant,
+            self.table(),
+            self.read_type(),
+            self.data_predicates(),
+            &[],
+        )?;
         if grant.is_unrestricted() {
             self.to_arrow_dispatch(data_splits)
         } else {
@@ -171,14 +166,12 @@ impl<'a> TableRead<'a> {
         }
     }
 
-    /// The single query-auth grant every split in `data_splits` was planned
-    /// under, or `None` when the table is not `query-auth.enabled`.
+    /// The single grant every split was planned under, or `None` for a
+    /// non-query-auth table.
     ///
-    /// Splits from different plans must not be mixed: taking any one grant and
-    /// applying it to the whole slice would let a split carrying a permissive
-    /// grant relax the read of splits planned under a stricter one, so a
-    /// disagreement fails closed. A `query-auth.enabled` table whose splits
-    /// carry no grant means an unauthorized read path — also fail closed.
+    /// A disagreement fails closed: one split's permissive grant must not relax
+    /// the read of splits planned under a stricter one. So does a
+    /// `query-auth.enabled` table whose splits carry no grant at all.
     fn resolve_split_grant<'s>(
         &self,
         data_splits: impl IntoIterator<Item = &'s DataSplit>,
@@ -241,7 +234,7 @@ impl<'a> TableRead<'a> {
         &self,
         plan: &IncrementalPlan,
     ) -> crate::Result<ArrowRecordBatchStream> {
-        self.ensure_incremental_plan_authorized(plan)?;
+        self.ensure_incremental_plan_authorized(plan, &[])?;
         plan.validate()?;
         match &self.0 {
             TableReadKind::Paimon(read) => read.to_incremental_arrow(plan),
@@ -252,10 +245,13 @@ impl<'a> TableRead<'a> {
     }
 
     /// Incremental and audit-log reads consume their splits inside
-    /// `PaimonTableRead`, which cannot apply the row filter / masking pass, so a
-    /// restricted grant must fail closed here rather than return raw rows. An
-    /// unrestricted grant (or a non-query-auth table) proceeds.
-    fn ensure_incremental_plan_authorized(&self, plan: &IncrementalPlan) -> crate::Result<()> {
+    /// `PaimonTableRead`, which cannot apply the filter / masking pass, so a
+    /// restricted grant fails closed here rather than return raw rows.
+    fn ensure_incremental_plan_authorized(
+        &self,
+        plan: &IncrementalPlan,
+        implicit_system_fields: &[&str],
+    ) -> crate::Result<()> {
         // `all_data_splits` (not `data_splits`) so a Diff plan's pairs are seen:
         // `data_splits` drops them, which would present no splits at all.
         let Some(grant) = self.resolve_split_grant(plan.all_data_splits())? else {
@@ -272,21 +268,14 @@ impl<'a> TableRead<'a> {
 
         // A scoped grant still needs checking, and nothing downstream on this
         // path does it (the batch path does, in `to_arrow_auth_enforced`).
-        let table = self.table();
-        if !grant.matches_table(table) {
-            return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table or schema cannot be \
-                          enforced here; re-plan the scan"
-                    .to_string(),
-            });
-        }
-        let schema_fields = table.schema().fields();
-        let projected = query_auth::canonical_projection(schema_fields, self.read_type())?;
-        let mut filter_columns = std::collections::HashSet::new();
-        self.data_predicates()
-            .iter()
-            .for_each(|p| p.collect_leaf_field_indices(&mut filter_columns));
-        query_auth::scope_check(&grant, schema_fields, &filter_columns, Some(projected))
+        query_auth::authorize_read(
+            &grant,
+            self.table(),
+            self.read_type(),
+            self.data_predicates(),
+            implicit_system_fields,
+        )
+        .map(|_| ())
     }
 
     /// Returns an audit-log [`ArrowRecordBatchStream`] for an incremental plan.
@@ -299,7 +288,14 @@ impl<'a> TableRead<'a> {
         &self,
         plan: &IncrementalPlan,
     ) -> crate::Result<ArrowRecordBatchStream> {
-        self.ensure_incremental_plan_authorized(plan)?;
+        // The audit schema prepends these on top of the read type, so neither
+        // reached the auth request via the projection. Check only what this read
+        // actually emits: `_SEQUENCE_NUMBER` is conditional.
+        let mut implicit = vec![ROW_KIND_FIELD_NAME];
+        if audit_sequence_number_enabled(self.table()) {
+            implicit.push(SEQUENCE_NUMBER_FIELD_NAME);
+        }
+        self.ensure_incremental_plan_authorized(plan, &implicit)?;
         plan.validate()?;
         match &self.0 {
             TableReadKind::Paimon(read) => read.to_audit_log_arrow(plan),
@@ -309,10 +305,9 @@ impl<'a> TableRead<'a> {
         }
     }
 
-    /// Read with the query-auth grant applied exactly: read the union of the
-    /// projection, the filter columns, and the mask inputs; per batch, drop
-    /// non-matching rows (on raw values, like Java), overwrite masked columns,
-    /// then project back to the requested columns.
+    /// Read the union of the projection, filter columns and mask inputs; per
+    /// batch drop non-matching rows (on raw values, like Java), overwrite masked
+    /// columns, then project back to the requested columns.
     fn to_arrow_auth_enforced(
         &self,
         data_splits: &[DataSplit],
@@ -324,53 +319,27 @@ impl<'a> TableRead<'a> {
         // The grant's filter and mask indices are POSITIONAL in the schema they
         // were parsed against, so enforcing them on another schema would bind
         // them to different columns. Refuse a grant issued for a different one.
-        if !grant.matches_table(table) {
-            return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table or schema cannot be \
-                          enforced here; re-plan the scan"
-                    .to_string(),
-            });
-        }
+        let projected = query_auth::authorize_read(
+            &grant,
+            table,
+            self.read_type(),
+            self.data_predicates(),
+            &[],
+        )?;
         let schema_fields = table.schema().fields().to_vec();
-
-        // A caller predicate on a masked column would leak raw values through
-        // row selection (an oracle); refuse such reads.
-        let masked: std::collections::HashSet<usize> =
-            grant.masks().iter().map(|m| m.column).collect();
-        let mut caller_referenced = std::collections::HashSet::new();
-        self.data_predicates()
-            .iter()
-            .for_each(|p| p.collect_leaf_field_indices(&mut caller_referenced));
-        if let Some(index) = caller_referenced.intersection(&masked).next() {
-            return Err(query_auth::masked_filter_error(&schema_fields, *index));
-        }
-
-        // The grant is scoped to the columns authorized for this read; a wider
-        // projection or a predicate on an un-approved column must re-authorize.
-        // (The builder/scan paths also check this before pruning; this covers a
-        // directly-constructed `TableRead`.)
-        let projected = query_auth::canonical_projection(&schema_fields, self.read_type())?;
-        if let Some(index) = grant.first_unauthorized(
-            projected
-                .into_iter()
-                .chain(caller_referenced.iter().copied()),
-        ) {
-            return Err(query_auth::unauthorized_column_error(&schema_fields, index));
-        }
 
         // Only masks whose target is caller-projected matter (others are
         // projected away); keeping just those avoids masking a target that was
         // added to the physical read solely because a filter references it.
-        let caller_ids: std::collections::HashSet<i32> =
-            self.read_type().iter().map(|f| f.id()).collect();
+        //
+        // Comparing against `projected` is equivalent to matching field ids ONLY
+        // because `authorize_read` above rejected any non-canonical read type:
+        // an id present in the read type therefore always has its schema index
+        // here. Moving that call after this point would silently drop masks.
         let masks: Vec<query_auth::ColumnMask> = grant
             .masks()
             .iter()
-            .filter(|m| {
-                schema_fields
-                    .get(m.column)
-                    .is_some_and(|t| caller_ids.contains(&t.id()))
-            })
+            .filter(|m| projected.contains(&m.column))
             .cloned()
             .collect();
 
@@ -1110,7 +1079,7 @@ fn audit_schema_for_read_type(
     build_target_arrow_schema(&fields)
 }
 
-fn audit_sequence_number_enabled(table: &Table) -> bool {
+pub(crate) fn audit_sequence_number_enabled(table: &Table) -> bool {
     table
         .schema()
         .options()
@@ -1768,11 +1737,9 @@ mod tests {
 
     #[test]
     fn test_grant_from_another_table_cannot_authorize_a_raw_read() {
-        // `authorize_rewrite_splits` is public and stamps grants, so a caller
-        // holding two tables can stamp one table's UNRESTRICTED grant onto
-        // splits of another. Both tables sit at schema id 0 (a per-table
-        // counter, so freshly created tables collide), which is exactly why the
-        // grant binds the table identity and not just that counter.
+        // `authorize_rewrite_splits` is public, so a caller holding two tables
+        // can stamp one's unrestricted grant onto the other's splits. Both sit
+        // at schema id 0 — a per-table counter — hence the identity binding.
         let table = query_auth_table();
         let other = {
             let mut t = query_auth_table();
@@ -1784,6 +1751,7 @@ mod tests {
         let foreign = Arc::new(query_auth::QueryAuthGrant::new(
             Vec::new(),
             Vec::new(),
+            None,
             None,
             query_auth::GrantBinding::of(&other),
         ));
@@ -1819,6 +1787,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            None,
             query_auth::GrantBinding::of(&table),
         ));
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
@@ -1853,6 +1822,7 @@ mod tests {
                 Vec::new(),
                 Vec::new(),
                 Some(authorized),
+                None,
                 query_auth::GrantBinding::of(&table),
             ));
             let granted =
@@ -1875,7 +1845,9 @@ mod tests {
 
         // Reading exactly the authorized columns is allowed.
         let in_scope = plan_for((0..fields.len()).collect());
-        assert!(read.ensure_incremental_plan_authorized(&in_scope).is_ok());
+        assert!(read
+            .ensure_incremental_plan_authorized(&in_scope, &[])
+            .is_ok());
     }
 
     #[test]
@@ -1896,6 +1868,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            None,
             query_auth::GrantBinding::of(&table),
         ));
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
@@ -1938,6 +1911,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            None,
             query_auth::GrantBinding::of(&table),
         ));
         let granted =

--- a/crates/paimon/src/table/table_read.rs
+++ b/crates/paimon/src/table/table_read.rs
@@ -186,11 +186,24 @@ impl<'a> TableRead<'a> {
     /// raw; and a `query-auth.enabled` table whose splits carry no grant means
     /// an unauthorized read path — fail closed.
     pub fn to_arrow(&self, data_splits: &[DataSplit]) -> crate::Result<ArrowRecordBatchStream> {
-        match self.resolve_split_grant(data_splits)? {
-            Some(grant) if !grant.is_unrestricted() => {
-                self.to_arrow_auth_enforced(data_splits, grant)
-            }
-            _ => self.to_arrow_dispatch(data_splits),
+        let Some(grant) = self.resolve_split_grant(data_splits)? else {
+            return self.to_arrow_dispatch(data_splits);
+        };
+        // Checked for every grant, not just restricted ones: an unrestricted
+        // grant fetched for one table must not authorize a raw read of another's
+        // splits. `authorize_rewrite_splits` is public and stamps grants, so a
+        // caller holding two tables could otherwise launder splits through it.
+        if !grant.matches_schema(self.table().schema().id()) {
+            return Err(crate::Error::Unsupported {
+                message: "a query-auth grant issued for a different table schema cannot be \
+                          enforced here; re-plan the scan"
+                    .to_string(),
+            });
+        }
+        if grant.is_unrestricted() {
+            self.to_arrow_dispatch(data_splits)
+        } else {
+            self.to_arrow_auth_enforced(data_splits, grant)
         }
     }
 
@@ -281,14 +294,38 @@ impl<'a> TableRead<'a> {
     fn ensure_incremental_plan_authorized(&self, plan: &IncrementalPlan) -> crate::Result<()> {
         // `all_data_splits` (not `data_splits`) so a Diff plan's pairs are seen:
         // `data_splits` drops them, which would present no splits at all.
-        match self.resolve_split_grant(plan.all_data_splits())? {
-            Some(grant) if grant.has_server_restrictions() => Err(crate::Error::Unsupported {
+        let Some(grant) = self.resolve_split_grant(plan.all_data_splits())? else {
+            return Ok(());
+        };
+
+        // Filters and masks cannot be applied on this path at all.
+        if grant.has_server_restrictions() {
+            return Err(crate::Error::Unsupported {
                 message: "reading a query-auth row filter / column masking grant on an \
                           incremental or audit-log scan is not supported"
                     .to_string(),
-            }),
-            _ => Ok(()),
+            });
         }
+
+        // No filter or mask, but the grant may still be scoped to a subset of
+        // columns, and nothing downstream re-checks that on this path (the batch
+        // path does it inside `to_arrow_auth_enforced`). Without this a read
+        // wider than the scope returns columns the server never authorized.
+        let table = self.table();
+        if !grant.matches_schema(table.schema().id()) {
+            return Err(crate::Error::Unsupported {
+                message: "a query-auth grant issued for a different table schema cannot be \
+                          enforced here; re-plan the scan"
+                    .to_string(),
+            });
+        }
+        let schema_fields = table.schema().fields();
+        let projected = query_auth::canonical_projection(schema_fields, self.read_type())?;
+        let mut filter_columns = std::collections::HashSet::new();
+        self.data_predicates()
+            .iter()
+            .for_each(|p| p.collect_leaf_field_indices(&mut filter_columns));
+        query_auth::scope_check(&grant, schema_fields, &filter_columns, Some(projected))
     }
 
     /// Returns an audit-log [`ArrowRecordBatchStream`] for an incremental plan.
@@ -347,47 +384,16 @@ impl<'a> TableRead<'a> {
             return Err(query_auth::masked_filter_error(&schema_fields, *index));
         }
 
-        // Every projected field must be a canonical (id, name) pair from the
-        // table schema. Authorization and mask selection resolve columns by id,
-        // but the physical read resolves them by name, so a hand-built read type
-        // pairing an authorized id with another column's name would read that
-        // other column and skip its mask. `with_read_type` / `TableRead::new`
-        // are public, so this is reachable — fail closed.
-        for field in self.read_type() {
-            let by_id = schema_fields.iter().find(|s| s.id() == field.id());
-            let by_name = schema_fields.iter().find(|s| s.name() == field.name());
-            match (by_id, by_name) {
-                // Canonical: the same schema field on both lookups.
-                (Some(s), Some(n)) if s.name() == field.name() && n.id() == field.id() => {}
-                // Neither an id nor a name of this schema: a system column (row
-                // id, etc.), which carries no grant scope — leave it to the reader.
-                (None, None) => {}
-                // Any mix — a known id under another column's name, or an
-                // unknown id borrowing a real column's name — would be scoped and
-                // masked by id while the physical read resolves it by name.
-                _ => {
-                    return Err(crate::Error::Unsupported {
-                        message: format!(
-                            "query-auth read type field #{} `{}` is not a column of this table",
-                            field.id(),
-                            field.name()
-                        ),
-                    });
-                }
-            }
-        }
-
         // The grant is scoped to the columns authorized for this read; a wider
         // projection or a predicate on an un-approved column must re-authorize.
         // (The builder/scan paths also check this before pruning; this covers a
         // directly-constructed `TableRead`.)
-        let projected_indices = self
-            .read_type()
-            .iter()
-            .filter_map(|f| schema_fields.iter().position(|s| s.id() == f.id()));
-        if let Some(index) =
-            grant.first_unauthorized(projected_indices.chain(caller_referenced.iter().copied()))
-        {
+        let projected = query_auth::canonical_projection(&schema_fields, self.read_type())?;
+        if let Some(index) = grant.first_unauthorized(
+            projected
+                .into_iter()
+                .chain(caller_referenced.iter().copied()),
+        ) {
             return Err(query_auth::unauthorized_column_error(&schema_fields, index));
         }
 
@@ -1968,6 +1974,110 @@ mod tests {
     }
 
     #[test]
+    fn test_grant_from_another_schema_cannot_authorize_a_raw_read() {
+        // `authorize_rewrite_splits` is public and stamps grants, so a caller
+        // holding two tables could stamp one table's UNRESTRICTED grant onto
+        // splits of a restricted one. An unrestricted grant used to skip
+        // straight to the raw dispatch, so the binding must be checked first.
+        let table = query_auth_table();
+        let foreign = Arc::new(query_auth::QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            None,
+            table.schema.id() + 1,
+        ));
+        assert!(foreign.is_unrestricted());
+        let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(foreign));
+        let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
+        assert!(
+            matches!(
+                read.to_arrow(&[granted]),
+                Err(crate::Error::Unsupported { ref message })
+                    if message.contains("different table schema")
+            ),
+            "a grant bound to another schema must not authorize a raw read"
+        );
+    }
+
+    #[test]
+    fn test_incremental_read_rejects_noncanonical_read_type() {
+        use super::super::incremental_scan::{IncrementalPlan, IncrementalScanMode};
+        use std::collections::HashSet;
+        let table = query_auth_table();
+        let real = table.schema.fields()[0].clone();
+        // Authorized id 0 under another column's NAME: scoping resolves by id
+        // (would pass) while the physical read resolves by name. The batch path
+        // guards this too; both must go through `canonical_projection`.
+        let forged = crate::spec::DataField::new(
+            real.id(),
+            "not_the_real_name".to_string(),
+            real.data_type().clone(),
+        );
+        let grant = Arc::new(query_auth::QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+            table.schema.id(),
+        ));
+        let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
+        let plan = IncrementalPlan::new(
+            IncrementalScanMode::Delta,
+            vec![IncrementalSplit::Data(granted)],
+        );
+        let read = TableRead::new(&table, vec![forged], Vec::new());
+        assert!(
+            matches!(
+                read.to_incremental_arrow(&plan),
+                Err(crate::Error::Unsupported { ref message })
+                    if message.contains("is not a column of this table")
+            ),
+            "a read type pairing an authorized id with another column's name must fail closed"
+        );
+    }
+
+    #[test]
+    fn test_incremental_read_enforces_column_scope() {
+        use super::super::incremental_scan::{IncrementalPlan, IncrementalScanMode};
+        use std::collections::HashSet;
+
+        // A column-scoped grant carries no filter and no mask, so the "cannot
+        // apply filters here" check passes it through. Nothing else on the
+        // incremental path checks scope, so without an explicit check a read
+        // wider than the scope would return unauthorized columns raw.
+        let table = query_auth_table();
+        let fields = table.schema.fields().to_vec();
+        let read = TableRead::new(&table, fields.clone(), Vec::new());
+        let plan_for = |authorized: HashSet<usize>| {
+            let grant = Arc::new(query_auth::QueryAuthGrant::new(
+                Vec::new(),
+                Vec::new(),
+                Some(authorized),
+                table.schema.id(),
+            ));
+            let granted =
+                split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
+            IncrementalPlan::new(
+                IncrementalScanMode::Delta,
+                vec![IncrementalSplit::Data(granted)],
+            )
+        };
+
+        let out_of_scope = plan_for(HashSet::new());
+        assert!(
+            matches!(
+                read.to_incremental_arrow(&out_of_scope),
+                Err(crate::Error::Unsupported { ref message })
+                    if message.contains("outside the authorized set")
+            ),
+            "incremental read wider than the grant's column scope must fail closed"
+        );
+
+        // Reading exactly the authorized columns is allowed.
+        let in_scope = plan_for((0..fields.len()).collect());
+        assert!(read.ensure_incremental_plan_authorized(&in_scope).is_ok());
+    }
+
+    #[test]
     fn test_noncanonical_read_type_fails_closed() {
         use std::collections::HashSet;
 
@@ -1985,6 +2095,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            table.schema.id(),
         ));
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
 
@@ -2026,6 +2137,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            table.schema.id(),
         ));
         let granted =
             split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant.clone()));

--- a/crates/paimon/src/table/table_read.rs
+++ b/crates/paimon/src/table/table_read.rs
@@ -156,6 +156,15 @@ impl<'a> TableRead<'a> {
 
     /// Override the Parquet resource budget shared by this read.
     #[doc(hidden)]
+    /// The budget the caller attached, if any. `None` means "use the table's
+    /// configured default", which each read resolves for itself.
+    fn explicit_parquet_read_budget(&self) -> Option<Arc<ParquetReadBudget>> {
+        match &self.0 {
+            TableReadKind::Paimon(read) => read.parquet_read_budget.clone(),
+            TableReadKind::Format(read) => read.explicit_parquet_read_budget(),
+        }
+    }
+
     pub fn with_parquet_read_budget(self, budget: Arc<ParquetReadBudget>) -> Self {
         match self.0 {
             TableReadKind::Paimon(read) => {
@@ -178,27 +187,20 @@ impl<'a> TableRead<'a> {
 
     /// Returns an [`ArrowRecordBatchStream`].
     ///
-    /// Query-auth is enforced here off the grant stamped on the splits by scan
-    /// planning (or a write-path authorizer), never a shared slot on `Table`, so
-    /// the grant is exactly the one this query planned and cannot leak from a
-    /// concurrent query or a write rewrite. A restricted grant is applied on the
-    /// output stream; an unrestricted grant (or a non-query-auth table) reads
-    /// raw; and a `query-auth.enabled` table whose splits carry no grant means
-    /// an unauthorized read path — fail closed.
+    /// Query-auth is enforced off the grant stamped on the splits, never a shared
+    /// slot, so a concurrent query or a rewrite cannot leak into it. No grant on
+    /// a `query-auth.enabled` table means an unauthorized path: fail closed.
     pub fn to_arrow(&self, data_splits: &[DataSplit]) -> crate::Result<ArrowRecordBatchStream> {
         let Some(grant) = self.resolve_split_grant(data_splits)? else {
             return self.to_arrow_dispatch(data_splits);
         };
-        // Checked for every grant: `authorize_rewrite_splits` is public, so an
-        // unrestricted grant from one table must not authorize a raw read of
-        // another's splits.
-        if !grant.matches_table(self.table()) {
-            return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table or schema cannot be \
-                          enforced here; re-plan the scan"
-                    .to_string(),
-            });
-        }
+        query_auth::authorize_read(
+            &grant,
+            self.table(),
+            self.read_type(),
+            self.data_predicates(),
+            &[],
+        )?;
         if grant.is_unrestricted() {
             self.to_arrow_dispatch(data_splits)
         } else {
@@ -206,14 +208,11 @@ impl<'a> TableRead<'a> {
         }
     }
 
-    /// The single query-auth grant every split in `data_splits` was planned
-    /// under, or `None` when the table is not `query-auth.enabled`.
+    /// The single grant every split was planned under, or `None` for a
+    /// non-query-auth table.
     ///
-    /// Splits from different plans must not be mixed: taking any one grant and
-    /// applying it to the whole slice would let a split carrying a permissive
-    /// grant relax the read of splits planned under a stricter one, so a
-    /// disagreement fails closed. A `query-auth.enabled` table whose splits
-    /// carry no grant means an unauthorized read path — also fail closed.
+    /// A disagreement fails closed: one split's permissive grant must not relax
+    /// the read of splits planned under a stricter one.
     fn resolve_split_grant<'s>(
         &self,
         data_splits: impl IntoIterator<Item = &'s DataSplit>,
@@ -276,7 +275,7 @@ impl<'a> TableRead<'a> {
         &self,
         plan: &IncrementalPlan,
     ) -> crate::Result<ArrowRecordBatchStream> {
-        self.ensure_incremental_plan_authorized(plan)?;
+        self.ensure_incremental_plan_authorized(plan, &[])?;
         plan.validate()?;
         match &self.0 {
             TableReadKind::Paimon(read) => read.to_incremental_arrow(plan),
@@ -287,10 +286,13 @@ impl<'a> TableRead<'a> {
     }
 
     /// Incremental and audit-log reads consume their splits inside
-    /// `PaimonTableRead`, which cannot apply the row filter / masking pass, so a
-    /// restricted grant must fail closed here rather than return raw rows. An
-    /// unrestricted grant (or a non-query-auth table) proceeds.
-    fn ensure_incremental_plan_authorized(&self, plan: &IncrementalPlan) -> crate::Result<()> {
+    /// `PaimonTableRead`, which cannot apply the filter / masking pass, so a
+    /// restricted grant fails closed here rather than return raw rows.
+    fn ensure_incremental_plan_authorized(
+        &self,
+        plan: &IncrementalPlan,
+        implicit_system_fields: &[&str],
+    ) -> crate::Result<()> {
         // `all_data_splits` (not `data_splits`) so a Diff plan's pairs are seen:
         // `data_splits` drops them, which would present no splits at all.
         let Some(grant) = self.resolve_split_grant(plan.all_data_splits())? else {
@@ -307,21 +309,14 @@ impl<'a> TableRead<'a> {
 
         // A scoped grant still needs checking, and nothing downstream on this
         // path does it (the batch path does, in `to_arrow_auth_enforced`).
-        let table = self.table();
-        if !grant.matches_table(table) {
-            return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table or schema cannot be \
-                          enforced here; re-plan the scan"
-                    .to_string(),
-            });
-        }
-        let schema_fields = table.schema().fields();
-        let projected = query_auth::canonical_projection(schema_fields, self.read_type())?;
-        let mut filter_columns = std::collections::HashSet::new();
-        self.data_predicates()
-            .iter()
-            .for_each(|p| p.collect_leaf_field_indices(&mut filter_columns));
-        query_auth::scope_check(&grant, schema_fields, &filter_columns, Some(projected))
+        query_auth::authorize_read(
+            &grant,
+            self.table(),
+            self.read_type(),
+            self.data_predicates(),
+            implicit_system_fields,
+        )
+        .map(|_| ())
     }
 
     /// Returns an audit-log [`ArrowRecordBatchStream`] for an incremental plan.
@@ -334,7 +329,14 @@ impl<'a> TableRead<'a> {
         &self,
         plan: &IncrementalPlan,
     ) -> crate::Result<ArrowRecordBatchStream> {
-        self.ensure_incremental_plan_authorized(plan)?;
+        // The audit schema prepends these on top of the read type, so neither
+        // reached the auth request via the projection. Check only what this read
+        // actually emits: `_SEQUENCE_NUMBER` is conditional.
+        let mut implicit = vec![ROW_KIND_FIELD_NAME];
+        if audit_sequence_number_enabled(self.table()) {
+            implicit.push(SEQUENCE_NUMBER_FIELD_NAME);
+        }
+        self.ensure_incremental_plan_authorized(plan, &implicit)?;
         plan.validate()?;
         match &self.0 {
             TableReadKind::Paimon(read) => read.to_audit_log_arrow(plan),
@@ -344,10 +346,9 @@ impl<'a> TableRead<'a> {
         }
     }
 
-    /// Read with the query-auth grant applied exactly: read the union of the
-    /// projection, the filter columns, and the mask inputs; per batch, drop
-    /// non-matching rows (on raw values, like Java), overwrite masked columns,
-    /// then project back to the requested columns.
+    /// Read the union of the projection, filter columns and mask inputs; per
+    /// batch drop non-matching rows (on raw values, like Java), overwrite masked
+    /// columns, then project back to the requested columns.
     fn to_arrow_auth_enforced(
         &self,
         data_splits: &[DataSplit],
@@ -359,53 +360,23 @@ impl<'a> TableRead<'a> {
         // The grant's filter and mask indices are POSITIONAL in the schema they
         // were parsed against, so enforcing them on another schema would bind
         // them to different columns. Refuse a grant issued for a different one.
-        if !grant.matches_table(table) {
-            return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table or schema cannot be \
-                          enforced here; re-plan the scan"
-                    .to_string(),
-            });
-        }
+        let projected = query_auth::authorize_read(
+            &grant,
+            table,
+            self.read_type(),
+            self.data_predicates(),
+            &[],
+        )?;
         let schema_fields = table.schema().fields().to_vec();
 
-        // A caller predicate on a masked column would leak raw values through
-        // row selection (an oracle); refuse such reads.
-        let masked: std::collections::HashSet<usize> =
-            grant.masks().iter().map(|m| m.column).collect();
-        let mut caller_referenced = std::collections::HashSet::new();
-        self.data_predicates()
-            .iter()
-            .for_each(|p| p.collect_leaf_field_indices(&mut caller_referenced));
-        if let Some(index) = caller_referenced.intersection(&masked).next() {
-            return Err(query_auth::masked_filter_error(&schema_fields, *index));
-        }
-
-        // The grant is scoped to the columns authorized for this read; a wider
-        // projection or a predicate on an un-approved column must re-authorize.
-        // (The builder/scan paths also check this before pruning; this covers a
-        // directly-constructed `TableRead`.)
-        let projected = query_auth::canonical_projection(&schema_fields, self.read_type())?;
-        if let Some(index) = grant.first_unauthorized(
-            projected
-                .into_iter()
-                .chain(caller_referenced.iter().copied()),
-        ) {
-            return Err(query_auth::unauthorized_column_error(&schema_fields, index));
-        }
-
-        // Only masks whose target is caller-projected matter (others are
-        // projected away); keeping just those avoids masking a target that was
-        // added to the physical read solely because a filter references it.
-        let caller_ids: std::collections::HashSet<i32> =
-            self.read_type().iter().map(|f| f.id()).collect();
+        // Only masks whose target the caller projected matter; the rest would
+        // mask a column added to the physical read just for a filter. Comparing
+        // by index is sound only because `authorize_read` above rejected any
+        // non-canonical read type — moving it later would silently drop masks.
         let masks: Vec<query_auth::ColumnMask> = grant
             .masks()
             .iter()
-            .filter(|m| {
-                schema_fields
-                    .get(m.column)
-                    .is_some_and(|t| caller_ids.contains(&t.id()))
-            })
+            .filter(|m| projected.contains(&m.column))
             .cloned()
             .collect();
 
@@ -436,7 +407,13 @@ impl<'a> TableRead<'a> {
         // The inner read must NOT apply the caller's limit: it would cap rows
         // before the auth filter. Read everything, then truncate the output.
         let caller_limit = self.read_limit();
-        let inner = TableRead::new(table, physical.clone(), self.data_predicates().to_vec());
+        // Carry the caller's Parquet budget: DataFusion hands one query-wide
+        // budget to every scan partition, so a fresh read here would give each
+        // authorized partition its own and multiply row-group concurrency.
+        let mut inner = TableRead::new(table, physical.clone(), self.data_predicates().to_vec());
+        if let Some(budget) = self.explicit_parquet_read_budget() {
+            inner = inner.with_parquet_read_budget(budget);
+        }
         let stream = inner.to_arrow_dispatch(data_splits)?.map(move |batch| {
             let batch = batch?;
             let filtered =
@@ -1192,7 +1169,7 @@ fn audit_schema_for_read_type(
     build_target_arrow_schema(&fields)
 }
 
-fn audit_sequence_number_enabled(table: &Table) -> bool {
+pub(crate) fn audit_sequence_number_enabled(table: &Table) -> bool {
     table
         .schema()
         .options()
@@ -1971,11 +1948,9 @@ mod tests {
 
     #[test]
     fn test_grant_from_another_table_cannot_authorize_a_raw_read() {
-        // `authorize_rewrite_splits` is public and stamps grants, so a caller
-        // holding two tables can stamp one table's UNRESTRICTED grant onto
-        // splits of another. Both tables sit at schema id 0 (a per-table
-        // counter, so freshly created tables collide), which is exactly why the
-        // grant binds the table identity and not just that counter.
+        // `authorize_rewrite_splits` is public, so a caller holding two tables
+        // can stamp one's unrestricted grant onto the other's splits. Both sit
+        // at schema id 0 — a per-table counter — hence the identity binding.
         let table = query_auth_table();
         let other = {
             let mut t = query_auth_table();
@@ -1987,6 +1962,7 @@ mod tests {
         let foreign = Arc::new(query_auth::QueryAuthGrant::new(
             Vec::new(),
             Vec::new(),
+            None,
             None,
             query_auth::GrantBinding::of(&other),
         ));
@@ -2022,6 +1998,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            None,
             query_auth::GrantBinding::of(&table),
         ));
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
@@ -2056,6 +2033,7 @@ mod tests {
                 Vec::new(),
                 Vec::new(),
                 Some(authorized),
+                None,
                 query_auth::GrantBinding::of(&table),
             ));
             let granted =
@@ -2078,7 +2056,9 @@ mod tests {
 
         // Reading exactly the authorized columns is allowed.
         let in_scope = plan_for((0..fields.len()).collect());
-        assert!(read.ensure_incremental_plan_authorized(&in_scope).is_ok());
+        assert!(read
+            .ensure_incremental_plan_authorized(&in_scope, &[])
+            .is_ok());
     }
 
     #[test]
@@ -2099,6 +2079,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            None,
             query_auth::GrantBinding::of(&table),
         ));
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
@@ -2141,6 +2122,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
+            None,
             query_auth::GrantBinding::of(&table),
         ));
         let granted =

--- a/crates/paimon/src/table/table_read.rs
+++ b/crates/paimon/src/table/table_read.rs
@@ -189,13 +189,12 @@ impl<'a> TableRead<'a> {
         let Some(grant) = self.resolve_split_grant(data_splits)? else {
             return self.to_arrow_dispatch(data_splits);
         };
-        // Checked for every grant, not just restricted ones: an unrestricted
-        // grant fetched for one table must not authorize a raw read of another's
-        // splits. `authorize_rewrite_splits` is public and stamps grants, so a
-        // caller holding two tables could otherwise launder splits through it.
-        if !grant.matches_schema(self.table().schema().id()) {
+        // Checked for every grant: `authorize_rewrite_splits` is public, so an
+        // unrestricted grant from one table must not authorize a raw read of
+        // another's splits.
+        if !grant.matches_table(self.table()) {
             return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table schema cannot be \
+                message: "a query-auth grant issued for a different table or schema cannot be \
                           enforced here; re-plan the scan"
                     .to_string(),
             });
@@ -298,7 +297,6 @@ impl<'a> TableRead<'a> {
             return Ok(());
         };
 
-        // Filters and masks cannot be applied on this path at all.
         if grant.has_server_restrictions() {
             return Err(crate::Error::Unsupported {
                 message: "reading a query-auth row filter / column masking grant on an \
@@ -307,14 +305,12 @@ impl<'a> TableRead<'a> {
             });
         }
 
-        // No filter or mask, but the grant may still be scoped to a subset of
-        // columns, and nothing downstream re-checks that on this path (the batch
-        // path does it inside `to_arrow_auth_enforced`). Without this a read
-        // wider than the scope returns columns the server never authorized.
+        // A scoped grant still needs checking, and nothing downstream on this
+        // path does it (the batch path does, in `to_arrow_auth_enforced`).
         let table = self.table();
-        if !grant.matches_schema(table.schema().id()) {
+        if !grant.matches_table(table) {
             return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table schema cannot be \
+                message: "a query-auth grant issued for a different table or schema cannot be \
                           enforced here; re-plan the scan"
                     .to_string(),
             });
@@ -363,9 +359,9 @@ impl<'a> TableRead<'a> {
         // The grant's filter and mask indices are POSITIONAL in the schema they
         // were parsed against, so enforcing them on another schema would bind
         // them to different columns. Refuse a grant issued for a different one.
-        if !grant.matches_schema(table.schema().id()) {
+        if !grant.matches_table(table) {
             return Err(crate::Error::Unsupported {
-                message: "a query-auth grant issued for a different table schema cannot be \
+                message: "a query-auth grant issued for a different table or schema cannot be \
                           enforced here; re-plan the scan"
                     .to_string(),
             });
@@ -1974,18 +1970,28 @@ mod tests {
     }
 
     #[test]
-    fn test_grant_from_another_schema_cannot_authorize_a_raw_read() {
+    fn test_grant_from_another_table_cannot_authorize_a_raw_read() {
         // `authorize_rewrite_splits` is public and stamps grants, so a caller
-        // holding two tables could stamp one table's UNRESTRICTED grant onto
-        // splits of a restricted one. An unrestricted grant used to skip
-        // straight to the raw dispatch, so the binding must be checked first.
+        // holding two tables can stamp one table's UNRESTRICTED grant onto
+        // splits of another. Both tables sit at schema id 0 (a per-table
+        // counter, so freshly created tables collide), which is exactly why the
+        // grant binds the table identity and not just that counter.
         let table = query_auth_table();
+        let other = {
+            let mut t = query_auth_table();
+            t.location = "/tmp/test-query-auth-table-other".to_string();
+            t
+        };
+        assert_eq!(table.schema.id(), other.schema.id());
+
         let foreign = Arc::new(query_auth::QueryAuthGrant::new(
             Vec::new(),
             Vec::new(),
             None,
-            table.schema.id() + 1,
+            query_auth::GrantBinding::of(&other),
         ));
+        // Unrestricted grants used to skip straight to the raw dispatch, so the
+        // binding has to be checked before that branch.
         assert!(foreign.is_unrestricted());
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(foreign));
         let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
@@ -1993,9 +1999,9 @@ mod tests {
             matches!(
                 read.to_arrow(&[granted]),
                 Err(crate::Error::Unsupported { ref message })
-                    if message.contains("different table schema")
+                    if message.contains("different table or schema")
             ),
-            "a grant bound to another schema must not authorize a raw read"
+            "a grant bound to another table must not authorize a raw read"
         );
     }
 
@@ -2005,9 +2011,8 @@ mod tests {
         use std::collections::HashSet;
         let table = query_auth_table();
         let real = table.schema.fields()[0].clone();
-        // Authorized id 0 under another column's NAME: scoping resolves by id
-        // (would pass) while the physical read resolves by name. The batch path
-        // guards this too; both must go through `canonical_projection`.
+        // Authorized id under another column's name: scoped by id, read by
+        // name. Both paths must go through `canonical_projection`.
         let forged = crate::spec::DataField::new(
             real.id(),
             "not_the_real_name".to_string(),
@@ -2017,7 +2022,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
-            table.schema.id(),
+            query_auth::GrantBinding::of(&table),
         ));
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
         let plan = IncrementalPlan::new(
@@ -2040,10 +2045,9 @@ mod tests {
         use super::super::incremental_scan::{IncrementalPlan, IncrementalScanMode};
         use std::collections::HashSet;
 
-        // A column-scoped grant carries no filter and no mask, so the "cannot
-        // apply filters here" check passes it through. Nothing else on the
-        // incremental path checks scope, so without an explicit check a read
-        // wider than the scope would return unauthorized columns raw.
+        // A column-scoped grant has no filter or mask, so the filter check
+        // passes it through; without an explicit scope check a wider read
+        // would return unauthorized columns raw.
         let table = query_auth_table();
         let fields = table.schema.fields().to_vec();
         let read = TableRead::new(&table, fields.clone(), Vec::new());
@@ -2052,7 +2056,7 @@ mod tests {
                 Vec::new(),
                 Vec::new(),
                 Some(authorized),
-                table.schema.id(),
+                query_auth::GrantBinding::of(&table),
             ));
             let granted =
                 split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
@@ -2095,7 +2099,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
-            table.schema.id(),
+            query_auth::GrantBinding::of(&table),
         ));
         let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
 
@@ -2137,7 +2141,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(HashSet::from([0])),
-            table.schema.id(),
+            query_auth::GrantBinding::of(&table),
         ));
         let granted =
             split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant.clone()));

--- a/crates/paimon/src/table/table_read.rs
+++ b/crates/paimon/src/table/table_read.rs
@@ -21,7 +21,7 @@ use super::format_table_read::FormatTableRead;
 use super::incremental_scan::{IncrementalPlan, IncrementalScanMode, IncrementalSplit};
 use super::kv_file_reader::{KeyValueFileReader, KeyValueReadConfig};
 use super::read_builder::split_scan_predicates;
-use super::{ArrowRecordBatchStream, Table};
+use super::{query_auth, ArrowRecordBatchStream, Table};
 use crate::arrow::build_target_arrow_schema;
 use crate::arrow::ParquetReadBudget;
 use crate::spec::{
@@ -121,6 +121,15 @@ impl<'a> TableRead<'a> {
         }
     }
 
+    /// A read-level row limit that must be applied after materialization
+    /// (format tables); Paimon reads push their limit to scan planning.
+    fn read_limit(&self) -> Option<usize> {
+        match &self.0 {
+            TableReadKind::Paimon(_) => None,
+            TableReadKind::Format(read) => read.limit(),
+        }
+    }
+
     /// Set a filter predicate.
     pub fn with_filter(self, filter: Predicate) -> Self {
         match self.0 {
@@ -168,7 +177,79 @@ impl<'a> TableRead<'a> {
     }
 
     /// Returns an [`ArrowRecordBatchStream`].
+    ///
+    /// Query-auth is enforced here off the grant stamped on the splits by scan
+    /// planning (or a write-path authorizer), never a shared slot on `Table`, so
+    /// the grant is exactly the one this query planned and cannot leak from a
+    /// concurrent query or a write rewrite. A restricted grant is applied on the
+    /// output stream; an unrestricted grant (or a non-query-auth table) reads
+    /// raw; and a `query-auth.enabled` table whose splits carry no grant means
+    /// an unauthorized read path — fail closed.
     pub fn to_arrow(&self, data_splits: &[DataSplit]) -> crate::Result<ArrowRecordBatchStream> {
+        match self.resolve_split_grant(data_splits)? {
+            Some(grant) if !grant.is_unrestricted() => {
+                self.to_arrow_auth_enforced(data_splits, grant)
+            }
+            _ => self.to_arrow_dispatch(data_splits),
+        }
+    }
+
+    /// The single query-auth grant every split in `data_splits` was planned
+    /// under, or `None` when the table is not `query-auth.enabled`.
+    ///
+    /// Splits from different plans must not be mixed: taking any one grant and
+    /// applying it to the whole slice would let a split carrying a permissive
+    /// grant relax the read of splits planned under a stricter one, so a
+    /// disagreement fails closed. A `query-auth.enabled` table whose splits
+    /// carry no grant means an unauthorized read path — also fail closed.
+    fn resolve_split_grant<'s>(
+        &self,
+        data_splits: impl IntoIterator<Item = &'s DataSplit>,
+    ) -> crate::Result<Option<Arc<query_auth::QueryAuthGrant>>> {
+        let mut grant: Option<&Arc<query_auth::QueryAuthGrant>> = None;
+        let mut saw_ungranted = false;
+        let mut empty = true;
+        for split in data_splits {
+            empty = false;
+            match (split.query_auth_grant(), &grant) {
+                (Some(found), None) => grant = Some(found),
+                (Some(found), Some(seen)) if found != *seen => {
+                    return Err(crate::Error::Unsupported {
+                        message: "reading splits planned under different query-auth grants is \
+                                  not supported; re-plan the scan"
+                            .to_string(),
+                    });
+                }
+                (Some(_), Some(_)) => {}
+                // A grant found later must not retroactively authorize an
+                // earlier grant-less split, so record it and check after the
+                // loop — matching on what was seen so far is order-dependent.
+                (None, _) => saw_ungranted = true,
+            }
+        }
+        if saw_ungranted && grant.is_some() {
+            return Err(crate::Error::Unsupported {
+                message: "a query-auth split was mixed with an unauthorized split; \
+                          re-plan the scan"
+                    .to_string(),
+            });
+        }
+        match grant {
+            Some(grant) => Ok(Some(Arc::clone(grant))),
+            // Nothing to read: an empty table or a fully pruned scan produces no
+            // rows, so there is nothing to leak (an authorized plan legitimately
+            // has no split to stamp).
+            None if empty => Ok(None),
+            // Real splits with no grant: either not a query-auth table, or an
+            // unauthorized read path — fail closed.
+            None => self.table().ensure_read_without_grant().map(|()| None),
+        }
+    }
+
+    fn to_arrow_dispatch(
+        &self,
+        data_splits: &[DataSplit],
+    ) -> crate::Result<ArrowRecordBatchStream> {
         match &self.0 {
             TableReadKind::Paimon(read) => read.to_arrow(data_splits),
             TableReadKind::Format(read) => read.to_arrow(data_splits),
@@ -183,13 +264,30 @@ impl<'a> TableRead<'a> {
         &self,
         plan: &IncrementalPlan,
     ) -> crate::Result<ArrowRecordBatchStream> {
-        self.ensure_query_auth_allowed()?;
+        self.ensure_incremental_plan_authorized(plan)?;
         plan.validate()?;
         match &self.0 {
             TableReadKind::Paimon(read) => read.to_incremental_arrow(plan),
             TableReadKind::Format(_) => Err(crate::Error::Unsupported {
                 message: "Format tables do not support incremental batch read".to_string(),
             }),
+        }
+    }
+
+    /// Incremental and audit-log reads consume their splits inside
+    /// `PaimonTableRead`, which cannot apply the row filter / masking pass, so a
+    /// restricted grant must fail closed here rather than return raw rows. An
+    /// unrestricted grant (or a non-query-auth table) proceeds.
+    fn ensure_incremental_plan_authorized(&self, plan: &IncrementalPlan) -> crate::Result<()> {
+        // `all_data_splits` (not `data_splits`) so a Diff plan's pairs are seen:
+        // `data_splits` drops them, which would present no splits at all.
+        match self.resolve_split_grant(plan.all_data_splits())? {
+            Some(grant) if grant.has_server_restrictions() => Err(crate::Error::Unsupported {
+                message: "reading a query-auth row filter / column masking grant on an \
+                          incremental or audit-log scan is not supported"
+                    .to_string(),
+            }),
+            _ => Ok(()),
         }
     }
 
@@ -203,7 +301,7 @@ impl<'a> TableRead<'a> {
         &self,
         plan: &IncrementalPlan,
     ) -> crate::Result<ArrowRecordBatchStream> {
-        self.ensure_query_auth_allowed()?;
+        self.ensure_incremental_plan_authorized(plan)?;
         plan.validate()?;
         match &self.0 {
             TableReadKind::Paimon(read) => read.to_audit_log_arrow(plan),
@@ -213,8 +311,169 @@ impl<'a> TableRead<'a> {
         }
     }
 
-    fn ensure_query_auth_allowed(&self) -> crate::Result<()> {
-        CoreOptions::new(self.table().schema().options()).ensure_read_authorized()
+    /// Read with the query-auth grant applied exactly: read the union of the
+    /// projection, the filter columns, and the mask inputs; per batch, drop
+    /// non-matching rows (on raw values, like Java), overwrite masked columns,
+    /// then project back to the requested columns.
+    fn to_arrow_auth_enforced(
+        &self,
+        data_splits: &[DataSplit],
+        grant: std::sync::Arc<query_auth::QueryAuthGrant>,
+    ) -> crate::Result<ArrowRecordBatchStream> {
+        use futures::StreamExt;
+
+        let table = self.table();
+        // The grant's filter and mask indices are POSITIONAL in the schema they
+        // were parsed against, so enforcing them on another schema would bind
+        // them to different columns. Refuse a grant issued for a different one.
+        if !grant.matches_schema(table.schema().id()) {
+            return Err(crate::Error::Unsupported {
+                message: "a query-auth grant issued for a different table schema cannot be \
+                          enforced here; re-plan the scan"
+                    .to_string(),
+            });
+        }
+        let schema_fields = table.schema().fields().to_vec();
+
+        // A caller predicate on a masked column would leak raw values through
+        // row selection (an oracle); refuse such reads.
+        let masked: std::collections::HashSet<usize> =
+            grant.masks().iter().map(|m| m.column).collect();
+        let mut caller_referenced = std::collections::HashSet::new();
+        self.data_predicates()
+            .iter()
+            .for_each(|p| p.collect_leaf_field_indices(&mut caller_referenced));
+        if let Some(index) = caller_referenced.intersection(&masked).next() {
+            return Err(query_auth::masked_filter_error(&schema_fields, *index));
+        }
+
+        // Every projected field must be a canonical (id, name) pair from the
+        // table schema. Authorization and mask selection resolve columns by id,
+        // but the physical read resolves them by name, so a hand-built read type
+        // pairing an authorized id with another column's name would read that
+        // other column and skip its mask. `with_read_type` / `TableRead::new`
+        // are public, so this is reachable — fail closed.
+        for field in self.read_type() {
+            let by_id = schema_fields.iter().find(|s| s.id() == field.id());
+            let by_name = schema_fields.iter().find(|s| s.name() == field.name());
+            match (by_id, by_name) {
+                // Canonical: the same schema field on both lookups.
+                (Some(s), Some(n)) if s.name() == field.name() && n.id() == field.id() => {}
+                // Neither an id nor a name of this schema: a system column (row
+                // id, etc.), which carries no grant scope — leave it to the reader.
+                (None, None) => {}
+                // Any mix — a known id under another column's name, or an
+                // unknown id borrowing a real column's name — would be scoped and
+                // masked by id while the physical read resolves it by name.
+                _ => {
+                    return Err(crate::Error::Unsupported {
+                        message: format!(
+                            "query-auth read type field #{} `{}` is not a column of this table",
+                            field.id(),
+                            field.name()
+                        ),
+                    });
+                }
+            }
+        }
+
+        // The grant is scoped to the columns authorized for this read; a wider
+        // projection or a predicate on an un-approved column must re-authorize.
+        // (The builder/scan paths also check this before pruning; this covers a
+        // directly-constructed `TableRead`.)
+        let projected_indices = self
+            .read_type()
+            .iter()
+            .filter_map(|f| schema_fields.iter().position(|s| s.id() == f.id()));
+        if let Some(index) =
+            grant.first_unauthorized(projected_indices.chain(caller_referenced.iter().copied()))
+        {
+            return Err(query_auth::unauthorized_column_error(&schema_fields, index));
+        }
+
+        // Only masks whose target is caller-projected matter (others are
+        // projected away); keeping just those avoids masking a target that was
+        // added to the physical read solely because a filter references it.
+        let caller_ids: std::collections::HashSet<i32> =
+            self.read_type().iter().map(|f| f.id()).collect();
+        let masks: Vec<query_auth::ColumnMask> = grant
+            .masks()
+            .iter()
+            .filter(|m| {
+                schema_fields
+                    .get(m.column)
+                    .is_some_and(|t| caller_ids.contains(&t.id()))
+            })
+            .cloned()
+            .collect();
+
+        // Widen the physical read with filter columns and the applied masks'
+        // inputs, so both are always available to the in-memory pass.
+        let mut referenced = std::collections::HashSet::new();
+        grant
+            .filters()
+            .iter()
+            .for_each(|f| f.collect_leaf_field_indices(&mut referenced));
+        masks
+            .iter()
+            .for_each(|m| m.transform.collect_field_indices(&mut referenced));
+        let mut physical = self.read_type().to_vec();
+        for index in referenced {
+            let field = schema_fields
+                .get(index)
+                .ok_or_else(|| crate::Error::Unsupported {
+                    message: format!("query-auth grant references unknown field #{index}"),
+                })?;
+            if !physical.iter().any(|f| f.id() == field.id()) {
+                physical.push(field.clone());
+            }
+        }
+
+        let projected_columns = self.read_type().len();
+        let filters = grant.filters().to_vec();
+        // The inner read must NOT apply the caller's limit: it would cap rows
+        // before the auth filter. Read everything, then truncate the output.
+        let caller_limit = self.read_limit();
+        let inner = TableRead::new(table, physical.clone(), self.data_predicates().to_vec());
+        let stream = inner.to_arrow_dispatch(data_splits)?.map(move |batch| {
+            let batch = batch?;
+            let filtered =
+                query_auth::strict_filter_batch(&batch, &filters, &schema_fields, &physical)?;
+            let masked = query_auth::mask_batch(&filtered, &masks, &schema_fields, &physical)?;
+            masked
+                .project(&(0..projected_columns).collect::<Vec<_>>())
+                .map_err(|e| crate::Error::DataInvalid {
+                    message: format!("failed to re-project query-auth batch: {e}"),
+                    source: Some(Box::new(e)),
+                })
+        });
+        match caller_limit {
+            None => Ok(Box::pin(stream)),
+            // `unfold` stops as soon as the cap is reached (state `emitted >=
+            // limit`) without polling the inner stream again, so a read error in
+            // a later batch can't surface after the limit is satisfied.
+            Some(limit) => Ok(Box::pin(futures::stream::unfold(
+                (Box::pin(stream), 0usize),
+                move |(mut inner, emitted)| async move {
+                    if emitted >= limit {
+                        return None;
+                    }
+                    match inner.next().await? {
+                        Err(e) => Some((Err(e), (inner, limit))),
+                        Ok(batch) => {
+                            let remaining = limit - emitted;
+                            let batch = if batch.num_rows() > remaining {
+                                batch.slice(0, remaining)
+                            } else {
+                                batch
+                            };
+                            let emitted = emitted + batch.num_rows();
+                            Some((Ok(batch), (inner, emitted)))
+                        }
+                    }
+                },
+            ))),
+        }
     }
 }
 
@@ -714,12 +973,12 @@ impl<'a> PaimonTableRead<'a> {
         reader.read(splits)
     }
 
-    /// Returns an [`ArrowRecordBatchStream`].
+    /// Returns an [`ArrowRecordBatchStream`]. Query-auth (fail-closed + row
+    /// filter + masking) is enforced by the outer [`TableRead::to_arrow`] off
+    /// the grant stamped on the splits.
     pub fn to_arrow(&self, data_splits: &[DataSplit]) -> crate::Result<ArrowRecordBatchStream> {
         let has_primary_keys = !self.table.schema.primary_keys().is_empty();
         let core_options = self.table.schema.core_options();
-        // Fail closed for a direct `TableRead` (bypassing `ReadBuilder::new_read`).
-        core_options.ensure_read_authorized()?;
         let merge_engine = core_options.merge_engine()?;
 
         // Route supported PK merge engines through the split-aware reader.
@@ -1694,13 +1953,98 @@ mod tests {
         // Bypass `ReadBuilder` by constructing `TableRead` directly; the `to_arrow` guard
         // still fails closed.
         let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
+        // Real splits with no stamped grant: the read would return raw rows.
+        let ungranted = split(vec![file("a", 5, Some(0))], true);
         assert!(
             matches!(
-                read.to_arrow(&[]),
+                read.to_arrow(&[ungranted]),
                 Err(crate::Error::Unsupported { ref message }) if message.contains("query-auth.enabled")
             ),
             "directly-constructed read of a query-auth.enabled table must fail closed"
         );
+        // An empty slice reads no rows, so it is allowed (an authorized plan may
+        // legitimately produce no splits).
+        assert!(read.to_arrow(&[]).is_ok());
+    }
+
+    #[test]
+    fn test_noncanonical_read_type_fails_closed() {
+        use std::collections::HashSet;
+
+        // Authorization and mask selection resolve by field id, but the physical
+        // read resolves by name. A read type pairing an authorized id with
+        // another column's name would read that other column and skip its mask.
+        let table = query_auth_table();
+        let schema_field = table.schema.fields()[0].clone();
+        let forged = crate::spec::DataField::new(
+            schema_field.id(),
+            "not_the_real_name".to_string(),
+            schema_field.data_type().clone(),
+        );
+        let grant = Arc::new(query_auth::QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+        ));
+        let granted = split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant));
+
+        // Direction A: a known id carrying another column's name.
+        let read = TableRead::new(&table, vec![forged], Vec::new());
+        let Err(err) = read.to_arrow(std::slice::from_ref(&granted)) else {
+            panic!("a read type with a mismatched id/name pair must fail closed");
+        };
+        assert!(
+            err.to_string().contains("not a column of this table"),
+            "got: {err}"
+        );
+
+        // Direction B: an UNKNOWN id borrowing a real column's name. The
+        // physical read resolves by name, so this would read the real column
+        // while scoping and mask selection (both by id) see an unrelated field.
+        let forged_id = crate::spec::DataField::new(
+            9999,
+            schema_field.name().to_string(),
+            schema_field.data_type().clone(),
+        );
+        let read = TableRead::new(&table, vec![forged_id], Vec::new());
+        let Err(err) = read.to_arrow(&[granted]) else {
+            panic!("an unknown id borrowing a real column name must fail closed");
+        };
+        assert!(
+            err.to_string().contains("not a column of this table"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_mixed_granted_and_ungranted_splits_fail_closed_in_both_orders() {
+        use std::collections::HashSet;
+
+        let table = query_auth_table();
+        let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
+        let grant = Arc::new(query_auth::QueryAuthGrant::new(
+            Vec::new(),
+            Vec::new(),
+            Some(HashSet::from([0])),
+        ));
+        let granted =
+            split(vec![file("a", 5, Some(0))], true).with_query_auth_grant(Some(grant.clone()));
+        let ungranted = split(vec![file("b", 5, Some(0))], true);
+
+        // Order must not decide the verdict: a grant found later must never
+        // retroactively authorize an earlier grant-less split.
+        for slice in [
+            vec![granted.clone(), ungranted.clone()],
+            vec![ungranted, granted],
+        ] {
+            let Err(err) = read.to_arrow(&slice) else {
+                panic!("mixing a granted and an ungranted split must fail closed");
+            };
+            assert!(
+                err.to_string().contains("mixed with an unauthorized split"),
+                "got: {err}"
+            );
+        }
     }
 
     #[test]
@@ -1724,7 +2068,9 @@ mod tests {
     fn test_direct_incremental_read_fails_closed_when_query_auth_enabled() {
         let table = query_auth_table();
         let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
-        let plan = IncrementalPlan::new(IncrementalScanMode::Delta, Vec::new());
+        // Real splits carrying no grant: an unauthorized read path.
+        let ungranted = IncrementalSplit::Data(split(vec![file("a", 5, Some(0))], true));
+        let plan = IncrementalPlan::new(IncrementalScanMode::Delta, vec![ungranted]);
         assert!(
             matches!(
                 read.to_incremental_arrow(&plan),
@@ -1732,13 +2078,19 @@ mod tests {
             ),
             "directly-constructed incremental read of a query-auth.enabled table must fail closed"
         );
+        // An empty plan reads no rows, so it has nothing to leak (same rule as
+        // the batch path); authorization is per-split, not per-table.
+        let empty = IncrementalPlan::new(IncrementalScanMode::Delta, Vec::new());
+        assert!(read.to_incremental_arrow(&empty).is_ok());
     }
 
     #[test]
     fn test_direct_audit_log_read_fails_closed_when_query_auth_enabled() {
         let table = query_auth_table();
         let read = TableRead::new(&table, table.schema.fields().to_vec(), Vec::new());
-        let plan = IncrementalPlan::new(IncrementalScanMode::Delta, Vec::new());
+        // Real splits carrying no grant: an unauthorized read path.
+        let ungranted = IncrementalSplit::Data(split(vec![file("a", 5, Some(0))], true));
+        let plan = IncrementalPlan::new(IncrementalScanMode::Delta, vec![ungranted]);
         assert!(
             matches!(
                 read.to_audit_log_arrow(&plan),
@@ -1746,6 +2098,10 @@ mod tests {
             ),
             "directly-constructed audit-log read of a query-auth.enabled table must fail closed"
         );
+        // An empty plan reads no rows, so it has nothing to leak (same rule as
+        // the batch path); authorization is per-split, not per-table.
+        let empty = IncrementalPlan::new(IncrementalScanMode::Delta, Vec::new());
+        assert!(read.to_audit_log_arrow(&empty).is_ok());
     }
 
     #[test]

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -1185,7 +1185,18 @@ impl<'a> PaimonTableScan<'a> {
     ///
     /// This replaces any existing row_ranges. Typically used to inject
     /// results from global index lookups (e.g. full-text search).
+    /// Slicing by physical row id selects rows by `_ROW_ID` with no predicate,
+    /// so it must reach the auth request even when set after `new_scan` fixed
+    /// the scope (`ReadBuilder::with_row_ranges` does the same on its side).
     pub fn with_row_ranges(mut self, ranges: Vec<RowRange>) -> Self {
+        let row_id = crate::spec::ROW_ID_FIELD_NAME.to_string();
+        // Only while ranges actually apply: clearing them must not leave a
+        // stale system-column request that could get an otherwise valid read
+        // rejected.
+        self.query_auth_system_select.retain(|n| n != &row_id);
+        if !ranges.is_empty() {
+            self.query_auth_system_select.push(row_id);
+        }
         self.row_ranges = if ranges.is_empty() {
             None
         } else {
@@ -1235,6 +1246,36 @@ impl<'a> PaimonTableScan<'a> {
     /// Reference: [TimeTravelUtil.tryTravelToSnapshot](https://github.com/apache/paimon/blob/master/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/TimeTravelUtil.java)
     /// for `scan.version`; the strict selectors mirror Java's typed
     /// `scan.snapshot-id` / `scan.tag-name` handling.
+    /// Fail closed when the snapshot the plan will read was written under a
+    /// different schema than the grant was parsed against.
+    ///
+    /// The grant is fetched before the snapshot is resolved, so a schema-changing
+    /// commit landing in between would leave the rules bound to this copy's
+    /// schema while the plan consumes the new one — a drop-and-re-add in that
+    /// window binds them to unrelated field ids.
+    fn ensure_grant_matches_snapshot(
+        &self,
+        grant: Option<&Arc<QueryAuthGrant>>,
+        snapshot: &Snapshot,
+    ) -> crate::Result<()> {
+        let Some(grant) = grant else {
+            return Ok(());
+        };
+        // Only a snapshot NEWER than this copy is a problem. A schema-only ALTER
+        // writes `schema-N` without committing a snapshot, so the table schema
+        // is routinely ahead of the latest data snapshot — the reader evolves
+        // those older files by field id, and the rules were parsed against the
+        // newer schema they are expressed in.
+        if !grant.has_server_restrictions() || snapshot.schema_id() <= self.table.schema().id() {
+            return Ok(());
+        }
+        Err(crate::Error::Unsupported {
+            message: "the snapshot being planned was written under a newer schema than the \
+                      query-auth grant was issued for; re-plan the scan"
+                .to_string(),
+        })
+    }
+
     pub async fn plan(&self) -> crate::Result<Plan> {
         let grant = self.ensure_query_auth_allowed().await?;
         let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
@@ -1243,6 +1284,7 @@ impl<'a> PaimonTableScan<'a> {
             Some(snapshot) => snapshot,
             None => return Ok(self.finalize_plan(Plan::new(Vec::new()), grant.as_ref())),
         };
+        self.ensure_grant_matches_snapshot(grant.as_ref(), &snapshot)?;
         self.plan_snapshot(
             snapshot,
             data_evolution_read_field_ids.as_ref(),
@@ -1271,6 +1313,7 @@ impl<'a> PaimonTableScan<'a> {
                 ))
             }
         };
+        self.ensure_grant_matches_snapshot(grant.as_ref(), &snapshot)?;
         trace.snapshot_id = Some(snapshot.id());
         let plan = self
             .plan_snapshot(
@@ -1287,10 +1330,9 @@ impl<'a> PaimonTableScan<'a> {
     /// exactly this plan's grant) and mark row counts inexact when it carries a
     /// row filter (dropped as a residual pass inside `TableRead`).
     fn finalize_plan(&self, plan: Plan, grant: Option<&Arc<QueryAuthGrant>>) -> Plan {
-        // Any restricted grant invalidates the plan's statistics: a row filter
-        // drops rows, and masking rewrites column values (a NULL mask makes the
-        // column entirely null), so a statistics-only `COUNT` would report raw
-        // counts and bypass enforcement.
+        // A row filter drops rows and masking rewrites values, so a
+        // statistics-only `COUNT` would report raw counts and bypass
+        // enforcement.
         let restricted = grant.is_some_and(|g| g.has_server_restrictions());
         let plan = plan.stamp_query_auth_grant(grant.cloned());
         if restricted {
@@ -1317,9 +1359,21 @@ impl<'a> PaimonTableScan<'a> {
         });
         let grant = self
             .table
-            .verify_query_auth_for_read(select.as_ref(), &self.query_auth_system_select)
+            .verify_query_auth_for_read(select.as_ref(), Some(&self.query_auth_system_select))
             .await?;
         if let Some(grant) = &grant {
+            // `scan_all_files` returns the un-merged files a normal PK scan
+            // hides, whose paths and statistics precede the filtering that only
+            // runs in `TableRead`. A pure column scope distorts none of that and
+            // stays allowed (the cross-partition bucket assigner needs it).
+            if self.scan_all_files && grant.has_server_restrictions() {
+                return Err(crate::Error::Unsupported {
+                    message: "a query-auth row filter / column masking grant cannot be applied \
+                              to a scan-all-files plan: it returns raw physical files whose \
+                              paths and statistics precede enforcement"
+                        .to_string(),
+                });
+            }
             crate::table::query_auth::scope_check(
                 grant,
                 self.table.schema().fields(),
@@ -1330,11 +1384,10 @@ impl<'a> PaimonTableScan<'a> {
         Ok(grant)
     }
 
-    /// The projected field ids for data-evolution column-slice pruning, widened
-    /// with the grant's row-filter / mask-input columns so pruning cannot drop a
-    /// file holding a column the grant needs (an omitted column would read as
-    /// null and wrongly satisfy `IS_NULL`). Computed here — with the grant in
-    /// hand — rather than at `new_scan` time, where the grant does not yet exist.
+    /// Projected field ids for data-evolution column-slice pruning, widened with
+    /// the grant's filter / mask-input columns so pruning cannot drop a file
+    /// holding one (an omitted column reads as null and wrongly satisfies
+    /// `IS_NULL`). Needs the grant, so it cannot happen at `new_scan` time.
     fn auth_widened_read_field_ids(&self, grant: Option<&QueryAuthGrant>) -> Option<HashSet<i32>> {
         let mut ids = self.projected_read_field_ids.clone();
         if let (Some(set), Some(grant)) = (ids.as_mut(), grant) {

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -44,6 +44,7 @@ use crate::table::bin_pack::split_for_batch;
 use crate::table::merge_tree_split_generator::{
     merge_tree_split_for_batch, KeyComparator, SplitGroup,
 };
+use crate::table::query_auth::QueryAuthGrant;
 use crate::table::schema_manager::SchemaManager;
 use crate::table::source::{
     any_range_overlaps_file, intersect_ranges_with_file, merge_row_ranges, DataSplit,
@@ -1027,6 +1028,21 @@ impl<'a> TableScan<'a> {
         }
     }
 
+    pub(super) fn with_query_auth_scope(
+        self,
+        filter_columns: HashSet<usize>,
+        projected: Option<Vec<usize>>,
+    ) -> Self {
+        match self.0 {
+            TableScanKind::Paimon(scan) => Self(TableScanKind::Paimon(
+                scan.with_query_auth_scope(filter_columns, projected),
+            )),
+            TableScanKind::Format(scan) => Self(TableScanKind::Format(
+                scan.with_query_auth_scope(filter_columns, projected),
+            )),
+        }
+    }
+
     pub async fn plan(&self) -> crate::Result<Plan> {
         match &self.0 {
             TableScanKind::Paimon(scan) => scan.plan().await,
@@ -1091,7 +1107,7 @@ impl<'a> TableScan<'a> {
     fn apply_limit_pushdown(&self, splits: Vec<DataSplit>) -> Vec<DataSplit> {
         match &self.0 {
             TableScanKind::Paimon(scan) => scan.apply_limit_pushdown(splits),
-            TableScanKind::Format(scan) => scan.apply_limit_pushdown(splits),
+            TableScanKind::Format(scan) => scan.apply_limit_pushdown(splits, false),
         }
     }
 }
@@ -1117,6 +1133,10 @@ struct PaimonTableScan<'a> {
     /// the complete file set. Normal read scans leave this as `false`.
     scan_all_files: bool,
     projected_read_field_ids: Option<HashSet<i32>>,
+    /// Filter/projection columns for the query-auth scope check, evaluated
+    /// against the live grant at plan time (see `ensure_query_auth_allowed`).
+    query_auth_filter_columns: HashSet<usize>,
+    query_auth_projected: Option<Vec<usize>>,
 }
 
 impl<'a> PaimonTableScan<'a> {
@@ -1138,6 +1158,8 @@ impl<'a> PaimonTableScan<'a> {
             row_range_optimization_disabled: false,
             scan_all_files: false,
             projected_read_field_ids: None,
+            query_auth_filter_columns: HashSet::new(),
+            query_auth_projected: None,
         }
     }
 
@@ -1178,6 +1200,16 @@ impl<'a> PaimonTableScan<'a> {
         self
     }
 
+    pub(super) fn with_query_auth_scope(
+        mut self,
+        filter_columns: HashSet<usize>,
+        projected: Option<Vec<usize>>,
+    ) -> Self {
+        self.query_auth_filter_columns = filter_columns;
+        self.query_auth_projected = projected;
+        self
+    }
+
     /// Plan the full scan: resolve snapshot (via options or latest), then read manifests and build DataSplits.
     ///
     /// Time travel is resolved from table options:
@@ -1194,27 +1226,40 @@ impl<'a> PaimonTableScan<'a> {
     /// for `scan.version`; the strict selectors mirror Java's typed
     /// `scan.snapshot-id` / `scan.tag-name` handling.
     pub async fn plan(&self) -> crate::Result<Plan> {
-        self.ensure_query_auth_allowed()?;
-        let data_evolution_read_field_ids = self.projected_read_field_ids()?;
+        let grant = self.ensure_query_auth_allowed().await?;
+        let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
+        let data_evolution_read_field_ids = self.auth_widened_read_field_ids(grant.as_deref());
         let snapshot = match super::time_travel::resolve_snapshot(self.table).await? {
             Some(snapshot) => snapshot,
-            None => return Ok(Plan::new(Vec::new())),
+            None => return Ok(self.finalize_plan(Plan::new(Vec::new()), grant.as_ref())),
         };
-        self.plan_snapshot(snapshot, data_evolution_read_field_ids.as_ref(), None)
-            .await
+        self.plan_snapshot(
+            snapshot,
+            data_evolution_read_field_ids.as_ref(),
+            None,
+            has_row_filter,
+        )
+        .await
+        .map(|plan| self.finalize_plan(plan, grant.as_ref()))
     }
 
     /// Plan the full scan and return metadata-pruning trace counters.
     pub async fn plan_with_trace(&self) -> crate::Result<(Plan, ScanTrace)> {
-        self.ensure_query_auth_allowed()?;
+        let grant = self.ensure_query_auth_allowed().await?;
+        let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
         let mut trace = ScanTrace {
             limit: self.limit,
             ..Default::default()
         };
-        let data_evolution_read_field_ids = self.projected_read_field_ids()?;
+        let data_evolution_read_field_ids = self.auth_widened_read_field_ids(grant.as_deref());
         let snapshot = match super::time_travel::resolve_snapshot(self.table).await? {
             Some(snapshot) => snapshot,
-            None => return Ok((Plan::new(Vec::new()), trace)),
+            None => {
+                return Ok((
+                    self.finalize_plan(Plan::new(Vec::new()), grant.as_ref()),
+                    trace,
+                ))
+            }
         };
         trace.snapshot_id = Some(snapshot.id());
         let plan = self
@@ -1222,20 +1267,70 @@ impl<'a> PaimonTableScan<'a> {
                 snapshot,
                 data_evolution_read_field_ids.as_ref(),
                 Some(&mut trace),
+                has_row_filter,
             )
             .await?;
-        Ok((plan, trace))
+        Ok((self.finalize_plan(plan, grant.as_ref()), trace))
+    }
+
+    /// Stamp the grant onto every split (so `TableRead::to_arrow` enforces
+    /// exactly this plan's grant) and mark row counts inexact when it carries a
+    /// row filter (dropped as a residual pass inside `TableRead`).
+    fn finalize_plan(&self, plan: Plan, grant: Option<&Arc<QueryAuthGrant>>) -> Plan {
+        // Any restricted grant invalidates the plan's statistics: a row filter
+        // drops rows, and masking rewrites column values (a NULL mask makes the
+        // column entirely null), so a statistics-only `COUNT` would report raw
+        // counts and bypass enforcement.
+        let restricted = grant.is_some_and(|g| g.has_server_restrictions());
+        let plan = plan.stamp_query_auth_grant(grant.cloned());
+        if restricted {
+            plan.with_inexact_row_counts()
+        } else {
+            plan
+        }
     }
 
     /// Fail closed for a `query-auth.enabled` table: scan planning — including
     /// `with_scan_all_files`, which read-facing system tables like `files` use —
     /// exposes file paths, row counts, and stats the client can't authorize.
-    fn ensure_query_auth_allowed(&self) -> crate::Result<()> {
-        CoreOptions::new(self.table.schema().options()).ensure_read_authorized()
+    /// Returns the fetched grant (`None` = not a query-auth table) so the caller
+    /// can widen the projection and stamp the splits with it.
+    async fn ensure_query_auth_allowed(&self) -> crate::Result<Option<Arc<QueryAuthGrant>>> {
+        // Fetch/refresh the grant at plan time (Java parity), then guard
+        // against pruning on masked or out-of-scope columns.
+        let select = self.query_auth_projected.as_ref().map(|projected| {
+            projected
+                .iter()
+                .copied()
+                .chain(self.query_auth_filter_columns.iter().copied())
+                .collect::<std::collections::HashSet<usize>>()
+        });
+        let grant = self
+            .table
+            .verify_query_auth_for_read(select.as_ref())
+            .await?;
+        if let Some(grant) = &grant {
+            crate::table::query_auth::scope_check(
+                grant,
+                self.table.schema().fields(),
+                &self.query_auth_filter_columns,
+                self.query_auth_projected.clone(),
+            )?;
+        }
+        Ok(grant)
     }
 
-    fn projected_read_field_ids(&self) -> crate::Result<Option<HashSet<i32>>> {
-        Ok(self.projected_read_field_ids.clone())
+    /// The projected field ids for data-evolution column-slice pruning, widened
+    /// with the grant's row-filter / mask-input columns so pruning cannot drop a
+    /// file holding a column the grant needs (an omitted column would read as
+    /// null and wrongly satisfy `IS_NULL`). Computed here — with the grant in
+    /// hand — rather than at `new_scan` time, where the grant does not yet exist.
+    fn auth_widened_read_field_ids(&self, grant: Option<&QueryAuthGrant>) -> Option<HashSet<i32>> {
+        let mut ids = self.projected_read_field_ids.clone();
+        if let (Some(set), Some(grant)) = (ids.as_mut(), grant) {
+            set.extend(grant.read_field_ids(self.table.schema().fields()));
+        }
+        ids
     }
 
     /// Apply a limit-pushdown hint to the generated splits.
@@ -1361,8 +1456,16 @@ impl<'a> PaimonTableScan<'a> {
         Ok(entries)
     }
 
-    fn can_push_down_limit_hint(&self, row_ranges: Option<&[RowRange]>) -> bool {
+    fn can_push_down_limit_hint(
+        &self,
+        row_ranges: Option<&[RowRange]>,
+        query_auth_row_filter: bool,
+    ) -> bool {
+        // A query-auth row filter is applied as a residual pass at read time, so
+        // split merged_row_count overcounts; count-based limit pruning would drop
+        // splits holding later authorized rows.
         can_push_down_limit_hint_for_scan(&self.data_predicates, row_ranges)
+            && !query_auth_row_filter
     }
 
     fn global_index_scan_settings(
@@ -1525,14 +1628,17 @@ impl<'a> PaimonTableScan<'a> {
     /// Reuses the same split-building path as a full snapshot plan, but only
     /// reads the delta manifest list and keeps ADD entries.
     pub(crate) async fn plan_snapshot_delta(&self, snapshot: &Snapshot) -> crate::Result<Plan> {
-        self.ensure_query_auth_allowed()?;
-        let data_evolution_read_field_ids = self.projected_read_field_ids()?;
-        self.plan_snapshot_manifest_list(
-            snapshot,
-            snapshot.delta_manifest_list(),
-            data_evolution_read_field_ids.as_ref(),
-        )
-        .await
+        let grant = self.ensure_query_auth_allowed().await?;
+        let data_evolution_read_field_ids = self.auth_widened_read_field_ids(grant.as_deref());
+        let plan = self
+            .plan_snapshot_manifest_list(
+                snapshot,
+                snapshot.delta_manifest_list(),
+                data_evolution_read_field_ids.as_ref(),
+                grant.as_deref().is_some_and(|g| g.has_row_filter()),
+            )
+            .await?;
+        Ok(self.finalize_plan(plan, grant.as_ref()))
     }
 
     /// Plan data splits from a snapshot's changelog manifest list.
@@ -1541,17 +1647,20 @@ impl<'a> PaimonTableScan<'a> {
     /// reads the changelog manifest list and keeps ADD entries. Snapshots
     /// without a changelog list yield an empty plan.
     pub(crate) async fn plan_snapshot_changelog(&self, snapshot: &Snapshot) -> crate::Result<Plan> {
-        self.ensure_query_auth_allowed()?;
+        let grant = self.ensure_query_auth_allowed().await?;
         let Some(list_name) = snapshot.changelog_manifest_list() else {
-            return Ok(Plan::new(Vec::new()));
+            return Ok(self.finalize_plan(Plan::new(Vec::new()), grant.as_ref()));
         };
-        let data_evolution_read_field_ids = self.projected_read_field_ids()?;
-        self.plan_snapshot_manifest_list(
-            snapshot,
-            list_name,
-            data_evolution_read_field_ids.as_ref(),
-        )
-        .await
+        let data_evolution_read_field_ids = self.auth_widened_read_field_ids(grant.as_deref());
+        let plan = self
+            .plan_snapshot_manifest_list(
+                snapshot,
+                list_name,
+                data_evolution_read_field_ids.as_ref(),
+                grant.as_deref().is_some_and(|g| g.has_row_filter()),
+            )
+            .await?;
+        Ok(self.finalize_plan(plan, grant.as_ref()))
     }
 
     async fn plan_snapshot_manifest_list(
@@ -1559,6 +1668,7 @@ impl<'a> PaimonTableScan<'a> {
         snapshot: &Snapshot,
         manifest_list_name: &str,
         data_evolution_read_field_ids: Option<&HashSet<i32>>,
+        query_auth_row_filter: bool,
     ) -> crate::Result<Plan> {
         if matches!(self.limit, Some(0)) {
             return Ok(Plan::new(Vec::new()));
@@ -1604,6 +1714,7 @@ impl<'a> PaimonTableScan<'a> {
             index_entries,
             effective_row_ranges,
             None,
+            query_auth_row_filter,
         )
         .await
     }
@@ -1619,7 +1730,8 @@ impl<'a> PaimonTableScan<'a> {
         before: &Snapshot,
         after: &Snapshot,
     ) -> crate::Result<(Plan, Plan)> {
-        self.ensure_query_auth_allowed()?;
+        let grant = self.ensure_query_auth_allowed().await?;
+        let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
         let core_options = CoreOptions::new(self.table.schema().options());
         if core_options.deletion_vectors_enabled() {
             return Err(crate::Error::Unsupported {
@@ -1647,12 +1759,34 @@ impl<'a> PaimonTableScan<'a> {
         let before_entries = full_state_scan.plan_manifest_entries(before).await?;
         let after_entries = full_state_scan.plan_manifest_entries(after).await?;
         let before_plan = full_state_scan
-            .plan_snapshot_from_entries(before.clone(), before_entries, None, None, None, None)
+            .plan_snapshot_from_entries(
+                before.clone(),
+                before_entries,
+                None,
+                None,
+                None,
+                None,
+                has_row_filter,
+            )
             .await?;
         let after_plan = full_state_scan
-            .plan_snapshot_from_entries(after.clone(), after_entries, None, None, None, None)
+            .plan_snapshot_from_entries(
+                after.clone(),
+                after_entries,
+                None,
+                None,
+                None,
+                None,
+                has_row_filter,
+            )
             .await?;
-        Ok((before_plan, after_plan))
+        // Both sides must carry the grant: the diff pairs them into
+        // `IncrementalSplit::DiffPair`, and the read gate authorizes off the
+        // splits it is handed.
+        Ok((
+            self.finalize_plan(before_plan, grant.as_ref()),
+            self.finalize_plan(after_plan, grant.as_ref()),
+        ))
     }
 
     async fn validate_diff_bucket_layout(
@@ -1799,6 +1933,7 @@ impl<'a> PaimonTableScan<'a> {
         snapshot: Snapshot,
         data_evolution_read_field_ids: Option<&HashSet<i32>>,
         mut trace: Option<&mut ScanTrace>,
+        query_auth_row_filter: bool,
     ) -> crate::Result<Plan> {
         if matches!(self.limit, Some(0)) {
             if let Some(trace) = trace {
@@ -1854,10 +1989,12 @@ impl<'a> PaimonTableScan<'a> {
             index_entries,
             effective_row_ranges,
             trace,
+            query_auth_row_filter,
         )
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn plan_snapshot_from_entries(
         &self,
         snapshot: Snapshot,
@@ -1866,6 +2003,7 @@ impl<'a> PaimonTableScan<'a> {
         index_entries: Option<Vec<IndexManifestEntry>>,
         effective_row_ranges: Option<Vec<RowRange>>,
         mut trace: Option<&mut ScanTrace>,
+        query_auth_row_filter: bool,
     ) -> crate::Result<Plan> {
         let table_path = self.table.location();
         let table_schema_id = self.table.schema().id();
@@ -1993,7 +2131,8 @@ impl<'a> PaimonTableScan<'a> {
             .map(|entries| build_deletion_files_map(entries, base_path));
 
         let mut data_file_field_ids_cache = DataFileFieldIdsCache::new();
-        let can_push_down_limit = self.can_push_down_limit_hint(effective_row_ranges.as_deref());
+        let can_push_down_limit =
+            self.can_push_down_limit_hint(effective_row_ranges.as_deref(), query_auth_row_filter);
         let mut limit_accumulator = match self.limit {
             Some(limit) if limit > 0 && can_push_down_limit => {
                 Some(LimitPushdownAccumulator::new(limit))

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -1032,14 +1032,19 @@ impl<'a> TableScan<'a> {
         self,
         filter_columns: HashSet<usize>,
         projected: Option<Vec<usize>>,
+        system_select: Vec<String>,
     ) -> Self {
         match self.0 {
-            TableScanKind::Paimon(scan) => Self(TableScanKind::Paimon(
-                scan.with_query_auth_scope(filter_columns, projected),
-            )),
-            TableScanKind::Format(scan) => Self(TableScanKind::Format(
-                scan.with_query_auth_scope(filter_columns, projected),
-            )),
+            TableScanKind::Paimon(scan) => Self(TableScanKind::Paimon(scan.with_query_auth_scope(
+                filter_columns,
+                projected,
+                system_select,
+            ))),
+            TableScanKind::Format(scan) => Self(TableScanKind::Format(scan.with_query_auth_scope(
+                filter_columns,
+                projected,
+                system_select,
+            ))),
         }
     }
 
@@ -1137,6 +1142,8 @@ struct PaimonTableScan<'a> {
     /// against the live grant at plan time (see `ensure_query_auth_allowed`).
     query_auth_filter_columns: HashSet<usize>,
     query_auth_projected: Option<Vec<usize>>,
+    /// Sent in `select`, but has no index to scope.
+    query_auth_system_select: Vec<String>,
 }
 
 impl<'a> PaimonTableScan<'a> {
@@ -1160,6 +1167,7 @@ impl<'a> PaimonTableScan<'a> {
             projected_read_field_ids: None,
             query_auth_filter_columns: HashSet::new(),
             query_auth_projected: None,
+            query_auth_system_select: Vec::new(),
         }
     }
 
@@ -1204,9 +1212,11 @@ impl<'a> PaimonTableScan<'a> {
         mut self,
         filter_columns: HashSet<usize>,
         projected: Option<Vec<usize>>,
+        system_select: Vec<String>,
     ) -> Self {
         self.query_auth_filter_columns = filter_columns;
         self.query_auth_projected = projected;
+        self.query_auth_system_select = system_select;
         self
     }
 
@@ -1307,7 +1317,7 @@ impl<'a> PaimonTableScan<'a> {
         });
         let grant = self
             .table
-            .verify_query_auth_for_read(select.as_ref())
+            .verify_query_auth_for_read(select.as_ref(), &self.query_auth_system_select)
             .await?;
         if let Some(grant) = &grant {
             crate::table::query_auth::scope_check(

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -937,14 +937,19 @@ impl<'a> TableScan<'a> {
         self,
         filter_columns: HashSet<usize>,
         projected: Option<Vec<usize>>,
+        system_select: Vec<String>,
     ) -> Self {
         match self.0 {
-            TableScanKind::Paimon(scan) => Self(TableScanKind::Paimon(
-                scan.with_query_auth_scope(filter_columns, projected),
-            )),
-            TableScanKind::Format(scan) => Self(TableScanKind::Format(
-                scan.with_query_auth_scope(filter_columns, projected),
-            )),
+            TableScanKind::Paimon(scan) => Self(TableScanKind::Paimon(scan.with_query_auth_scope(
+                filter_columns,
+                projected,
+                system_select,
+            ))),
+            TableScanKind::Format(scan) => Self(TableScanKind::Format(scan.with_query_auth_scope(
+                filter_columns,
+                projected,
+                system_select,
+            ))),
         }
     }
 
@@ -1042,6 +1047,8 @@ struct PaimonTableScan<'a> {
     /// against the live grant at plan time (see `ensure_query_auth_allowed`).
     query_auth_filter_columns: HashSet<usize>,
     query_auth_projected: Option<Vec<usize>>,
+    /// Sent in `select`, but has no index to scope.
+    query_auth_system_select: Vec<String>,
 }
 
 impl<'a> PaimonTableScan<'a> {
@@ -1065,6 +1072,7 @@ impl<'a> PaimonTableScan<'a> {
             projected_read_field_ids: None,
             query_auth_filter_columns: HashSet::new(),
             query_auth_projected: None,
+            query_auth_system_select: Vec::new(),
         }
     }
 
@@ -1105,9 +1113,11 @@ impl<'a> PaimonTableScan<'a> {
         mut self,
         filter_columns: HashSet<usize>,
         projected: Option<Vec<usize>>,
+        system_select: Vec<String>,
     ) -> Self {
         self.query_auth_filter_columns = filter_columns;
         self.query_auth_projected = projected;
+        self.query_auth_system_select = system_select;
         self
     }
 
@@ -1211,7 +1221,7 @@ impl<'a> PaimonTableScan<'a> {
         });
         let grant = self
             .table
-            .verify_query_auth_for_read(select.as_ref())
+            .verify_query_auth_for_read(select.as_ref(), &self.query_auth_system_select)
             .await?;
         if let Some(grant) = &grant {
             crate::table::query_auth::scope_check(

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -45,6 +45,7 @@ use crate::table::index_file_path::IndexFileLocation;
 use crate::table::merge_tree_split_generator::{
     merge_tree_split_for_batch, KeyComparator, SplitGroup,
 };
+use crate::table::query_auth::QueryAuthGrant;
 use crate::table::schema_manager::SchemaManager;
 use crate::table::source::{
     any_range_overlaps_file, intersect_ranges_with_file, merge_row_ranges, DataSplit,
@@ -932,6 +933,21 @@ impl<'a> TableScan<'a> {
         }
     }
 
+    pub(super) fn with_query_auth_scope(
+        self,
+        filter_columns: HashSet<usize>,
+        projected: Option<Vec<usize>>,
+    ) -> Self {
+        match self.0 {
+            TableScanKind::Paimon(scan) => Self(TableScanKind::Paimon(
+                scan.with_query_auth_scope(filter_columns, projected),
+            )),
+            TableScanKind::Format(scan) => Self(TableScanKind::Format(
+                scan.with_query_auth_scope(filter_columns, projected),
+            )),
+        }
+    }
+
     pub async fn plan(&self) -> crate::Result<Plan> {
         match &self.0 {
             TableScanKind::Paimon(scan) => scan.plan().await,
@@ -996,7 +1012,7 @@ impl<'a> TableScan<'a> {
     fn apply_limit_pushdown(&self, splits: Vec<DataSplit>) -> Vec<DataSplit> {
         match &self.0 {
             TableScanKind::Paimon(scan) => scan.apply_limit_pushdown(splits),
-            TableScanKind::Format(scan) => scan.apply_limit_pushdown(splits),
+            TableScanKind::Format(scan) => scan.apply_limit_pushdown(splits, false),
         }
     }
 }
@@ -1022,6 +1038,10 @@ struct PaimonTableScan<'a> {
     /// the complete file set. Normal read scans leave this as `false`.
     scan_all_files: bool,
     projected_read_field_ids: Option<HashSet<i32>>,
+    /// Filter/projection columns for the query-auth scope check, evaluated
+    /// against the live grant at plan time (see `ensure_query_auth_allowed`).
+    query_auth_filter_columns: HashSet<usize>,
+    query_auth_projected: Option<Vec<usize>>,
 }
 
 impl<'a> PaimonTableScan<'a> {
@@ -1043,6 +1063,8 @@ impl<'a> PaimonTableScan<'a> {
             row_range_optimization_disabled: false,
             scan_all_files: false,
             projected_read_field_ids: None,
+            query_auth_filter_columns: HashSet::new(),
+            query_auth_projected: None,
         }
     }
 
@@ -1079,6 +1101,16 @@ impl<'a> PaimonTableScan<'a> {
         self
     }
 
+    pub(super) fn with_query_auth_scope(
+        mut self,
+        filter_columns: HashSet<usize>,
+        projected: Option<Vec<usize>>,
+    ) -> Self {
+        self.query_auth_filter_columns = filter_columns;
+        self.query_auth_projected = projected;
+        self
+    }
+
     /// Plan the full scan: resolve snapshot (via options or latest), then read manifests and build DataSplits.
     ///
     /// Time travel is resolved from table options:
@@ -1097,27 +1129,40 @@ impl<'a> PaimonTableScan<'a> {
     /// for `scan.version`; the strict selectors mirror Java's typed
     /// `scan.snapshot-id` / `scan.tag-name` handling.
     pub async fn plan(&self) -> crate::Result<Plan> {
-        self.ensure_query_auth_allowed()?;
-        let data_evolution_read_field_ids = self.projected_read_field_ids()?;
+        let grant = self.ensure_query_auth_allowed().await?;
+        let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
+        let data_evolution_read_field_ids = self.auth_widened_read_field_ids(grant.as_deref());
         let snapshot = match super::time_travel::resolve_snapshot(self.table).await? {
             Some(snapshot) => snapshot,
-            None => return Ok(Plan::new(Vec::new())),
+            None => return Ok(self.finalize_plan(Plan::new(Vec::new()), grant.as_ref())),
         };
-        self.plan_snapshot(snapshot, data_evolution_read_field_ids.as_ref(), None)
-            .await
+        self.plan_snapshot(
+            snapshot,
+            data_evolution_read_field_ids.as_ref(),
+            None,
+            has_row_filter,
+        )
+        .await
+        .map(|plan| self.finalize_plan(plan, grant.as_ref()))
     }
 
     /// Plan the full scan and return metadata-pruning trace counters.
     pub async fn plan_with_trace(&self) -> crate::Result<(Plan, ScanTrace)> {
-        self.ensure_query_auth_allowed()?;
+        let grant = self.ensure_query_auth_allowed().await?;
+        let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
         let mut trace = ScanTrace {
             limit: self.limit,
             ..Default::default()
         };
-        let data_evolution_read_field_ids = self.projected_read_field_ids()?;
+        let data_evolution_read_field_ids = self.auth_widened_read_field_ids(grant.as_deref());
         let snapshot = match super::time_travel::resolve_snapshot(self.table).await? {
             Some(snapshot) => snapshot,
-            None => return Ok((Plan::new(Vec::new()), trace)),
+            None => {
+                return Ok((
+                    self.finalize_plan(Plan::new(Vec::new()), grant.as_ref()),
+                    trace,
+                ))
+            }
         };
         trace.snapshot_id = Some(snapshot.id());
         let plan = self
@@ -1125,21 +1170,71 @@ impl<'a> PaimonTableScan<'a> {
                 snapshot,
                 data_evolution_read_field_ids.as_ref(),
                 Some(&mut trace),
+                has_row_filter,
             )
             .await?;
         trace.planned_data_file_bytes = plan.planned_data_file_bytes();
-        Ok((plan, trace))
+        Ok((self.finalize_plan(plan, grant.as_ref()), trace))
+    }
+
+    /// Stamp the grant onto every split (so `TableRead::to_arrow` enforces
+    /// exactly this plan's grant) and mark row counts inexact when it carries a
+    /// row filter (dropped as a residual pass inside `TableRead`).
+    fn finalize_plan(&self, plan: Plan, grant: Option<&Arc<QueryAuthGrant>>) -> Plan {
+        // Any restricted grant invalidates the plan's statistics: a row filter
+        // drops rows, and masking rewrites column values (a NULL mask makes the
+        // column entirely null), so a statistics-only `COUNT` would report raw
+        // counts and bypass enforcement.
+        let restricted = grant.is_some_and(|g| g.has_server_restrictions());
+        let plan = plan.stamp_query_auth_grant(grant.cloned());
+        if restricted {
+            plan.with_inexact_row_counts()
+        } else {
+            plan
+        }
     }
 
     /// Fail closed for a `query-auth.enabled` table: scan planning — including
     /// `with_scan_all_files`, which read-facing system tables like `files` use —
     /// exposes file paths, row counts, and stats the client can't authorize.
-    fn ensure_query_auth_allowed(&self) -> crate::Result<()> {
-        CoreOptions::new(self.table.schema().options()).ensure_read_authorized()
+    /// Returns the fetched grant (`None` = not a query-auth table) so the caller
+    /// can widen the projection and stamp the splits with it.
+    async fn ensure_query_auth_allowed(&self) -> crate::Result<Option<Arc<QueryAuthGrant>>> {
+        // Fetch/refresh the grant at plan time (Java parity), then guard
+        // against pruning on masked or out-of-scope columns.
+        let select = self.query_auth_projected.as_ref().map(|projected| {
+            projected
+                .iter()
+                .copied()
+                .chain(self.query_auth_filter_columns.iter().copied())
+                .collect::<std::collections::HashSet<usize>>()
+        });
+        let grant = self
+            .table
+            .verify_query_auth_for_read(select.as_ref())
+            .await?;
+        if let Some(grant) = &grant {
+            crate::table::query_auth::scope_check(
+                grant,
+                self.table.schema().fields(),
+                &self.query_auth_filter_columns,
+                self.query_auth_projected.clone(),
+            )?;
+        }
+        Ok(grant)
     }
 
-    fn projected_read_field_ids(&self) -> crate::Result<Option<HashSet<i32>>> {
-        Ok(self.projected_read_field_ids.clone())
+    /// The projected field ids for data-evolution column-slice pruning, widened
+    /// with the grant's row-filter / mask-input columns so pruning cannot drop a
+    /// file holding a column the grant needs (an omitted column would read as
+    /// null and wrongly satisfy `IS_NULL`). Computed here — with the grant in
+    /// hand — rather than at `new_scan` time, where the grant does not yet exist.
+    fn auth_widened_read_field_ids(&self, grant: Option<&QueryAuthGrant>) -> Option<HashSet<i32>> {
+        let mut ids = self.projected_read_field_ids.clone();
+        if let (Some(set), Some(grant)) = (ids.as_mut(), grant) {
+            set.extend(grant.read_field_ids(self.table.schema().fields()));
+        }
+        ids
     }
 
     /// Apply a limit-pushdown hint to the generated splits.
@@ -1270,8 +1365,16 @@ impl<'a> PaimonTableScan<'a> {
         Ok(entries)
     }
 
-    fn can_push_down_limit_hint(&self, row_ranges: Option<&[RowRange]>) -> bool {
+    fn can_push_down_limit_hint(
+        &self,
+        row_ranges: Option<&[RowRange]>,
+        query_auth_row_filter: bool,
+    ) -> bool {
+        // A query-auth row filter is applied as a residual pass at read time, so
+        // split merged_row_count overcounts; count-based limit pruning would drop
+        // splits holding later authorized rows.
         can_push_down_limit_hint_for_scan(&self.data_predicates, row_ranges)
+            && !query_auth_row_filter
     }
 
     fn global_index_scan_settings(
@@ -1468,14 +1571,17 @@ impl<'a> PaimonTableScan<'a> {
     /// Reuses the same split-building path as a full snapshot plan, but only
     /// reads the delta manifest list and keeps ADD entries.
     pub(crate) async fn plan_snapshot_delta(&self, snapshot: &Snapshot) -> crate::Result<Plan> {
-        self.ensure_query_auth_allowed()?;
-        let data_evolution_read_field_ids = self.projected_read_field_ids()?;
-        self.plan_snapshot_manifest_list(
-            snapshot,
-            snapshot.delta_manifest_list(),
-            data_evolution_read_field_ids.as_ref(),
-        )
-        .await
+        let grant = self.ensure_query_auth_allowed().await?;
+        let data_evolution_read_field_ids = self.auth_widened_read_field_ids(grant.as_deref());
+        let plan = self
+            .plan_snapshot_manifest_list(
+                snapshot,
+                snapshot.delta_manifest_list(),
+                data_evolution_read_field_ids.as_ref(),
+                grant.as_deref().is_some_and(|g| g.has_row_filter()),
+            )
+            .await?;
+        Ok(self.finalize_plan(plan, grant.as_ref()))
     }
 
     /// Plan data splits from a snapshot's changelog manifest list.
@@ -1484,17 +1590,20 @@ impl<'a> PaimonTableScan<'a> {
     /// reads the changelog manifest list and keeps ADD entries. Snapshots
     /// without a changelog list yield an empty plan.
     pub(crate) async fn plan_snapshot_changelog(&self, snapshot: &Snapshot) -> crate::Result<Plan> {
-        self.ensure_query_auth_allowed()?;
+        let grant = self.ensure_query_auth_allowed().await?;
         let Some(list_name) = snapshot.changelog_manifest_list() else {
-            return Ok(Plan::new(Vec::new()));
+            return Ok(self.finalize_plan(Plan::new(Vec::new()), grant.as_ref()));
         };
-        let data_evolution_read_field_ids = self.projected_read_field_ids()?;
-        self.plan_snapshot_manifest_list(
-            snapshot,
-            list_name,
-            data_evolution_read_field_ids.as_ref(),
-        )
-        .await
+        let data_evolution_read_field_ids = self.auth_widened_read_field_ids(grant.as_deref());
+        let plan = self
+            .plan_snapshot_manifest_list(
+                snapshot,
+                list_name,
+                data_evolution_read_field_ids.as_ref(),
+                grant.as_deref().is_some_and(|g| g.has_row_filter()),
+            )
+            .await?;
+        Ok(self.finalize_plan(plan, grant.as_ref()))
     }
 
     async fn plan_snapshot_manifest_list(
@@ -1502,6 +1611,7 @@ impl<'a> PaimonTableScan<'a> {
         snapshot: &Snapshot,
         manifest_list_name: &str,
         data_evolution_read_field_ids: Option<&HashSet<i32>>,
+        query_auth_row_filter: bool,
     ) -> crate::Result<Plan> {
         if matches!(self.limit, Some(0)) {
             return Ok(Plan::new(Vec::new()));
@@ -1547,6 +1657,7 @@ impl<'a> PaimonTableScan<'a> {
             index_entries,
             effective_row_ranges,
             None,
+            query_auth_row_filter,
         )
         .await
     }
@@ -1562,7 +1673,8 @@ impl<'a> PaimonTableScan<'a> {
         before: &Snapshot,
         after: &Snapshot,
     ) -> crate::Result<(Plan, Plan)> {
-        self.ensure_query_auth_allowed()?;
+        let grant = self.ensure_query_auth_allowed().await?;
+        let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
         let core_options = CoreOptions::new(self.table.schema().options());
         if core_options.deletion_vectors_enabled() {
             return Err(crate::Error::Unsupported {
@@ -1596,12 +1708,34 @@ impl<'a> PaimonTableScan<'a> {
         let before_entries = full_state_scan.plan_manifest_entries(before).await?;
         let after_entries = full_state_scan.plan_manifest_entries(after).await?;
         let before_plan = full_state_scan
-            .plan_snapshot_from_entries(before.clone(), before_entries, None, None, None, None)
+            .plan_snapshot_from_entries(
+                before.clone(),
+                before_entries,
+                None,
+                None,
+                None,
+                None,
+                has_row_filter,
+            )
             .await?;
         let after_plan = full_state_scan
-            .plan_snapshot_from_entries(after.clone(), after_entries, None, None, None, None)
+            .plan_snapshot_from_entries(
+                after.clone(),
+                after_entries,
+                None,
+                None,
+                None,
+                None,
+                has_row_filter,
+            )
             .await?;
-        Ok((before_plan, after_plan))
+        // Both sides must carry the grant: the diff pairs them into
+        // `IncrementalSplit::DiffPair`, and the read gate authorizes off the
+        // splits it is handed.
+        Ok((
+            self.finalize_plan(before_plan, grant.as_ref()),
+            self.finalize_plan(after_plan, grant.as_ref()),
+        ))
     }
 
     async fn validate_diff_bucket_layout(
@@ -1748,6 +1882,7 @@ impl<'a> PaimonTableScan<'a> {
         snapshot: Snapshot,
         data_evolution_read_field_ids: Option<&HashSet<i32>>,
         mut trace: Option<&mut ScanTrace>,
+        query_auth_row_filter: bool,
     ) -> crate::Result<Plan> {
         if matches!(self.limit, Some(0)) {
             if let Some(trace) = trace {
@@ -1803,10 +1938,12 @@ impl<'a> PaimonTableScan<'a> {
             index_entries,
             effective_row_ranges,
             trace,
+            query_auth_row_filter,
         )
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn plan_snapshot_from_entries(
         &self,
         snapshot: Snapshot,
@@ -1815,6 +1952,7 @@ impl<'a> PaimonTableScan<'a> {
         index_entries: Option<Vec<IndexManifestEntry>>,
         effective_row_ranges: Option<Vec<RowRange>>,
         mut trace: Option<&mut ScanTrace>,
+        query_auth_row_filter: bool,
     ) -> crate::Result<Plan> {
         let table_path = self.table.location();
         let table_schema_id = self.table.schema().id();
@@ -1942,7 +2080,8 @@ impl<'a> PaimonTableScan<'a> {
             .index_file_in_data_file_dir();
 
         let mut data_file_field_ids_cache = DataFileFieldIdsCache::new();
-        let can_push_down_limit = self.can_push_down_limit_hint(effective_row_ranges.as_deref());
+        let can_push_down_limit =
+            self.can_push_down_limit_hint(effective_row_ranges.as_deref(), query_auth_row_filter);
         let mut limit_accumulator = match self.limit {
             Some(limit) if limit > 0 && can_push_down_limit => {
                 Some(LimitPushdownAccumulator::new(limit))

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -1090,7 +1090,19 @@ impl<'a> PaimonTableScan<'a> {
     ///
     /// This replaces any existing row_ranges. Typically used to inject
     /// results from global index lookups. An empty vector selects no rows.
+    ///
+    /// Slicing by physical row id selects rows by `_ROW_ID` with no predicate,
+    /// so it must reach the auth request even when set after `new_scan` fixed
+    /// the scope (`ReadBuilder::with_row_ranges` does the same on its side).
     pub fn with_row_ranges(mut self, ranges: Vec<RowRange>) -> Self {
+        let row_id = crate::spec::ROW_ID_FIELD_NAME.to_string();
+        // Only while ranges actually apply: clearing them must not leave a
+        // stale system-column request that could get an otherwise valid read
+        // rejected.
+        self.query_auth_system_select.retain(|n| n != &row_id);
+        if !ranges.is_empty() {
+            self.query_auth_system_select.push(row_id);
+        }
         self.row_ranges = Some(ranges);
         self
     }
@@ -1138,6 +1150,31 @@ impl<'a> PaimonTableScan<'a> {
     /// Reference: [TimeTravelUtil.tryTravelToSnapshot](https://github.com/apache/paimon/blob/master/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/TimeTravelUtil.java)
     /// for `scan.version`; the strict selectors mirror Java's typed
     /// `scan.snapshot-id` / `scan.tag-name` handling.
+    /// Fail closed when the snapshot the plan will read was written under a
+    /// different schema than the grant was parsed against: the grant is fetched
+    /// first, so a schema-changing commit in between would bind the rules to
+    /// this copy's schema while the plan consumes the new one.
+    fn ensure_grant_matches_snapshot(
+        &self,
+        grant: Option<&Arc<QueryAuthGrant>>,
+        snapshot: &Snapshot,
+    ) -> crate::Result<()> {
+        let Some(grant) = grant else {
+            return Ok(());
+        };
+        // Only a NEWER snapshot is a problem: a schema-only ALTER leaves the
+        // table schema routinely ahead of the latest data snapshot, and the
+        // reader evolves those older files by field id.
+        if !grant.has_server_restrictions() || snapshot.schema_id() <= self.table.schema().id() {
+            return Ok(());
+        }
+        Err(crate::Error::Unsupported {
+            message: "the snapshot being planned was written under a newer schema than the \
+                      query-auth grant was issued for; re-plan the scan"
+                .to_string(),
+        })
+    }
+
     pub async fn plan(&self) -> crate::Result<Plan> {
         let grant = self.ensure_query_auth_allowed().await?;
         let has_row_filter = grant.as_deref().is_some_and(|g| g.has_row_filter());
@@ -1146,6 +1183,7 @@ impl<'a> PaimonTableScan<'a> {
             Some(snapshot) => snapshot,
             None => return Ok(self.finalize_plan(Plan::new(Vec::new()), grant.as_ref())),
         };
+        self.ensure_grant_matches_snapshot(grant.as_ref(), &snapshot)?;
         self.plan_snapshot(
             snapshot,
             data_evolution_read_field_ids.as_ref(),
@@ -1174,6 +1212,7 @@ impl<'a> PaimonTableScan<'a> {
                 ))
             }
         };
+        self.ensure_grant_matches_snapshot(grant.as_ref(), &snapshot)?;
         trace.snapshot_id = Some(snapshot.id());
         let plan = self
             .plan_snapshot(
@@ -1191,10 +1230,9 @@ impl<'a> PaimonTableScan<'a> {
     /// exactly this plan's grant) and mark row counts inexact when it carries a
     /// row filter (dropped as a residual pass inside `TableRead`).
     fn finalize_plan(&self, plan: Plan, grant: Option<&Arc<QueryAuthGrant>>) -> Plan {
-        // Any restricted grant invalidates the plan's statistics: a row filter
-        // drops rows, and masking rewrites column values (a NULL mask makes the
-        // column entirely null), so a statistics-only `COUNT` would report raw
-        // counts and bypass enforcement.
+        // A row filter drops rows and masking rewrites values, so a
+        // statistics-only `COUNT` would report raw counts and bypass
+        // enforcement.
         let restricted = grant.is_some_and(|g| g.has_server_restrictions());
         let plan = plan.stamp_query_auth_grant(grant.cloned());
         if restricted {
@@ -1221,9 +1259,21 @@ impl<'a> PaimonTableScan<'a> {
         });
         let grant = self
             .table
-            .verify_query_auth_for_read(select.as_ref(), &self.query_auth_system_select)
+            .verify_query_auth_for_read(select.as_ref(), Some(&self.query_auth_system_select))
             .await?;
         if let Some(grant) = &grant {
+            // `scan_all_files` returns the un-merged files a normal PK scan
+            // hides, whose paths and statistics precede the filtering that only
+            // runs in `TableRead`. A pure column scope distorts none of that and
+            // stays allowed (the cross-partition bucket assigner needs it).
+            if self.scan_all_files && grant.has_server_restrictions() {
+                return Err(crate::Error::Unsupported {
+                    message: "a query-auth row filter / column masking grant cannot be applied \
+                              to a scan-all-files plan: it returns raw physical files whose \
+                              paths and statistics precede enforcement"
+                        .to_string(),
+                });
+            }
             crate::table::query_auth::scope_check(
                 grant,
                 self.table.schema().fields(),
@@ -1234,11 +1284,10 @@ impl<'a> PaimonTableScan<'a> {
         Ok(grant)
     }
 
-    /// The projected field ids for data-evolution column-slice pruning, widened
-    /// with the grant's row-filter / mask-input columns so pruning cannot drop a
-    /// file holding a column the grant needs (an omitted column would read as
-    /// null and wrongly satisfy `IS_NULL`). Computed here — with the grant in
-    /// hand — rather than at `new_scan` time, where the grant does not yet exist.
+    /// Projected field ids for data-evolution column-slice pruning, widened with
+    /// the grant's filter / mask-input columns so pruning cannot drop a file
+    /// holding one (an omitted column reads as null and wrongly satisfies
+    /// `IS_NULL`). Needs the grant, so it cannot happen at `new_scan` time.
     fn auth_widened_read_field_ids(&self, grant: Option<&QueryAuthGrant>) -> Option<HashSet<i32>> {
         let mut ids = self.projected_read_field_ids.clone();
         if let (Some(set), Some(grant)) = (ids.as_mut(), grant) {

--- a/crates/paimon/src/table/vector_search_builder.rs
+++ b/crates/paimon/src/table/vector_search_builder.rs
@@ -1057,12 +1057,9 @@ impl<'a> BatchVectorSearchBuilder<'a> {
     }
 
     pub async fn execute(&self) -> crate::Result<Vec<SearchResult>> {
-        // Strict, like the scored path: batch vector search reads index files
-        // raw and returns top-k membership/ordering/scores over masked or
-        // filter-hidden rows — a ranking oracle it cannot enforce the row filter
-        // on, so only a fully unrestricted grant may run it. Checked before any
-        // validation or fast path (an empty snapshot would otherwise return
-        // empty results and bypass it); also covers the DataFusion lateral path.
+        // Batch vector search reads index files raw and ranks over masked or
+        // hidden rows — an oracle it cannot enforce the filter on. Checked
+        // before any fast path, or an empty snapshot would bypass it.
         self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
         let vector_column =
@@ -3540,11 +3537,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_batch_execute_fails_closed_when_query_auth_enabled() {
-        // The batch builder reads index files raw (never through plan/to_arrow),
-        // so it must gate query-auth itself — a top-k ranking oracle over
-        // masked/filter-hidden rows otherwise. The config here is valid, so
-        // without the guard the empty-snapshot fast path would return empty
-        // results and silently bypass authorization.
+        // The batch builder reads index files raw, never through
+        // `plan`/`to_arrow`, so it gates query-auth itself. The config is valid,
+        // so without the guard the empty-snapshot path would bypass it.
         let table = crate::table::query_auth_table();
         let err = table
             .new_batch_vector_search_builder()

--- a/crates/paimon/src/table/vector_search_builder.rs
+++ b/crates/paimon/src/table/vector_search_builder.rs
@@ -200,8 +200,10 @@ impl<'a> VectorSearchBuilder<'a> {
 
     pub async fn execute_scored(&self) -> crate::Result<SearchResult> {
         // Fail closed: returns data-derived row ranges outside `TableScan`/`TableRead`.
+        // Strict: search results bypass the query-auth row filter, so only a
+        // fully unrestricted grant may search.
+        self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
-        core.ensure_read_authorized()?;
         let vector_column =
             self.vector_column
                 .as_deref()
@@ -275,9 +277,11 @@ impl<'a> VectorSearchBuilder<'a> {
     /// [`with_projection`](Self::with_projection)) plus `__paimon_search_score`;
     /// `_ROW_ID` and `_PKEY_VECTOR_POSITION` are always hidden.
     pub async fn execute_read(&self) -> crate::Result<ArrowRecordBatchStream> {
-        // Fail closed: returns data outside `TableScan`/`TableRead`.
+        // Fail closed: materializes rows outside `TableScan`/`TableRead`, so it
+        // cannot apply the row filter / masking — only a fully unrestricted
+        // grant may run it (same gate as the scored entry points).
+        self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
-        core.ensure_read_authorized()?;
         let vector_column =
             self.vector_column
                 .as_deref()
@@ -1053,12 +1057,14 @@ impl<'a> BatchVectorSearchBuilder<'a> {
     }
 
     pub async fn execute(&self) -> crate::Result<Vec<SearchResult>> {
-        // Fail closed: like `execute_read` and the single-query builder, this
-        // returns data-derived row ids/scores outside `TableScan`/`TableRead`,
-        // so it must refuse a `query-auth.enabled` table before any fast path
-        // (an empty snapshot would otherwise return empty results and bypass it).
+        // Strict, like the scored path: batch vector search reads index files
+        // raw and returns top-k membership/ordering/scores over masked or
+        // filter-hidden rows — a ranking oracle it cannot enforce the row filter
+        // on, so only a fully unrestricted grant may run it. Checked before any
+        // validation or fast path (an empty snapshot would otherwise return
+        // empty results and bypass it); also covers the DataFusion lateral path.
+        self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
-        core.ensure_read_authorized()?;
         let vector_column =
             self.vector_column
                 .as_deref()
@@ -1172,9 +1178,11 @@ impl<'a> BatchVectorSearchBuilder<'a> {
     /// scored global row-ids, not materialized rows, so callers use
     /// [`execute`](Self::execute) instead.
     pub async fn execute_read(&self) -> crate::Result<Vec<ArrowRecordBatchStream>> {
-        // Fail closed: returns data outside `TableScan`/`TableRead`.
+        // Fail closed: materializes rows outside `TableScan`/`TableRead`, so it
+        // cannot apply the row filter / masking — only a fully unrestricted
+        // grant may run it (same gate as the scored entry points).
+        self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
-        core.ensure_read_authorized()?;
         let vector_column =
             self.vector_column
                 .as_deref()
@@ -3532,11 +3540,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_batch_execute_fails_closed_when_query_auth_enabled() {
-        // The batch scored entry returns data-derived row ids/scores outside
-        // `TableScan`/`TableRead`, so it must fail closed under
-        // `query-auth.enabled` exactly like the single-query builder. Its config
-        // is otherwise valid, so without the guard the empty-snapshot fast path
-        // would return empty results and silently bypass authorization.
+        // The batch builder reads index files raw (never through plan/to_arrow),
+        // so it must gate query-auth itself — a top-k ranking oracle over
+        // masked/filter-hidden rows otherwise. The config here is valid, so
+        // without the guard the empty-snapshot fast path would return empty
+        // results and silently bypass authorization.
         let table = crate::table::query_auth_table();
         let err = table
             .new_batch_vector_search_builder()

--- a/crates/paimon/src/table/vector_search_builder.rs
+++ b/crates/paimon/src/table/vector_search_builder.rs
@@ -1551,7 +1551,7 @@ impl<'a> BatchVectorSearchBuilder<'a> {
         let total_start = timing_enabled.then(Instant::now);
         // The builder target is authoritative for current auth/type policy.
         // A prepared filter only pins a snapshot and may carry older options.
-        CoreOptions::new(self.table.schema().options()).ensure_read_authorized()?;
+        self.table.authorize_unrestricted_read().await?;
         if let Some(prepared) = &self.prepared_filter {
             if !same_vector_search_table(self.table, prepared.table()) {
                 return Err(crate::Error::DataInvalid {
@@ -1566,7 +1566,7 @@ impl<'a> BatchVectorSearchBuilder<'a> {
                 });
             }
         }
-        // Strict, like the scored path: batch vector search reads index files
+        // Strict: batch vector search reads index files raw and ranks over
         // raw and returns top-k membership/ordering/scores over masked or
         // filter-hidden rows — a ranking oracle it cannot enforce the row filter
         // on, so only a fully unrestricted grant may run it. The pinned
@@ -1578,8 +1578,8 @@ impl<'a> BatchVectorSearchBuilder<'a> {
             .as_ref()
             .map(PreparedVectorSearchFilter::table)
             .unwrap_or(self.table);
-        execution_table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(execution_table.schema().options());
+        core.ensure_read_authorized()?;
         let vector_column =
             self.vector_column
                 .as_deref()
@@ -5410,11 +5410,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_batch_execute_fails_closed_when_query_auth_enabled() {
-        // The batch scored entry returns data-derived row ids/scores outside
-        // `TableScan`/`TableRead`, so it must fail closed under
-        // `query-auth.enabled` exactly like the single-query builder. Its config
-        // is otherwise valid, so without the guard the empty-snapshot fast path
-        // would return empty results and silently bypass authorization.
+        // The batch builder reads index files raw, never through
+        // `plan`/`to_arrow`, so it gates query-auth itself. The config is valid,
+        // so without the guard the empty-snapshot path would bypass it.
         let table = crate::table::query_auth_table();
         let err = table
             .new_batch_vector_search_builder()

--- a/crates/paimon/src/table/vector_search_builder.rs
+++ b/crates/paimon/src/table/vector_search_builder.rs
@@ -336,9 +336,10 @@ impl<'a> VectorSearchBuilder<'a> {
     }
 
     pub async fn execute_scored(&self) -> crate::Result<SearchResult> {
-        // Fail closed: returns data-derived row ranges outside `TableScan`/`TableRead`.
+        // Strict: search results bypass the query-auth row filter, so only a
+        // fully unrestricted grant may search.
+        self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
-        core.ensure_read_authorized()?;
         let vector_column =
             self.vector_column
                 .as_deref()
@@ -400,9 +401,11 @@ impl<'a> VectorSearchBuilder<'a> {
     /// [`with_projection`](Self::with_projection)) plus `__paimon_search_score`;
     /// `_ROW_ID` and `_PKEY_VECTOR_POSITION` are always hidden.
     pub async fn execute_read(&self) -> crate::Result<ArrowRecordBatchStream> {
-        // Fail closed: returns data outside `TableScan`/`TableRead`.
+        // Fail closed: materializes rows outside `TableScan`/`TableRead`, so it
+        // cannot apply the row filter / masking — only a fully unrestricted
+        // grant may run it (same gate as the scored entry points).
+        self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
-        core.ensure_read_authorized()?;
         let vector_column =
             self.vector_column
                 .as_deref()
@@ -1563,15 +1566,20 @@ impl<'a> BatchVectorSearchBuilder<'a> {
                 });
             }
         }
-        // Check the pinned execution view as defense in depth before any fast
-        // path returns data-derived row ids/scores outside TableScan/TableRead.
+        // Strict, like the scored path: batch vector search reads index files
+        // raw and returns top-k membership/ordering/scores over masked or
+        // filter-hidden rows — a ranking oracle it cannot enforce the row filter
+        // on, so only a fully unrestricted grant may run it. The pinned
+        // execution view is what gets checked, before any fast path (an empty
+        // snapshot would otherwise return empty results and bypass it); this
+        // also covers the DataFusion lateral path.
         let execution_table = self
             .prepared_filter
             .as_ref()
             .map(PreparedVectorSearchFilter::table)
             .unwrap_or(self.table);
+        execution_table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(execution_table.schema().options());
-        core.ensure_read_authorized()?;
         let vector_column =
             self.vector_column
                 .as_deref()
@@ -1759,9 +1767,11 @@ impl<'a> BatchVectorSearchBuilder<'a> {
     /// scored global row-ids, not materialized rows, so callers use
     /// [`execute`](Self::execute) instead.
     pub async fn execute_read(&self) -> crate::Result<Vec<ArrowRecordBatchStream>> {
-        // Fail closed: returns data outside `TableScan`/`TableRead`.
+        // Fail closed: materializes rows outside `TableScan`/`TableRead`, so it
+        // cannot apply the row filter / masking — only a fully unrestricted
+        // grant may run it (same gate as the scored entry points).
+        self.table.authorize_unrestricted_read().await?;
         let core = CoreOptions::new(self.table.schema().options());
-        core.ensure_read_authorized()?;
         let vector_column =
             self.vector_column
                 .as_deref()

--- a/crates/paimon/src/table/vindex_index_build_builder.rs
+++ b/crates/paimon/src/table/vindex_index_build_builder.rs
@@ -552,6 +552,10 @@ async fn extract_vectors(
     index_column: &str,
     dimension: i32,
 ) -> Result<Vec<f32>> {
+    // Index building reads raw values, so it requires an unrestricted grant (a
+    // restricted one would index a filtered/masked view); stamp it so the read
+    // is authorized. Mirrors the B-tree index builder.
+    let build_grant = table.authorize_unrestricted_read().await?;
     let split = DataSplitBuilder::new()
         .with_snapshot(shard.snapshot_id)
         .with_partition(shard.partition.clone())
@@ -563,7 +567,8 @@ async fn extract_vectors(
             shard.row_range_start,
             shard.row_range_end,
         )])
-        .build()?;
+        .build()?
+        .with_query_auth_grant(build_grant);
 
     let mut read_builder = table.new_read_builder();
     read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME])?;

--- a/crates/paimon/src/table/vindex_index_build_builder.rs
+++ b/crates/paimon/src/table/vindex_index_build_builder.rs
@@ -63,6 +63,11 @@ impl<'a> VindexIndexBuildBuilder<'a> {
 
     pub async fn execute(&self) -> Result<usize> {
         self.table.ensure_not_branch_reference_for_write()?;
+        // Authorize before reading any manifest or index metadata, and once for
+        // the whole build: doing it per shard both skipped the early-return
+        // paths and issued one REST round-trip per shard.
+        let build_grant = self.table.authorize_unrestricted_read().await?;
+        let grant = build_grant.as_ref();
 
         if !is_vindex_index_type(&self.index_type) {
             return Err(Error::DataInvalid {
@@ -158,7 +163,8 @@ impl<'a> VindexIndexBuildBuilder<'a> {
         let shard_count = shards.len();
         let mut messages = Vec::with_capacity(shard_count);
         for shard in shards {
-            let vectors = extract_vectors(self.table, &shard, index_column, dimension).await?;
+            let vectors =
+                extract_vectors(self.table, &shard, index_column, dimension, grant).await?;
             let index_file = self
                 .build_index_file(
                     &shard,
@@ -551,11 +557,10 @@ async fn extract_vectors(
     shard: &VindexIndexShard,
     index_column: &str,
     dimension: i32,
+    grant: Option<&std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>,
 ) -> Result<Vec<f32>> {
-    // Index building reads raw values, so it requires an unrestricted grant (a
-    // restricted one would index a filtered/masked view); stamp it so the read
-    // is authorized. Mirrors the B-tree index builder.
-    let build_grant = table.authorize_unrestricted_read().await?;
+    // Index building reads raw values, so `grant` must be the unrestricted one
+    // the caller obtained; stamp it so the read is authorized.
     let split = DataSplitBuilder::new()
         .with_snapshot(shard.snapshot_id)
         .with_partition(shard.partition.clone())
@@ -568,7 +573,7 @@ async fn extract_vectors(
             shard.row_range_end,
         )])
         .build()?
-        .with_query_auth_grant(build_grant);
+        .with_query_auth_grant(grant.cloned());
 
     let mut read_builder = table.new_read_builder();
     read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME])?;

--- a/crates/paimon/src/table/vindex_index_build_builder.rs
+++ b/crates/paimon/src/table/vindex_index_build_builder.rs
@@ -60,8 +60,12 @@ impl<'a> VindexIndexBuildBuilder<'a> {
     }
 
     pub async fn execute(&self) -> Result<usize> {
-        // Building the index scans the table's rows.
-        CoreOptions::new(self.table.schema().options()).ensure_read_authorized()?;
+        // Building the index scans the table's rows. Authorize before reading any
+        // manifest or index metadata, and once for the whole build: doing it per
+        // shard both skipped the early-return paths and issued one REST
+        // round-trip per shard.
+        let build_grant = self.table.authorize_unrestricted_read().await?;
+        let grant = build_grant.as_ref();
 
         self.table.ensure_not_branch_reference_for_write()?;
 
@@ -176,6 +180,7 @@ impl<'a> VindexIndexBuildBuilder<'a> {
                     index_field.id(),
                     &vindex_options,
                     index_meta.clone(),
+                    grant,
                 )
                 .await
             {

--- a/crates/paimon/src/table/vindex_index_build_builder/writer.rs
+++ b/crates/paimon/src/table/vindex_index_build_builder/writer.rs
@@ -47,6 +47,7 @@ pub(super) struct BuiltIndexFile {
 }
 
 impl<'a> VindexIndexBuildBuilder<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn build_index_file(
         &self,
         shard: &VindexIndexShard,
@@ -55,6 +56,7 @@ impl<'a> VindexIndexBuildBuilder<'a> {
         index_field_id: i32,
         options: &VindexVectorIndexOptions,
         index_meta: Vec<u8>,
+        grant: Option<&std::sync::Arc<crate::table::query_auth::QueryAuthGrant>>,
     ) -> Result<BuiltIndexFile> {
         let timing_enabled = vector_index_build_timing_enabled();
         let total_start = timing_enabled.then(Instant::now);
@@ -106,11 +108,10 @@ impl<'a> VindexIndexBuildBuilder<'a> {
             source: Some(Box::new(e)),
         })?;
         let mut raw_file = tokio::fs::File::from_std(raw_file);
-        // Index building reads raw values, so it requires an unrestricted grant:
-        // a restricted one would index a filtered or masked view. Stamp it so the
-        // read below is authorized. Mirrors the sorted global index builder.
-        let build_grant = self.table.authorize_unrestricted_read().await?;
-        let split = data_split_for_shard(shard)?.with_query_auth_grant(build_grant);
+        // Index building reads raw values, so `grant` must be the unrestricted one
+        // `execute` obtained: a restricted one would index a filtered or masked
+        // view. Stamp it so the read below is authorized.
+        let split = data_split_for_shard(shard)?.with_query_auth_grant(grant.cloned());
         let mut read_builder = self.table.new_read_builder();
         read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME])?;
         let read = read_builder.new_read()?;

--- a/crates/paimon/src/table/vindex_index_build_builder/writer.rs
+++ b/crates/paimon/src/table/vindex_index_build_builder/writer.rs
@@ -106,7 +106,11 @@ impl<'a> VindexIndexBuildBuilder<'a> {
             source: Some(Box::new(e)),
         })?;
         let mut raw_file = tokio::fs::File::from_std(raw_file);
-        let split = data_split_for_shard(shard)?;
+        // Index building reads raw values, so it requires an unrestricted grant:
+        // a restricted one would index a filtered or masked view. Stamp it so the
+        // read below is authorized. Mirrors the sorted global index builder.
+        let build_grant = self.table.authorize_unrestricted_read().await?;
+        let split = data_split_for_shard(shard)?.with_query_auth_grant(build_grant);
         let mut read_builder = self.table.new_read_builder();
         read_builder.with_projection(&[index_column, ROW_ID_FIELD_NAME])?;
         let read = read_builder.new_read()?;

--- a/crates/paimon/tests/mock_server.rs
+++ b/crates/paimon/tests/mock_server.rs
@@ -34,8 +34,8 @@ use std::sync::{Arc, Mutex};
 use tokio::task::JoinHandle;
 
 use paimon::api::{
-    AlterDatabaseRequest, AlterTableRequest, AuditRESTResponse, ConfigResponse,
-    CreateFunctionRequest, CreateViewRequest, ErrorResponse, GetDatabaseResponse,
+    AlterDatabaseRequest, AlterTableRequest, AuditRESTResponse, AuthTableQueryResponse,
+    ConfigResponse, CreateFunctionRequest, CreateViewRequest, ErrorResponse, GetDatabaseResponse,
     GetFunctionResponse, GetTableResponse, GetViewResponse, ListDatabasesResponse,
     ListFunctionsResponse, ListTablesResponse, ListViewsResponse, RenameTableRequest,
     ResourcePaths,
@@ -53,6 +53,8 @@ struct MockState {
     list_page_size: Option<usize>,
     no_permission_databases: HashSet<String>,
     no_permission_tables: HashSet<String>,
+    /// Per-table auth response for `POST .../tables/{table}/auth`; absent = unrestricted.
+    auth_responses: HashMap<String, AuthTableQueryResponse>,
     /// ECS metadata role name (for token loader testing)
     ecs_role_name: Option<String>,
     /// ECS metadata token (for token loader testing)
@@ -705,6 +707,20 @@ impl RESTServer {
         (StatusCode::NOT_FOUND, Json(err)).into_response()
     }
 
+    /// Handle POST /databases/:db/tables/:table/auth - per-user query-auth check.
+    pub async fn auth_table_query(
+        Path((db, table)): Path<(String, String)>,
+        Extension(state): Extension<Arc<RESTServer>>,
+    ) -> impl IntoResponse {
+        let s = state.inner.lock().unwrap();
+        let response = s
+            .auth_responses
+            .get(&format!("{db}.{table}"))
+            .cloned()
+            .unwrap_or_default();
+        (StatusCode::OK, Json(response)).into_response()
+    }
+
     /// Handle DELETE /databases/:db/tables/:table - drop a table.
     pub async fn drop_table(
         Path((db, table)): Path<(String, String)>,
@@ -967,6 +983,13 @@ impl RESTServer {
         );
     }
 
+    /// Set the auth response returned for `POST .../tables/{table}/auth`.
+    pub fn set_auth_response(&self, database: &str, table: &str, response: AuthTableQueryResponse) {
+        let mut s = self.inner.lock().unwrap();
+        s.auth_responses
+            .insert(format!("{database}.{table}"), response);
+    }
+
     /// Add a no-permission table to the server state.
     pub fn add_no_permission_table(&self, database: &str, table: &str) {
         let mut s = self.inner.lock().unwrap();
@@ -1104,6 +1127,10 @@ pub async fn start_mock_server(
         .route(
             &format!("{prefix}/databases/:db/functions/:function"),
             get(RESTServer::get_function),
+        )
+        .route(
+            &format!("{prefix}/databases/:db/tables/:table/auth"),
+            post(RESTServer::auth_table_query),
         )
         .route(
             &format!("{prefix}/tables/rename"),

--- a/crates/paimon/tests/mock_server.rs
+++ b/crates/paimon/tests/mock_server.rs
@@ -34,12 +34,12 @@ use std::sync::{Arc, Mutex};
 use tokio::task::JoinHandle;
 
 use paimon::api::{
-    AlterDatabaseRequest, AlterTableRequest, AuditRESTResponse, ConfigResponse,
-    CreateFunctionRequest, CreatePartitionsRequest, CreateViewRequest, DropPartitionsRequest,
-    ErrorResponse, GetDatabaseResponse, GetFunctionResponse, GetTableResponse, GetViewResponse,
-    ListDatabasesResponse, ListFunctionsResponse, ListPartitionsByFilterRequest,
-    ListPartitionsByNamesRequest, ListPartitionsResponse, ListTablesResponse, ListViewsResponse,
-    RenameTableRequest, ResourcePaths,
+    AlterDatabaseRequest, AlterTableRequest, AuditRESTResponse, AuthTableQueryResponse,
+    ConfigResponse, CreateFunctionRequest, CreatePartitionsRequest, CreateViewRequest,
+    DropPartitionsRequest, ErrorResponse, GetDatabaseResponse, GetFunctionResponse,
+    GetTableResponse, GetViewResponse, ListDatabasesResponse, ListFunctionsResponse,
+    ListPartitionsByFilterRequest, ListPartitionsByNamesRequest, ListPartitionsResponse,
+    ListTablesResponse, ListViewsResponse, RenameTableRequest, ResourcePaths,
 };
 use paimon::catalog::{Function, Identifier};
 use paimon::spec::Partition;
@@ -69,6 +69,8 @@ struct MockState {
     create_partitions_calls: Vec<(String, String, CreatePartitionsRequest)>,
     drop_partitions_calls: Vec<(String, String, DropPartitionsRequest)>,
     create_partitions_error_status: Option<StatusCode>,
+    /// Per-table auth response for `POST .../tables/{table}/auth`; absent = unrestricted.
+    auth_responses: HashMap<String, AuthTableQueryResponse>,
     /// ECS metadata role name (for token loader testing)
     ecs_role_name: Option<String>,
     /// ECS metadata token (for token loader testing)
@@ -761,6 +763,20 @@ impl RESTServer {
         (StatusCode::NOT_FOUND, Json(err)).into_response()
     }
 
+    /// Handle POST /databases/:db/tables/:table/auth - per-user query-auth check.
+    pub async fn auth_table_query(
+        Path((db, table)): Path<(String, String)>,
+        Extension(state): Extension<Arc<RESTServer>>,
+    ) -> impl IntoResponse {
+        let s = state.inner.lock().unwrap();
+        let response = s
+            .auth_responses
+            .get(&format!("{db}.{table}"))
+            .cloned()
+            .unwrap_or_default();
+        (StatusCode::OK, Json(response)).into_response()
+    }
+
     /// Handle DELETE /databases/:db/tables/:table - drop a table.
     pub async fn drop_table(
         Path((db, table)): Path<(String, String)>,
@@ -1392,6 +1408,13 @@ impl RESTServer {
         );
     }
 
+    /// Set the auth response returned for `POST .../tables/{table}/auth`.
+    pub fn set_auth_response(&self, database: &str, table: &str, response: AuthTableQueryResponse) {
+        let mut s = self.inner.lock().unwrap();
+        s.auth_responses
+            .insert(format!("{database}.{table}"), response);
+    }
+
     /// Add a no-permission table to the server state.
     pub fn add_no_permission_table(&self, database: &str, table: &str) {
         let mut s = self.inner.lock().unwrap();
@@ -1628,6 +1651,10 @@ pub async fn start_mock_server(
         .route(
             &format!("{prefix}/databases/:db/functions/:function"),
             get(RESTServer::get_function),
+        )
+        .route(
+            &format!("{prefix}/databases/:db/tables/:table/auth"),
+            post(RESTServer::auth_table_query),
         )
         .route(
             &format!("{prefix}/tables/rename"),

--- a/crates/paimon/tests/rest_catalog_test.rs
+++ b/crates/paimon/tests/rest_catalog_test.rs
@@ -27,7 +27,7 @@ use arrow_array::{Array, BinaryArray, Int32Array, Int64Array, RecordBatch, Strin
 use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
 use axum::http::StatusCode;
 use futures::TryStreamExt;
-use paimon::api::ConfigResponse;
+use paimon::api::{AuthTableQueryResponse, ConfigResponse};
 use paimon::catalog::{Catalog, Function, FunctionDefinition, Identifier, RESTCatalog, ViewSchema};
 use paimon::common::Options;
 use paimon::spec::{
@@ -344,6 +344,564 @@ async fn test_catalog_get_table() {
     let identifier = Identifier::new("default", "my_table");
     let table = ctx.catalog.get_table(&identifier).await;
     assert!(table.is_ok(), "failed to get table: {table:?}");
+}
+
+/// The grant is scoped to the columns the plan requested (like Java passing
+/// `readType.getFieldNames()`): a wider read against a scoped grant fails
+/// closed until it re-plans.
+#[tokio::test]
+async fn test_query_auth_grant_scoped_to_planned_columns() {
+    let ctx = setup_catalog(vec!["default"]).await;
+    let schema = Schema::builder()
+        .column("id", DataType::BigInt(BigIntType::new()))
+        .column("name", DataType::VarChar(VarCharType::new(255).unwrap()))
+        .option("query-auth.enabled", "true")
+        .build()
+        .unwrap();
+    ctx.server.add_table_with_schema(
+        "default",
+        "qa_scope",
+        schema,
+        "file:///tmp/test_warehouse/default.db/qa_scope",
+    );
+    let table = ctx
+        .catalog
+        .get_table(&Identifier::new("default", "qa_scope"))
+        .await
+        .unwrap();
+
+    // Plan a projection of {id}: the grant is scoped to that column and stamped
+    // on this plan's splits (not a shared slot on the table).
+    let mut projected = table.new_read_builder();
+    projected.with_projection(&["id"]).unwrap();
+    projected.new_scan().plan().await.unwrap();
+
+    // The {id} plan's scoped grant lives on its own splits, so it cannot leak
+    // to a separate full-table read (per-query, no shared mutable slot). Reading
+    // real splits that carry no grant fails closed — covered by the read_builder
+    // unit tests, which can build such a split directly.
+
+    // A separate full-table read re-authorizes for all columns when it plans.
+    table.new_read_builder().new_scan().plan().await.unwrap();
+}
+
+/// Java #8447 baseline: a query-auth row filter disables count-based limit
+/// pushdown, so a limited read still reaches authorized rows in later files.
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_query_auth_row_filter_reads_past_limit_pushdown() {
+    let tmp = tempfile::tempdir().unwrap();
+    let warehouse = format!("file://{}", tmp.path().display());
+
+    // Write two commits (-> two files) through a plain FileSystemCatalog table.
+    let mut fs_options = Options::new();
+    fs_options.set(CatalogOptions::WAREHOUSE, &warehouse);
+    let fs_catalog = FileSystemCatalog::new(fs_options).expect("create filesystem catalog");
+    fs_catalog
+        .create_database("default", true, HashMap::new())
+        .await
+        .unwrap();
+    let write_schema = Schema::builder()
+        .column("id", DataType::BigInt(BigIntType::new()))
+        .option("bucket", "1")
+        .option("bucket-key", "id")
+        .build()
+        .unwrap();
+    let identifier = Identifier::new("default", "qa_limit");
+    fs_catalog
+        .create_table(&identifier, write_schema, false)
+        .await
+        .unwrap();
+    let writer = fs_catalog.get_table(&identifier).await.unwrap();
+    let int_batch = |ids: Vec<i64>| {
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            ArrowDataType::Int64,
+            true,
+        )]));
+        RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(ids))]).unwrap()
+    };
+    write_batch(&writer, int_batch(vec![1, 2, 3, 4]), "u1").await;
+    write_batch(&writer, int_batch(vec![5, 6, 7, 8]), "u2").await;
+
+    // Read the same files through the REST catalog with query-auth enabled and
+    // a row filter of id >= 6 (all matches live in the SECOND file).
+    let ctx = setup_catalog(vec!["default"]).await;
+    let read_schema = Schema::builder()
+        .column("id", DataType::BigInt(BigIntType::new()))
+        .option("bucket", "1")
+        .option("bucket-key", "id")
+        .option("query-auth.enabled", "true")
+        .build()
+        .unwrap();
+    ctx.server.add_table_with_schema(
+        "default",
+        "qa_limit",
+        read_schema,
+        &format!("{warehouse}/default.db/qa_limit"),
+    );
+    ctx.server.set_auth_response(
+        "default",
+        "qa_limit",
+        AuthTableQueryResponse {
+            filter: Some(vec![
+                r#"{"kind":"LEAF","transform":{"name":"FIELD_REF","fieldRef":{"index":0,"name":"id","type":"BIGINT"}},"function":"GREATER_OR_EQUAL","literals":[6]}"#
+                    .to_string(),
+            ]),
+            column_masking: None,
+        },
+    );
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+
+    let mut builder = table.new_read_builder();
+    builder.with_limit(2);
+    let plan = builder.new_scan().plan().await.unwrap();
+    // The filter runs as a residual pass, so the plan must not cap splits by
+    // the unfiltered limit and must report its row counts as inexact.
+    assert!(!plan.row_counts_exact());
+    let batches: Vec<RecordBatch> = builder
+        .new_read()
+        .unwrap()
+        .to_arrow(plan.splits())
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    let mut ids: Vec<i64> = batches
+        .iter()
+        .flat_map(|b| {
+            b.column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        })
+        .collect();
+    ids.sort_unstable();
+    assert_eq!(
+        ids,
+        vec![6, 7, 8],
+        "authorized rows beyond file 1 must appear"
+    );
+}
+
+/// Java #8570 baseline: a cross-column mask (`alias := UPPER(name)`) and a row
+/// filter on an unprojected column (`score`) must still enforce when the caller
+/// projects neither `name` nor `score` — the read is widened with the grant's
+/// columns and every batch of every split is projected back to the caller's
+/// columns (no auth-added column may leak from later splits).
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_query_auth_cross_column_mask_with_narrow_projection() {
+    let tmp = tempfile::tempdir().unwrap();
+    let warehouse = format!("file://{}", tmp.path().display());
+
+    let mut fs_options = Options::new();
+    fs_options.set(CatalogOptions::WAREHOUSE, &warehouse);
+    let fs_catalog = FileSystemCatalog::new(fs_options).expect("create filesystem catalog");
+    fs_catalog
+        .create_database("default", true, HashMap::new())
+        .await
+        .unwrap();
+    let columns = || {
+        Schema::builder()
+            .column("id", DataType::Int(IntType::new()))
+            .column("name", DataType::VarChar(VarCharType::new(255).unwrap()))
+            .column("alias", DataType::VarChar(VarCharType::new(255).unwrap()))
+            .column("score", DataType::BigInt(BigIntType::new()))
+            .option("bucket", "1")
+            .option("bucket-key", "id")
+    };
+    let identifier = Identifier::new("default", "qa_cross_mask");
+    fs_catalog
+        .create_table(&identifier, columns().build().unwrap(), false)
+        .await
+        .unwrap();
+    let writer = fs_catalog.get_table(&identifier).await.unwrap();
+    let batch = |ids: Vec<i32>, names: Vec<&str>, aliases: Vec<&str>, scores: Vec<i64>| {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, true),
+            ArrowField::new("name", ArrowDataType::Utf8, true),
+            ArrowField::new("alias", ArrowDataType::Utf8, true),
+            ArrowField::new("score", ArrowDataType::Int64, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(StringArray::from(names)),
+                Arc::new(StringArray::from(aliases)),
+                Arc::new(Int64Array::from(scores)),
+            ],
+        )
+        .unwrap()
+    };
+    // Two commits -> two files, so enforcement is exercised across splits.
+    write_batch(
+        &writer,
+        batch(vec![1, 2], vec!["ann", "bob"], vec!["x", "y"], vec![5, 15]),
+        "u1",
+    )
+    .await;
+    write_batch(
+        &writer,
+        batch(vec![3, 4], vec!["cid", "dan"], vec!["z", "w"], vec![20, 8]),
+        "u2",
+    )
+    .await;
+
+    let ctx = setup_catalog(vec!["default"]).await;
+    ctx.server.add_table_with_schema(
+        "default",
+        "qa_cross_mask",
+        columns()
+            .option("query-auth.enabled", "true")
+            .build()
+            .unwrap(),
+        &format!("{warehouse}/default.db/qa_cross_mask"),
+    );
+    ctx.server.set_auth_response(
+        "default",
+        "qa_cross_mask",
+        AuthTableQueryResponse {
+            // Row filter on `score` (index 3), which the caller does not project.
+            filter: Some(vec![
+                r#"{"kind":"LEAF","transform":{"name":"FIELD_REF","fieldRef":{"index":3,"name":"score","type":"BIGINT"}},"function":"GREATER_OR_EQUAL","literals":[10]}"#
+                    .to_string(),
+            ]),
+            // Cross-column mask: `alias` is overwritten from `name` (index 1),
+            // which the caller does not project either.
+            column_masking: Some(HashMap::from([(
+                "alias".to_string(),
+                r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#
+                    .to_string(),
+            )])),
+        },
+    );
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+
+    let mut builder = table.new_read_builder();
+    builder.with_projection(&["id", "alias"]).unwrap();
+    let plan = builder.new_scan().plan().await.unwrap();
+    let batches: Vec<RecordBatch> = builder
+        .new_read()
+        .unwrap()
+        .to_arrow(plan.splits())
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+
+    let mut rows = Vec::new();
+    for b in &batches {
+        assert_eq!(
+            b.schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect::<Vec<_>>(),
+            vec!["id", "alias"],
+            "auth-added columns (name, score) must not leak from any split"
+        );
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let aliases = b.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        for r in 0..b.num_rows() {
+            rows.push((ids.value(r), aliases.value(r).to_string()));
+        }
+    }
+    rows.sort_unstable();
+    assert_eq!(
+        rows,
+        vec![(2, "BOB".to_string()), (3, "CID".to_string())],
+        "filter must drop score<10 rows in both files and alias must be UPPER(name)"
+    );
+}
+
+/// Visible end-to-end demo of query-auth enforcement over a mock REST catalog:
+/// the same files are read once with no grant (raw) and once through a
+/// `query-auth.enabled` table whose per-user grant applies a row filter
+/// (`salary >= 90000`) plus column masking (`name -> UPPER(name)`). Run with:
+///   cargo test -p paimon --test rest_catalog_test query_auth_enforcement_demo -- --nocapture
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_query_auth_enforcement_demo() {
+    let tmp = tempfile::tempdir().unwrap();
+    let warehouse = format!("file://{}", tmp.path().display());
+
+    // --- Write demo_employees (id, name, salary) via a plain FileSystemCatalog ---
+    let mut fs_options = Options::new();
+    fs_options.set(CatalogOptions::WAREHOUSE, &warehouse);
+    let fs_catalog = FileSystemCatalog::new(fs_options).expect("create filesystem catalog");
+    fs_catalog
+        .create_database("default", true, HashMap::new())
+        .await
+        .unwrap();
+    let columns = || {
+        Schema::builder()
+            .column("id", DataType::Int(IntType::new()))
+            .column("name", DataType::VarChar(VarCharType::new(255).unwrap()))
+            .column("salary", DataType::BigInt(BigIntType::new()))
+            .option("bucket", "1")
+            .option("bucket-key", "id")
+    };
+    let identifier = Identifier::new("default", "demo_employees");
+    fs_catalog
+        .create_table(&identifier, columns().build().unwrap(), false)
+        .await
+        .unwrap();
+    let writer = fs_catalog.get_table(&identifier).await.unwrap();
+
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", ArrowDataType::Int32, true),
+        ArrowField::new("name", ArrowDataType::Utf8, true),
+        ArrowField::new("salary", ArrowDataType::Int64, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+            Arc::new(StringArray::from(vec![
+                "alice", "bob", "charlie", "diana", "eve",
+            ])),
+            Arc::new(Int64Array::from(vec![120000, 85000, 95000, 70000, 99000])),
+        ],
+    )
+    .unwrap();
+    write_batch(&writer, batch, "u1").await;
+
+    let dump = |label: &str, batches: &[RecordBatch]| {
+        println!("\n  {label}");
+        println!("    {:<4} {:<10} {:>8}", "id", "name", "salary");
+        for b in batches {
+            let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+            let names = b.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+            let sal = b.column(2).as_any().downcast_ref::<Int64Array>().unwrap();
+            for r in 0..b.num_rows() {
+                println!(
+                    "    {:<4} {:<10} {:>8}",
+                    ids.value(r),
+                    names.value(r),
+                    sal.value(r)
+                );
+            }
+        }
+    };
+
+    // --- Raw read (no query-auth) ---
+    let raw: Vec<RecordBatch> = {
+        let b = writer.new_read_builder();
+        b.new_read()
+            .unwrap()
+            .to_arrow(b.new_scan().plan().await.unwrap().splits())
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap()
+    };
+    dump("RAW (no grant): all rows, real names", &raw);
+
+    // --- Enforced read through the REST catalog with a per-user grant ---
+    let ctx = setup_catalog(vec!["default"]).await;
+    ctx.server.add_table_with_schema(
+        "default",
+        "demo_employees",
+        columns()
+            .option("query-auth.enabled", "true")
+            .build()
+            .unwrap(),
+        &format!("{warehouse}/default.db/demo_employees"),
+    );
+    ctx.server.set_auth_response(
+        "default",
+        "demo_employees",
+        AuthTableQueryResponse {
+            // Row filter: salary >= 90000 (field index 2).
+            filter: Some(vec![
+                r#"{"kind":"LEAF","transform":{"name":"FIELD_REF","fieldRef":{"index":2,"name":"salary","type":"BIGINT"}},"function":"GREATER_OR_EQUAL","literals":[90000]}"#
+                    .to_string(),
+            ]),
+            // Column masking: name -> UPPER(name) (field index 1).
+            column_masking: Some(HashMap::from([(
+                "name".to_string(),
+                r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#
+                    .to_string(),
+            )])),
+        },
+    );
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+    let b = table.new_read_builder();
+    // Plan first: scan planning fetches + verifies the per-user grant (mirroring
+    // Java `CatalogEnvironment.tableQueryAuth()`) and authorizes the shared read
+    // state; only then may the sync read gate (`new_read`/`to_arrow`) proceed.
+    let plan = b.new_scan().plan().await.unwrap();
+    let enforced: Vec<RecordBatch> = b
+        .new_read()
+        .unwrap()
+        .to_arrow(plan.splits())
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    dump("ENFORCED (grant: salary>=90000, name->UPPER)", &enforced);
+
+    let mut rows: Vec<(i32, String, i64)> = enforced
+        .iter()
+        .flat_map(|batch| {
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let names = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            let sal = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            (0..batch.num_rows())
+                .map(|r| (ids.value(r), names.value(r).to_string(), sal.value(r)))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    rows.sort_unstable();
+    assert_eq!(
+        rows,
+        vec![
+            (1, "ALICE".to_string(), 120000),
+            (3, "CHARLIE".to_string(), 95000),
+            (5, "EVE".to_string(), 99000),
+        ],
+        "row filter must drop salary<90000 and masking must uppercase name"
+    );
+}
+
+/// Query-auth: scan planning transparently fetches the per-user grant
+/// (mirroring Java's `CatalogEnvironment.tableQueryAuth()`); an unrestricted
+/// user reads everything, a filtered/masked user gets an enforced read, and
+/// paths that cannot enforce stay fail-closed.
+#[tokio::test]
+async fn test_catalog_get_table_query_auth() {
+    let ctx = setup_catalog(vec!["default"]).await;
+    let schema = Schema::builder()
+        .column("id", DataType::BigInt(BigIntType::new()))
+        .option("query-auth.enabled", "true")
+        .build()
+        .expect("Failed to build schema");
+    ctx.server.add_table_with_schema(
+        "default",
+        "qa",
+        schema,
+        "file:///tmp/test_warehouse/default.db/qa",
+    );
+    let identifier = Identifier::new("default", "qa");
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+
+    // Reading no splits yields no rows, so it is allowed even before planning;
+    // real splits carrying no grant fail closed (read_builder unit tests).
+    let ungranted = table.new_read_builder().new_read().unwrap();
+    assert!(ungranted.to_arrow(&[]).is_ok());
+
+    // The mock /auth endpoint reports unrestricted by default: planning a scan
+    // authorizes the table and stamps the grant on its splits.
+    let builder = table.new_read_builder();
+    builder
+        .new_scan()
+        .plan()
+        .await
+        .expect("unrestricted user should be able to plan a query-auth scan");
+
+    // A parseable row filter (Java Predicate JSON) grants a filtered read:
+    // planning and building the read succeed; the filter is enforced inside
+    // `to_arrow`.
+    ctx.server.set_auth_response(
+        "default",
+        "qa",
+        AuthTableQueryResponse {
+            filter: Some(vec![
+                r#"{"kind":"LEAF","transform":{"name":"FIELD_REF","fieldRef":{"index":0,"name":"id","type":"BIGINT"}},"function":"GREATER_THAN","literals":[5]}"#
+                    .to_string(),
+            ]),
+            column_masking: None,
+        },
+    );
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+    let builder = table.new_read_builder();
+    builder
+        .new_scan()
+        .plan()
+        .await
+        .expect("a parseable row filter should allow planning a (filtered) read");
+    // ... but paths that bypass the row filter stay strictly fail-closed.
+    let err = table
+        .new_vector_search_builder()
+        .execute()
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("query-auth.enabled"),
+        "search must stay fail-closed for a filtered user, got: {err}"
+    );
+
+    // An unparseable filter fails the plan and keeps the table fail-closed.
+    ctx.server.set_auth_response(
+        "default",
+        "qa",
+        AuthTableQueryResponse {
+            filter: Some(vec!["{\"kind\":\"CUSTOM\"}".to_string()]),
+            column_masking: None,
+        },
+    );
+    let fresh = ctx.catalog.get_table(&identifier).await.unwrap();
+    assert!(fresh.new_read_builder().new_scan().plan().await.is_err());
+
+    // Parseable column masking grants a (masked) read; a caller predicate on
+    // the masked column is rejected (it would leak the raw value).
+    ctx.server.set_auth_response(
+        "default",
+        "qa",
+        AuthTableQueryResponse {
+            filter: None,
+            column_masking: Some(HashMap::from([(
+                "id".to_string(),
+                "{\"name\":\"NULL\"}".to_string(),
+            )])),
+        },
+    );
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+    let builder = table.new_read_builder();
+    builder.new_scan().plan().await.expect("masked read plans");
+    // A caller predicate on a masked column fails closed at plan time (pruning
+    // on its raw value would leak it); the same guard runs again in `to_arrow`.
+    let mut filtered = table.new_read_builder();
+    filtered.with_filter(
+        PredicateBuilder::new(table.schema().fields())
+            .equal("id", Datum::Long(1))
+            .unwrap(),
+    );
+    let Err(err) = filtered.new_scan().plan().await else {
+        panic!("a caller predicate on a masked column must fail closed");
+    };
+    assert!(
+        err.to_string().contains("masked column"),
+        "a caller predicate on a masked column must fail closed, got: {err}"
+    );
+
+    // Every plan re-authorizes (like Java): revoking down to an unparseable
+    // grant fails the plan, and a read without a stamped grant stays closed.
+    ctx.server.set_auth_response(
+        "default",
+        "qa",
+        AuthTableQueryResponse {
+            filter: Some(vec!["{\"kind\":\"CUSTOM\"}".to_string()]),
+            column_masking: None,
+        },
+    );
+    assert!(table.new_read_builder().new_scan().plan().await.is_err());
 }
 
 #[tokio::test]

--- a/crates/paimon/tests/rest_catalog_test.rs
+++ b/crates/paimon/tests/rest_catalog_test.rs
@@ -349,37 +349,88 @@ async fn test_catalog_get_table() {
 /// The grant is scoped to the columns the plan requested (like Java passing
 /// `readType.getFieldNames()`): a wider read against a scoped grant fails
 /// closed until it re-plans.
+#[cfg(not(windows))]
 #[tokio::test]
 async fn test_query_auth_grant_scoped_to_planned_columns() {
-    let ctx = setup_catalog(vec!["default"]).await;
-    let schema = Schema::builder()
-        .column("id", DataType::BigInt(BigIntType::new()))
-        .column("name", DataType::VarChar(VarCharType::new(255).unwrap()))
-        .option("query-auth.enabled", "true")
-        .build()
+    let tmp = tempfile::tempdir().unwrap();
+    let warehouse = format!("file://{}", tmp.path().display());
+
+    // Real data, so the scoped plan actually produces splits to assert on.
+    let mut fs_options = Options::new();
+    fs_options.set(CatalogOptions::WAREHOUSE, &warehouse);
+    let fs_catalog = FileSystemCatalog::new(fs_options).expect("create filesystem catalog");
+    fs_catalog
+        .create_database("default", true, HashMap::new())
+        .await
         .unwrap();
+    let columns = || {
+        Schema::builder()
+            .column("id", DataType::BigInt(BigIntType::new()))
+            .column("name", DataType::VarChar(VarCharType::new(255).unwrap()))
+            .option("bucket", "1")
+            .option("bucket-key", "id")
+    };
+    let identifier = Identifier::new("default", "qa_scope");
+    fs_catalog
+        .create_table(&identifier, columns().build().unwrap(), false)
+        .await
+        .unwrap();
+    let writer = fs_catalog.get_table(&identifier).await.unwrap();
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", ArrowDataType::Int64, true),
+        ArrowField::new("name", ArrowDataType::Utf8, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(Int64Array::from(vec![1i64, 2])),
+            Arc::new(arrow_array::StringArray::from(vec!["a", "b"])),
+        ],
+    )
+    .unwrap();
+    write_batch(&writer, batch, "u1").await;
+
+    let ctx = setup_catalog(vec!["default"]).await;
     ctx.server.add_table_with_schema(
         "default",
         "qa_scope",
-        schema,
-        "file:///tmp/test_warehouse/default.db/qa_scope",
+        columns()
+            .option("query-auth.enabled", "true")
+            .build()
+            .unwrap(),
+        &format!("{warehouse}/default.db/qa_scope"),
     );
-    let table = ctx
-        .catalog
-        .get_table(&Identifier::new("default", "qa_scope"))
-        .await
-        .unwrap();
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
 
     // Plan a projection of {id}: the grant is scoped to that column and stamped
     // on this plan's splits (not a shared slot on the table).
     let mut projected = table.new_read_builder();
     projected.with_projection(&["id"]).unwrap();
-    projected.new_scan().plan().await.unwrap();
+    let scoped_plan = projected.new_scan().plan().await.unwrap();
+    assert!(
+        !scoped_plan.splits().is_empty(),
+        "the scoped plan must produce splits for this assertion to mean anything"
+    );
+    assert!(
+        projected
+            .new_read()
+            .unwrap()
+            .to_arrow(scoped_plan.splits())
+            .is_ok(),
+        "the planned projection must read under its own grant"
+    );
 
-    // The {id} plan's scoped grant lives on its own splits, so it cannot leak
-    // to a separate full-table read (per-query, no shared mutable slot). Reading
-    // real splits that carry no grant fails closed — covered by the read_builder
-    // unit tests, which can build such a split directly.
+    // The grant rides on the splits it was planned with, so handing those
+    // splits to a wider read must fail closed rather than widen the scope.
+    let wide = table.new_read_builder().new_read().unwrap();
+    match wide.to_arrow(scoped_plan.splits()) {
+        Err(paimon::Error::Unsupported { message }) => assert!(
+            message.contains("outside the authorized set"),
+            "unexpected rejection: {message}"
+        ),
+        Ok(_) => panic!("a wider read must not run under the {{id}} plan's scoped grant"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
 
     // A separate full-table read re-authorizes for all columns when it plans.
     table.new_read_builder().new_scan().plan().await.unwrap();

--- a/crates/paimon/tests/rest_catalog_test.rs
+++ b/crates/paimon/tests/rest_catalog_test.rs
@@ -27,7 +27,7 @@ use arrow_array::{Array, BinaryArray, Int32Array, Int64Array, RecordBatch, Strin
 use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
 use axum::http::StatusCode;
 use futures::TryStreamExt;
-use paimon::api::ConfigResponse;
+use paimon::api::{AuthTableQueryResponse, ConfigResponse};
 use paimon::catalog::{Catalog, Function, FunctionDefinition, Identifier, RESTCatalog, ViewSchema};
 use paimon::common::Options;
 use paimon::spec::{
@@ -661,6 +661,564 @@ async fn test_catalog_get_table() {
     let identifier = Identifier::new("default", "my_table");
     let table = ctx.catalog.get_table(&identifier).await;
     assert!(table.is_ok(), "failed to get table: {table:?}");
+}
+
+/// The grant is scoped to the columns the plan requested (like Java passing
+/// `readType.getFieldNames()`): a wider read against a scoped grant fails
+/// closed until it re-plans.
+#[tokio::test]
+async fn test_query_auth_grant_scoped_to_planned_columns() {
+    let ctx = setup_catalog(vec!["default"]).await;
+    let schema = Schema::builder()
+        .column("id", DataType::BigInt(BigIntType::new()))
+        .column("name", DataType::VarChar(VarCharType::new(255).unwrap()))
+        .option("query-auth.enabled", "true")
+        .build()
+        .unwrap();
+    ctx.server.add_table_with_schema(
+        "default",
+        "qa_scope",
+        schema,
+        "file:///tmp/test_warehouse/default.db/qa_scope",
+    );
+    let table = ctx
+        .catalog
+        .get_table(&Identifier::new("default", "qa_scope"))
+        .await
+        .unwrap();
+
+    // Plan a projection of {id}: the grant is scoped to that column and stamped
+    // on this plan's splits (not a shared slot on the table).
+    let mut projected = table.new_read_builder();
+    projected.with_projection(&["id"]).unwrap();
+    projected.new_scan().plan().await.unwrap();
+
+    // The {id} plan's scoped grant lives on its own splits, so it cannot leak
+    // to a separate full-table read (per-query, no shared mutable slot). Reading
+    // real splits that carry no grant fails closed — covered by the read_builder
+    // unit tests, which can build such a split directly.
+
+    // A separate full-table read re-authorizes for all columns when it plans.
+    table.new_read_builder().new_scan().plan().await.unwrap();
+}
+
+/// Java #8447 baseline: a query-auth row filter disables count-based limit
+/// pushdown, so a limited read still reaches authorized rows in later files.
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_query_auth_row_filter_reads_past_limit_pushdown() {
+    let tmp = tempfile::tempdir().unwrap();
+    let warehouse = format!("file://{}", tmp.path().display());
+
+    // Write two commits (-> two files) through a plain FileSystemCatalog table.
+    let mut fs_options = Options::new();
+    fs_options.set(CatalogOptions::WAREHOUSE, &warehouse);
+    let fs_catalog = FileSystemCatalog::new(fs_options).expect("create filesystem catalog");
+    fs_catalog
+        .create_database("default", true, HashMap::new())
+        .await
+        .unwrap();
+    let write_schema = Schema::builder()
+        .column("id", DataType::BigInt(BigIntType::new()))
+        .option("bucket", "1")
+        .option("bucket-key", "id")
+        .build()
+        .unwrap();
+    let identifier = Identifier::new("default", "qa_limit");
+    fs_catalog
+        .create_table(&identifier, write_schema, false)
+        .await
+        .unwrap();
+    let writer = fs_catalog.get_table(&identifier).await.unwrap();
+    let int_batch = |ids: Vec<i64>| {
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            ArrowDataType::Int64,
+            true,
+        )]));
+        RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(ids))]).unwrap()
+    };
+    write_batch(&writer, int_batch(vec![1, 2, 3, 4]), "u1").await;
+    write_batch(&writer, int_batch(vec![5, 6, 7, 8]), "u2").await;
+
+    // Read the same files through the REST catalog with query-auth enabled and
+    // a row filter of id >= 6 (all matches live in the SECOND file).
+    let ctx = setup_catalog(vec!["default"]).await;
+    let read_schema = Schema::builder()
+        .column("id", DataType::BigInt(BigIntType::new()))
+        .option("bucket", "1")
+        .option("bucket-key", "id")
+        .option("query-auth.enabled", "true")
+        .build()
+        .unwrap();
+    ctx.server.add_table_with_schema(
+        "default",
+        "qa_limit",
+        read_schema,
+        &format!("{warehouse}/default.db/qa_limit"),
+    );
+    ctx.server.set_auth_response(
+        "default",
+        "qa_limit",
+        AuthTableQueryResponse {
+            filter: Some(vec![
+                r#"{"kind":"LEAF","transform":{"name":"FIELD_REF","fieldRef":{"index":0,"name":"id","type":"BIGINT"}},"function":"GREATER_OR_EQUAL","literals":[6]}"#
+                    .to_string(),
+            ]),
+            column_masking: None,
+        },
+    );
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+
+    let mut builder = table.new_read_builder();
+    builder.with_limit(2);
+    let plan = builder.new_scan().plan().await.unwrap();
+    // The filter runs as a residual pass, so the plan must not cap splits by
+    // the unfiltered limit and must report its row counts as inexact.
+    assert!(!plan.row_counts_exact());
+    let batches: Vec<RecordBatch> = builder
+        .new_read()
+        .unwrap()
+        .to_arrow(plan.splits())
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    let mut ids: Vec<i64> = batches
+        .iter()
+        .flat_map(|b| {
+            b.column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values()
+                .to_vec()
+        })
+        .collect();
+    ids.sort_unstable();
+    assert_eq!(
+        ids,
+        vec![6, 7, 8],
+        "authorized rows beyond file 1 must appear"
+    );
+}
+
+/// Java #8570 baseline: a cross-column mask (`alias := UPPER(name)`) and a row
+/// filter on an unprojected column (`score`) must still enforce when the caller
+/// projects neither `name` nor `score` — the read is widened with the grant's
+/// columns and every batch of every split is projected back to the caller's
+/// columns (no auth-added column may leak from later splits).
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_query_auth_cross_column_mask_with_narrow_projection() {
+    let tmp = tempfile::tempdir().unwrap();
+    let warehouse = format!("file://{}", tmp.path().display());
+
+    let mut fs_options = Options::new();
+    fs_options.set(CatalogOptions::WAREHOUSE, &warehouse);
+    let fs_catalog = FileSystemCatalog::new(fs_options).expect("create filesystem catalog");
+    fs_catalog
+        .create_database("default", true, HashMap::new())
+        .await
+        .unwrap();
+    let columns = || {
+        Schema::builder()
+            .column("id", DataType::Int(IntType::new()))
+            .column("name", DataType::VarChar(VarCharType::new(255).unwrap()))
+            .column("alias", DataType::VarChar(VarCharType::new(255).unwrap()))
+            .column("score", DataType::BigInt(BigIntType::new()))
+            .option("bucket", "1")
+            .option("bucket-key", "id")
+    };
+    let identifier = Identifier::new("default", "qa_cross_mask");
+    fs_catalog
+        .create_table(&identifier, columns().build().unwrap(), false)
+        .await
+        .unwrap();
+    let writer = fs_catalog.get_table(&identifier).await.unwrap();
+    let batch = |ids: Vec<i32>, names: Vec<&str>, aliases: Vec<&str>, scores: Vec<i64>| {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, true),
+            ArrowField::new("name", ArrowDataType::Utf8, true),
+            ArrowField::new("alias", ArrowDataType::Utf8, true),
+            ArrowField::new("score", ArrowDataType::Int64, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(StringArray::from(names)),
+                Arc::new(StringArray::from(aliases)),
+                Arc::new(Int64Array::from(scores)),
+            ],
+        )
+        .unwrap()
+    };
+    // Two commits -> two files, so enforcement is exercised across splits.
+    write_batch(
+        &writer,
+        batch(vec![1, 2], vec!["ann", "bob"], vec!["x", "y"], vec![5, 15]),
+        "u1",
+    )
+    .await;
+    write_batch(
+        &writer,
+        batch(vec![3, 4], vec!["cid", "dan"], vec!["z", "w"], vec![20, 8]),
+        "u2",
+    )
+    .await;
+
+    let ctx = setup_catalog(vec!["default"]).await;
+    ctx.server.add_table_with_schema(
+        "default",
+        "qa_cross_mask",
+        columns()
+            .option("query-auth.enabled", "true")
+            .build()
+            .unwrap(),
+        &format!("{warehouse}/default.db/qa_cross_mask"),
+    );
+    ctx.server.set_auth_response(
+        "default",
+        "qa_cross_mask",
+        AuthTableQueryResponse {
+            // Row filter on `score` (index 3), which the caller does not project.
+            filter: Some(vec![
+                r#"{"kind":"LEAF","transform":{"name":"FIELD_REF","fieldRef":{"index":3,"name":"score","type":"BIGINT"}},"function":"GREATER_OR_EQUAL","literals":[10]}"#
+                    .to_string(),
+            ]),
+            // Cross-column mask: `alias` is overwritten from `name` (index 1),
+            // which the caller does not project either.
+            column_masking: Some(HashMap::from([(
+                "alias".to_string(),
+                r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#
+                    .to_string(),
+            )])),
+        },
+    );
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+
+    let mut builder = table.new_read_builder();
+    builder.with_projection(&["id", "alias"]).unwrap();
+    let plan = builder.new_scan().plan().await.unwrap();
+    let batches: Vec<RecordBatch> = builder
+        .new_read()
+        .unwrap()
+        .to_arrow(plan.splits())
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+
+    let mut rows = Vec::new();
+    for b in &batches {
+        assert_eq!(
+            b.schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect::<Vec<_>>(),
+            vec!["id", "alias"],
+            "auth-added columns (name, score) must not leak from any split"
+        );
+        let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let aliases = b.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        for r in 0..b.num_rows() {
+            rows.push((ids.value(r), aliases.value(r).to_string()));
+        }
+    }
+    rows.sort_unstable();
+    assert_eq!(
+        rows,
+        vec![(2, "BOB".to_string()), (3, "CID".to_string())],
+        "filter must drop score<10 rows in both files and alias must be UPPER(name)"
+    );
+}
+
+/// Visible end-to-end demo of query-auth enforcement over a mock REST catalog:
+/// the same files are read once with no grant (raw) and once through a
+/// `query-auth.enabled` table whose per-user grant applies a row filter
+/// (`salary >= 90000`) plus column masking (`name -> UPPER(name)`). Run with:
+///   cargo test -p paimon --test rest_catalog_test query_auth_enforcement_demo -- --nocapture
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_query_auth_enforcement_demo() {
+    let tmp = tempfile::tempdir().unwrap();
+    let warehouse = format!("file://{}", tmp.path().display());
+
+    // --- Write demo_employees (id, name, salary) via a plain FileSystemCatalog ---
+    let mut fs_options = Options::new();
+    fs_options.set(CatalogOptions::WAREHOUSE, &warehouse);
+    let fs_catalog = FileSystemCatalog::new(fs_options).expect("create filesystem catalog");
+    fs_catalog
+        .create_database("default", true, HashMap::new())
+        .await
+        .unwrap();
+    let columns = || {
+        Schema::builder()
+            .column("id", DataType::Int(IntType::new()))
+            .column("name", DataType::VarChar(VarCharType::new(255).unwrap()))
+            .column("salary", DataType::BigInt(BigIntType::new()))
+            .option("bucket", "1")
+            .option("bucket-key", "id")
+    };
+    let identifier = Identifier::new("default", "demo_employees");
+    fs_catalog
+        .create_table(&identifier, columns().build().unwrap(), false)
+        .await
+        .unwrap();
+    let writer = fs_catalog.get_table(&identifier).await.unwrap();
+
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", ArrowDataType::Int32, true),
+        ArrowField::new("name", ArrowDataType::Utf8, true),
+        ArrowField::new("salary", ArrowDataType::Int64, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+            Arc::new(StringArray::from(vec![
+                "alice", "bob", "charlie", "diana", "eve",
+            ])),
+            Arc::new(Int64Array::from(vec![120000, 85000, 95000, 70000, 99000])),
+        ],
+    )
+    .unwrap();
+    write_batch(&writer, batch, "u1").await;
+
+    let dump = |label: &str, batches: &[RecordBatch]| {
+        println!("\n  {label}");
+        println!("    {:<4} {:<10} {:>8}", "id", "name", "salary");
+        for b in batches {
+            let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+            let names = b.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+            let sal = b.column(2).as_any().downcast_ref::<Int64Array>().unwrap();
+            for r in 0..b.num_rows() {
+                println!(
+                    "    {:<4} {:<10} {:>8}",
+                    ids.value(r),
+                    names.value(r),
+                    sal.value(r)
+                );
+            }
+        }
+    };
+
+    // --- Raw read (no query-auth) ---
+    let raw: Vec<RecordBatch> = {
+        let b = writer.new_read_builder();
+        b.new_read()
+            .unwrap()
+            .to_arrow(b.new_scan().plan().await.unwrap().splits())
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap()
+    };
+    dump("RAW (no grant): all rows, real names", &raw);
+
+    // --- Enforced read through the REST catalog with a per-user grant ---
+    let ctx = setup_catalog(vec!["default"]).await;
+    ctx.server.add_table_with_schema(
+        "default",
+        "demo_employees",
+        columns()
+            .option("query-auth.enabled", "true")
+            .build()
+            .unwrap(),
+        &format!("{warehouse}/default.db/demo_employees"),
+    );
+    ctx.server.set_auth_response(
+        "default",
+        "demo_employees",
+        AuthTableQueryResponse {
+            // Row filter: salary >= 90000 (field index 2).
+            filter: Some(vec![
+                r#"{"kind":"LEAF","transform":{"name":"FIELD_REF","fieldRef":{"index":2,"name":"salary","type":"BIGINT"}},"function":"GREATER_OR_EQUAL","literals":[90000]}"#
+                    .to_string(),
+            ]),
+            // Column masking: name -> UPPER(name) (field index 1).
+            column_masking: Some(HashMap::from([(
+                "name".to_string(),
+                r#"{"name":"UPPER","inputs":[{"index":1,"name":"name","type":"STRING"}]}"#
+                    .to_string(),
+            )])),
+        },
+    );
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+    let b = table.new_read_builder();
+    // Plan first: scan planning fetches + verifies the per-user grant (mirroring
+    // Java `CatalogEnvironment.tableQueryAuth()`) and authorizes the shared read
+    // state; only then may the sync read gate (`new_read`/`to_arrow`) proceed.
+    let plan = b.new_scan().plan().await.unwrap();
+    let enforced: Vec<RecordBatch> = b
+        .new_read()
+        .unwrap()
+        .to_arrow(plan.splits())
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    dump("ENFORCED (grant: salary>=90000, name->UPPER)", &enforced);
+
+    let mut rows: Vec<(i32, String, i64)> = enforced
+        .iter()
+        .flat_map(|batch| {
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let names = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            let sal = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            (0..batch.num_rows())
+                .map(|r| (ids.value(r), names.value(r).to_string(), sal.value(r)))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    rows.sort_unstable();
+    assert_eq!(
+        rows,
+        vec![
+            (1, "ALICE".to_string(), 120000),
+            (3, "CHARLIE".to_string(), 95000),
+            (5, "EVE".to_string(), 99000),
+        ],
+        "row filter must drop salary<90000 and masking must uppercase name"
+    );
+}
+
+/// Query-auth: scan planning transparently fetches the per-user grant
+/// (mirroring Java's `CatalogEnvironment.tableQueryAuth()`); an unrestricted
+/// user reads everything, a filtered/masked user gets an enforced read, and
+/// paths that cannot enforce stay fail-closed.
+#[tokio::test]
+async fn test_catalog_get_table_query_auth() {
+    let ctx = setup_catalog(vec!["default"]).await;
+    let schema = Schema::builder()
+        .column("id", DataType::BigInt(BigIntType::new()))
+        .option("query-auth.enabled", "true")
+        .build()
+        .expect("Failed to build schema");
+    ctx.server.add_table_with_schema(
+        "default",
+        "qa",
+        schema,
+        "file:///tmp/test_warehouse/default.db/qa",
+    );
+    let identifier = Identifier::new("default", "qa");
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+
+    // Reading no splits yields no rows, so it is allowed even before planning;
+    // real splits carrying no grant fail closed (read_builder unit tests).
+    let ungranted = table.new_read_builder().new_read().unwrap();
+    assert!(ungranted.to_arrow(&[]).is_ok());
+
+    // The mock /auth endpoint reports unrestricted by default: planning a scan
+    // authorizes the table and stamps the grant on its splits.
+    let builder = table.new_read_builder();
+    builder
+        .new_scan()
+        .plan()
+        .await
+        .expect("unrestricted user should be able to plan a query-auth scan");
+
+    // A parseable row filter (Java Predicate JSON) grants a filtered read:
+    // planning and building the read succeed; the filter is enforced inside
+    // `to_arrow`.
+    ctx.server.set_auth_response(
+        "default",
+        "qa",
+        AuthTableQueryResponse {
+            filter: Some(vec![
+                r#"{"kind":"LEAF","transform":{"name":"FIELD_REF","fieldRef":{"index":0,"name":"id","type":"BIGINT"}},"function":"GREATER_THAN","literals":[5]}"#
+                    .to_string(),
+            ]),
+            column_masking: None,
+        },
+    );
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+    let builder = table.new_read_builder();
+    builder
+        .new_scan()
+        .plan()
+        .await
+        .expect("a parseable row filter should allow planning a (filtered) read");
+    // ... but paths that bypass the row filter stay strictly fail-closed.
+    let err = table
+        .new_vector_search_builder()
+        .execute()
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("query-auth.enabled"),
+        "search must stay fail-closed for a filtered user, got: {err}"
+    );
+
+    // An unparseable filter fails the plan and keeps the table fail-closed.
+    ctx.server.set_auth_response(
+        "default",
+        "qa",
+        AuthTableQueryResponse {
+            filter: Some(vec!["{\"kind\":\"CUSTOM\"}".to_string()]),
+            column_masking: None,
+        },
+    );
+    let fresh = ctx.catalog.get_table(&identifier).await.unwrap();
+    assert!(fresh.new_read_builder().new_scan().plan().await.is_err());
+
+    // Parseable column masking grants a (masked) read; a caller predicate on
+    // the masked column is rejected (it would leak the raw value).
+    ctx.server.set_auth_response(
+        "default",
+        "qa",
+        AuthTableQueryResponse {
+            filter: None,
+            column_masking: Some(HashMap::from([(
+                "id".to_string(),
+                "{\"name\":\"NULL\"}".to_string(),
+            )])),
+        },
+    );
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
+    let builder = table.new_read_builder();
+    builder.new_scan().plan().await.expect("masked read plans");
+    // A caller predicate on a masked column fails closed at plan time (pruning
+    // on its raw value would leak it); the same guard runs again in `to_arrow`.
+    let mut filtered = table.new_read_builder();
+    filtered.with_filter(
+        PredicateBuilder::new(table.schema().fields())
+            .equal("id", Datum::Long(1))
+            .unwrap(),
+    );
+    let Err(err) = filtered.new_scan().plan().await else {
+        panic!("a caller predicate on a masked column must fail closed");
+    };
+    assert!(
+        err.to_string().contains("masked column"),
+        "a caller predicate on a masked column must fail closed, got: {err}"
+    );
+
+    // Every plan re-authorizes (like Java): revoking down to an unparseable
+    // grant fails the plan, and a read without a stamped grant stays closed.
+    ctx.server.set_auth_response(
+        "default",
+        "qa",
+        AuthTableQueryResponse {
+            filter: Some(vec!["{\"kind\":\"CUSTOM\"}".to_string()]),
+            column_masking: None,
+        },
+    );
+    assert!(table.new_read_builder().new_scan().plan().await.is_err());
 }
 
 #[tokio::test]

--- a/crates/paimon/tests/rest_catalog_test.rs
+++ b/crates/paimon/tests/rest_catalog_test.rs
@@ -666,37 +666,88 @@ async fn test_catalog_get_table() {
 /// The grant is scoped to the columns the plan requested (like Java passing
 /// `readType.getFieldNames()`): a wider read against a scoped grant fails
 /// closed until it re-plans.
+#[cfg(not(windows))]
 #[tokio::test]
 async fn test_query_auth_grant_scoped_to_planned_columns() {
-    let ctx = setup_catalog(vec!["default"]).await;
-    let schema = Schema::builder()
-        .column("id", DataType::BigInt(BigIntType::new()))
-        .column("name", DataType::VarChar(VarCharType::new(255).unwrap()))
-        .option("query-auth.enabled", "true")
-        .build()
+    let tmp = tempfile::tempdir().unwrap();
+    let warehouse = format!("file://{}", tmp.path().display());
+
+    // Real data, so the scoped plan actually produces splits to assert on.
+    let mut fs_options = Options::new();
+    fs_options.set(CatalogOptions::WAREHOUSE, &warehouse);
+    let fs_catalog = FileSystemCatalog::new(fs_options).expect("create filesystem catalog");
+    fs_catalog
+        .create_database("default", true, HashMap::new())
+        .await
         .unwrap();
+    let columns = || {
+        Schema::builder()
+            .column("id", DataType::BigInt(BigIntType::new()))
+            .column("name", DataType::VarChar(VarCharType::new(255).unwrap()))
+            .option("bucket", "1")
+            .option("bucket-key", "id")
+    };
+    let identifier = Identifier::new("default", "qa_scope");
+    fs_catalog
+        .create_table(&identifier, columns().build().unwrap(), false)
+        .await
+        .unwrap();
+    let writer = fs_catalog.get_table(&identifier).await.unwrap();
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", ArrowDataType::Int64, true),
+        ArrowField::new("name", ArrowDataType::Utf8, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(Int64Array::from(vec![1i64, 2])),
+            Arc::new(arrow_array::StringArray::from(vec!["a", "b"])),
+        ],
+    )
+    .unwrap();
+    write_batch(&writer, batch, "u1").await;
+
+    let ctx = setup_catalog(vec!["default"]).await;
     ctx.server.add_table_with_schema(
         "default",
         "qa_scope",
-        schema,
-        "file:///tmp/test_warehouse/default.db/qa_scope",
+        columns()
+            .option("query-auth.enabled", "true")
+            .build()
+            .unwrap(),
+        &format!("{warehouse}/default.db/qa_scope"),
     );
-    let table = ctx
-        .catalog
-        .get_table(&Identifier::new("default", "qa_scope"))
-        .await
-        .unwrap();
+    let table = ctx.catalog.get_table(&identifier).await.unwrap();
 
     // Plan a projection of {id}: the grant is scoped to that column and stamped
     // on this plan's splits (not a shared slot on the table).
     let mut projected = table.new_read_builder();
     projected.with_projection(&["id"]).unwrap();
-    projected.new_scan().plan().await.unwrap();
+    let scoped_plan = projected.new_scan().plan().await.unwrap();
+    assert!(
+        !scoped_plan.splits().is_empty(),
+        "the scoped plan must produce splits for this assertion to mean anything"
+    );
+    assert!(
+        projected
+            .new_read()
+            .unwrap()
+            .to_arrow(scoped_plan.splits())
+            .is_ok(),
+        "the planned projection must read under its own grant"
+    );
 
-    // The {id} plan's scoped grant lives on its own splits, so it cannot leak
-    // to a separate full-table read (per-query, no shared mutable slot). Reading
-    // real splits that carry no grant fails closed — covered by the read_builder
-    // unit tests, which can build such a split directly.
+    // The grant rides on the splits it was planned with, so handing those
+    // splits to a wider read must fail closed rather than widen the scope.
+    let wide = table.new_read_builder().new_read().unwrap();
+    match wide.to_arrow(scoped_plan.splits()) {
+        Err(paimon::Error::Unsupported { message }) => assert!(
+            message.contains("outside the authorized set"),
+            "unexpected rejection: {message}"
+        ),
+        Ok(_) => panic!("a wider read must not run under the {{id}} plan's scoped grant"),
+        Err(e) => panic!("unexpected error: {e}"),
+    }
 
     // A separate full-table read re-authorizes for all columns when it plans.
     table.new_read_builder().new_scan().plan().await.unwrap();


### PR DESCRIPTION
  ### Purpose

  Apply the per-user query-auth grant on the read path. Since #447 the client fails closed on every `query-auth.enabled` table; with this change a granted read goes through: the row filter and column masking
  returned by the REST catalog's `authTableQuery` are enforced exactly, and reads the grant cannot cover keep failing closed.

  ### Brief change log

  - Plan-time transparent authorization: `TableScan::plan` / `FormatTableScan::plan` / search `execute_scored` fetch and verify the grant (where Java applies `CatalogEnvironment.tableQueryAuth()`), scoped to the
  planned projection ∪ filter columns; wider reads fail closed until re-plan.
  - Exact enforcement in `TableRead::to_arrow`: the physical read is widened with the grant's filter columns and mask inputs, each batch is filtered on raw values, masked columns are overwritten, then
  re-projected to the caller's columns (mirrors apache/paimon#7034; cross-column masks per apache/paimon#8570).
  - Statistics stay safe: a row filter makes `Plan::row_counts_exact()` false — count-based limit pushdown is skipped and DataFusion cannot answer `COUNT(*)` from unfiltered statistics.
  - Fail-closed guards kept: unparseable grant, caller predicate on a masked column (value oracle), unauthorized columns, dynamic-option override.