### PR TITLE
fix(datafusion): remove unneeded wildcard pattern for clippy 1.97.0

### DIFF
--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -1038,10 +1038,7 @@ impl SQLContext {
                 AlterTableOperation::AddColumn { column_def, .. } => {
                     changes.push(column_def_to_add_column(column_def)?);
                 }
-                AlterTableOperation::DropColumn {
-                    column_names,
-                    ..
-                } => {
+                AlterTableOperation::DropColumn { column_names, .. } => {
                     for col in column_names {
                         changes.push(SchemaChange::drop_column(col.value.clone()));
                     }

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -1040,7 +1040,6 @@ impl SQLContext {
                 }
                 AlterTableOperation::DropColumn {
                     column_names,
-                    if_exists: _,
                     ..
                 } => {
                     for col in column_names {


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
Fix the `unneeded_wildcard_pattern` clippy warning introduced in Rust 1.97.0. 

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Remove the redundant `if_exists: _` field in the `AlterTableOperation::DropColumn` match arm, as it is already covered by the `..` pattern

### Tests

<!-- List unit tests or integration cases to verify this change -->
No new tests needed — behavior is unchanged.

### API and Format

<!-- Does this change affect API or storage format -->
No changes.

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
No documentation update needed.
