### PR TITLE
feat(datafusion): add BlobDescriptor SQL helper functions

### DIFF
--- a/crates/integrations/datafusion/src/blob_descriptor_functions.rs
+++ b/crates/integrations/datafusion/src/blob_descriptor_functions.rs
@@ -1,0 +1,222 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    Array, BinaryArray, BinaryBuilder, BinaryViewArray, LargeBinaryArray, LargeStringArray,
+    StringArray, StringBuilder, StringViewArray,
+};
+use datafusion::arrow::datatypes::DataType as ArrowDataType;
+use datafusion::common::types::logical_binary;
+use datafusion::common::utils::take_function_args;
+use datafusion::common::{DataFusionError, Result as DFResult, ScalarValue};
+use datafusion::logical_expr::{
+    Coercion, ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
+    TypeSignatureClass, Volatility,
+};
+use datafusion::prelude::SessionContext;
+use paimon::spec::BlobDescriptor;
+
+use crate::error::to_datafusion_error;
+
+const PATH_TO_DESCRIPTOR: &str = "path_to_descriptor";
+const DESCRIPTOR_TO_STRING: &str = "descriptor_to_string";
+
+pub(crate) fn register_blob_descriptor_functions(ctx: &SessionContext) {
+    ctx.register_udf(ScalarUDF::from(PathToDescriptorFunc::new()));
+    ctx.register_udf(ScalarUDF::from(DescriptorToStringFunc::new()));
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct PathToDescriptorFunc {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl PathToDescriptorFunc {
+    fn new() -> Self {
+        Self {
+            signature: Signature::string(1, Volatility::Immutable),
+            aliases: vec!["sys.path_to_descriptor".to_string()],
+        }
+    }
+}
+
+impl ScalarUDFImpl for PathToDescriptorFunc {
+    fn name(&self) -> &str {
+        PATH_TO_DESCRIPTOR
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[ArrowDataType]) -> DFResult<ArrowDataType> {
+        Ok(ArrowDataType::Binary)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        let [input] = take_function_args(self.name(), args.args)?;
+        match input {
+            ColumnarValue::Scalar(value) => path_scalar(value),
+            ColumnarValue::Array(array) => path_array(array.as_ref()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DescriptorToStringFunc {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl DescriptorToStringFunc {
+    fn new() -> Self {
+        Self {
+            signature: Signature::coercible(
+                vec![Coercion::new_exact(TypeSignatureClass::Native(
+                    logical_binary(),
+                ))],
+                Volatility::Immutable,
+            ),
+            aliases: vec!["sys.descriptor_to_string".to_string()],
+        }
+    }
+}
+
+impl ScalarUDFImpl for DescriptorToStringFunc {
+    fn name(&self) -> &str {
+        DESCRIPTOR_TO_STRING
+    }
+
+    fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[ArrowDataType]) -> DFResult<ArrowDataType> {
+        Ok(ArrowDataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        let [input] = take_function_args(self.name(), args.args)?;
+        match input {
+            ColumnarValue::Scalar(value) => descriptor_scalar(value),
+            ColumnarValue::Array(array) => descriptor_array(array.as_ref()),
+        }
+    }
+}
+
+fn serialize_path(path: &str) -> Vec<u8> {
+    BlobDescriptor::new(path.to_string(), 0, -1).serialize()
+}
+
+fn descriptor_string(bytes: &[u8]) -> DFResult<String> {
+    BlobDescriptor::deserialize(bytes)
+        .map(|descriptor| descriptor.to_string())
+        .map_err(to_datafusion_error)
+}
+
+fn path_scalar(value: ScalarValue) -> DFResult<ColumnarValue> {
+    let path = match value {
+        ScalarValue::Utf8(path) | ScalarValue::LargeUtf8(path) | ScalarValue::Utf8View(path) => {
+            path
+        }
+        ScalarValue::Null => None,
+        other => return unexpected_type(PATH_TO_DESCRIPTOR, &other.data_type()),
+    };
+    Ok(ColumnarValue::Scalar(ScalarValue::Binary(
+        path.as_deref().map(serialize_path),
+    )))
+}
+
+fn path_array(input: &dyn Array) -> DFResult<ColumnarValue> {
+    if let Some(values) = input.as_any().downcast_ref::<StringArray>() {
+        return Ok(descriptor_array_from_paths(values.iter()));
+    }
+    if let Some(values) = input.as_any().downcast_ref::<LargeStringArray>() {
+        return Ok(descriptor_array_from_paths(values.iter()));
+    }
+    if let Some(values) = input.as_any().downcast_ref::<StringViewArray>() {
+        return Ok(descriptor_array_from_paths(values.iter()));
+    }
+    unexpected_type(PATH_TO_DESCRIPTOR, input.data_type())
+}
+
+fn descriptor_array_from_paths<'a>(paths: impl Iterator<Item = Option<&'a str>>) -> ColumnarValue {
+    let mut builder = BinaryBuilder::new();
+    for path in paths {
+        match path {
+            Some(path) => builder.append_value(serialize_path(path)),
+            None => builder.append_null(),
+        }
+    }
+    ColumnarValue::Array(Arc::new(builder.finish()))
+}
+
+fn descriptor_scalar(value: ScalarValue) -> DFResult<ColumnarValue> {
+    let bytes = match value {
+        ScalarValue::Binary(bytes)
+        | ScalarValue::LargeBinary(bytes)
+        | ScalarValue::BinaryView(bytes) => bytes,
+        ScalarValue::Null => None,
+        other => return unexpected_type(DESCRIPTOR_TO_STRING, &other.data_type()),
+    };
+    Ok(ColumnarValue::Scalar(ScalarValue::Utf8(
+        bytes.as_deref().map(descriptor_string).transpose()?,
+    )))
+}
+
+fn descriptor_array(input: &dyn Array) -> DFResult<ColumnarValue> {
+    if let Some(values) = input.as_any().downcast_ref::<BinaryArray>() {
+        return strings_from_descriptors(values.iter());
+    }
+    if let Some(values) = input.as_any().downcast_ref::<LargeBinaryArray>() {
+        return strings_from_descriptors(values.iter());
+    }
+    if let Some(values) = input.as_any().downcast_ref::<BinaryViewArray>() {
+        return strings_from_descriptors(values.iter());
+    }
+    unexpected_type(DESCRIPTOR_TO_STRING, input.data_type())
+}
+
+fn strings_from_descriptors<'a>(
+    descriptors: impl Iterator<Item = Option<&'a [u8]>>,
+) -> DFResult<ColumnarValue> {
+    let mut builder = StringBuilder::new();
+    for bytes in descriptors {
+        match bytes {
+            Some(bytes) => builder.append_value(descriptor_string(bytes)?),
+            None => builder.append_null(),
+        }
+    }
+    Ok(ColumnarValue::Array(Arc::new(builder.finish())))
+}
+
+fn unexpected_type<T>(function: &str, data_type: &ArrowDataType) -> DFResult<T> {
+    Err(DataFusionError::Execution(format!(
+        "{function} received unexpected argument type {data_type}"
+    )))
+}

--- a/crates/integrations/datafusion/src/lib.rs
+++ b/crates/integrations/datafusion/src/lib.rs
@@ -36,6 +36,7 @@
 //! This version supports partition predicate pushdown by extracting
 //! translatable partition-only conjuncts from DataFusion filters.
 
+mod blob_descriptor_functions;
 mod blob_reader;
 mod blob_view;
 mod catalog;

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -117,6 +117,7 @@ impl SQLContext {
             ))
             .build();
         let ctx = SessionContext::new_with_state(state);
+        crate::blob_descriptor_functions::register_blob_descriptor_functions(&ctx);
         crate::variant_functions::register_variant_functions(&ctx);
         Self {
             ctx,

--- a/crates/integrations/datafusion/tests/blob_descriptor_functions.rs
+++ b/crates/integrations/datafusion/tests/blob_descriptor_functions.rs
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion::arrow::array::{Array, BinaryArray, StringArray};
+use paimon_datafusion::SQLContext;
+
+const JAVA_V2_HEX: &str =
+    "0243534544424f4c420d00000066696c653a2f2f2f746d702f610000000000000000ffffffffffffffff";
+const JAVA_V2_STRING: &str = "BlobDescriptor{version=2, uri='file:///tmp/a', offset=0, length=-1}";
+const JAVA_V1_HEX: &str = "010a0000002f746573742f706174686400000000000000c800000000000000";
+const JAVA_V1_STRING: &str = "BlobDescriptor{version=1, uri='/test/path', offset=100, length=200}";
+
+fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+async fn query_error(ctx: &SQLContext, sql: &str) -> String {
+    match ctx.sql(sql).await {
+        Err(error) => error.to_string(),
+        Ok(dataframe) => dataframe
+            .collect()
+            .await
+            .expect_err("query should fail")
+            .to_string(),
+    }
+}
+
+#[tokio::test]
+async fn test_blob_descriptor_functions_are_registered_with_aliases_and_java_format() {
+    let ctx = SQLContext::new();
+    let batches = ctx
+        .sql(
+            "SELECT \
+             path_to_descriptor('file:///tmp/a'), \
+             sys.path_to_descriptor('file:///tmp/a'), \
+             descriptor_to_string(path_to_descriptor('file:///tmp/a')), \
+             sys.descriptor_to_string(sys.path_to_descriptor('file:///tmp/a'))",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let batch = &batches[0];
+    for column in 0..2 {
+        let descriptors = batch
+            .column(column)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        assert_eq!(to_hex(descriptors.value(0)), JAVA_V2_HEX);
+    }
+    for column in 2..4 {
+        let strings = batch
+            .column(column)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(strings.value(0), JAVA_V2_STRING);
+    }
+}
+
+#[tokio::test]
+async fn test_blob_descriptor_functions_propagate_nulls() {
+    let ctx = SQLContext::new();
+    let batches = ctx
+        .sql(
+            "SELECT id, \
+             path_to_descriptor(path), \
+             descriptor_to_string(path_to_descriptor(path)) \
+             FROM (VALUES \
+               (1, 'file:///tmp/a'), \
+               (2, CAST(NULL AS VARCHAR)), \
+               (3, 'file:///tmp/b') \
+             ) AS inputs(id, path) \
+             ORDER BY id",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let batch = &batches[0];
+    let descriptors = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .unwrap();
+    let strings = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(to_hex(descriptors.value(0)), JAVA_V2_HEX);
+    assert!(descriptors.is_null(1));
+    assert!(strings.is_null(1));
+    assert_eq!(
+        strings.value(2),
+        "BlobDescriptor{version=2, uri='file:///tmp/b', offset=0, length=-1}"
+    );
+
+    let alias_nulls = ctx
+        .sql(
+            "SELECT \
+             path_to_descriptor(NULL), \
+             sys.path_to_descriptor(NULL), \
+             descriptor_to_string(NULL), \
+             sys.descriptor_to_string(NULL)",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let batch = &alias_nulls[0];
+    for column in 0..4 {
+        assert!(batch.column(column).is_null(0));
+    }
+}
+
+#[tokio::test]
+async fn test_descriptor_to_string_supports_java_v1() {
+    let ctx = SQLContext::new();
+    let sql = format!(
+        "SELECT descriptor_to_string(X'{JAVA_V1_HEX}'), \
+         sys.descriptor_to_string(X'{JAVA_V1_HEX}')"
+    );
+    let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
+    let batch = &batches[0];
+    for column in 0..2 {
+        let strings = batch
+            .column(column)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(strings.value(0), JAVA_V1_STRING);
+    }
+}
+
+#[tokio::test]
+async fn test_blob_descriptor_functions_reject_invalid_arguments() {
+    let ctx = SQLContext::new();
+    for (sql, function) in [
+        ("SELECT path_to_descriptor()", "path_to_descriptor"),
+        ("SELECT path_to_descriptor(1)", "path_to_descriptor"),
+        (
+            "SELECT descriptor_to_string('not binary')",
+            "descriptor_to_string",
+        ),
+        (
+            "SELECT descriptor_to_string(X'00', X'01')",
+            "descriptor_to_string",
+        ),
+    ] {
+        let error = query_error(&ctx, sql).await;
+        assert!(
+            error.contains(function),
+            "expected error for {function}, got: {error}"
+        );
+    }
+
+    let error = query_error(&ctx, "SELECT descriptor_to_string(X'00')").await;
+    assert!(
+        error.contains("BlobDescriptor bytes too short"),
+        "unexpected malformed descriptor error: {error}"
+    );
+}

--- a/crates/paimon/src/spec/blob_descriptor.rs
+++ b/crates/paimon/src/spec/blob_descriptor.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::{Display, Formatter};
+
 use crate::Error;
 
 const CURRENT_VERSION: u8 = 2;
@@ -26,6 +28,16 @@ pub struct BlobDescriptor {
     uri: String,
     offset: i64,
     length: i64,
+}
+
+impl Display for BlobDescriptor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "BlobDescriptor{{version={}, uri='{}', offset={}, length={}}}",
+            self.version, self.uri, self.offset, self.length
+        )
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -219,6 +231,15 @@ mod tests {
         let bytes = desc.serialize();
         let deserialized = BlobDescriptor::deserialize(&bytes).unwrap();
         assert_eq!(desc, deserialized);
+    }
+
+    #[test]
+    fn test_display_matches_java() {
+        let desc = BlobDescriptor::new("file:///tmp/a".to_string(), 0, -1);
+        assert_eq!(
+            desc.to_string(),
+            "BlobDescriptor{version=2, uri='file:///tmp/a', offset=0, length=-1}"
+        );
     }
 
     #[test]

--- a/docs/src/sql.md
+++ b/docs/src/sql.md
@@ -68,13 +68,14 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-`SQLContext::new` creates a session context with the Paimon relation planner
-pre-registered. Use `register_catalog(...).await` to add one or more Paimon
-catalogs; registering a catalog also registers the built-in scalar function
-`blob_view` (alias `sys.blob_view`) and the built-in table-valued functions
-(`vector_search`, `hybrid_search`, and `full_text_search` when the `fulltext`
-feature is enabled) against it. It also manages session-scoped dynamic options
-internally for `SET`/`RESET` support.
+`SQLContext::new` creates a session context with the Paimon relation planner and
+the catalog-independent `path_to_descriptor` and `descriptor_to_string` scalar
+functions pre-registered. Use `register_catalog(...).await` to add one or more
+Paimon catalogs; registering a catalog also registers the built-in scalar
+function `blob_view` (alias `sys.blob_view`) and the built-in table-valued
+functions (`vector_search`, `hybrid_search`, and `full_text_search` when the
+`fulltext` feature is enabled) against it. It also manages session-scoped
+dynamic options internally for `SET`/`RESET` support.
 
 ### REST Catalog Views and SQL Functions
 
@@ -299,6 +300,25 @@ For serialized `BlobDescriptor` values supplied by another Paimon engine,
 The offset must be non-negative, and lengths below `-1` are invalid.
 
 The same directives are supported by `ALTER TABLE ... ADD COLUMN`.
+
+### Blob Descriptor Functions
+
+`path_to_descriptor(path)` converts a string path into Java-compatible
+`BlobDescriptor` bytes with offset `0` and length `-1`. Its alias is
+`sys.path_to_descriptor(path)`. The function only serializes the path; it does
+not access the referenced object or validate that it exists.
+
+`descriptor_to_string(descriptor)` converts serialized descriptor bytes to the
+same string representation used by Java Paimon. Its alias is
+`sys.descriptor_to_string(descriptor)`. Invalid descriptor bytes return an
+error. Both functions return `NULL` for `NULL` input.
+
+```sql
+SELECT sys.descriptor_to_string(
+    sys.path_to_descriptor('file:///tmp/image.png')
+);
+-- BlobDescriptor{version=2, uri='file:///tmp/image.png', offset=0, length=-1}
+```
 
 ### Blob View
 


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
DataFusion already had `BlobDescriptor` serialization and resolution support, but `SQLContext` did not expose the Java-compatible `path_to_descriptor` and `descriptor_to_string` SQL APIs. Queries using either the canonical names or `sys.*` aliases therefore failed as unknown functions.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - add `path_to_descriptor` and `descriptor_to_string` with `sys.*` aliases
  - register both functions in `SQLContext::new`
  - match Java serialization, string formatting, NULL, and invalid-input behavior
  - document the SQL APIs

### Tests

<!-- List unit tests or integration cases to verify this change -->

  - `cargo fmt --all -- --check`
  - `cargo clippy --all-targets --workspace --features fulltext,vortex -- -D warnings`
  - `cargo test -p paimon --lib blob_descriptor`
  - `cargo test -p paimon-datafusion --test blob_descriptor_functions --test blob_tests --test sql_context_tests`

### API and Format

<!-- Does this change affect API or storage format -->

Adds four SQL function names and `Display` for `BlobDescriptor`. No storage format change.

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->

Updated `docs/src/sql.md`.
