### PR TITLE
fix(core): resolve storage config aliases to canonical keys

### DIFF
--- a/crates/paimon/src/io/storage_azdls.rs
+++ b/crates/paimon/src/io/storage_azdls.rs
@@ -32,21 +32,23 @@ const AZURE_ACCOUNT_KEY: &str = "azure.account-key";
 const AZURE_SAS_TOKEN: &str = "azure.sas-token";
 
 const CONFIG_PREFIXES: &[&str] = &["fs.azure.", "fs.abfs.", "abfs.", "abfss.", "azure."];
-const MIRRORED_KEYS: &[(&str, &str)] = &[
-    ("azure.account-name", "azure.account.name"),
-    ("azure.account_name", "azure.account.name"),
-    ("azure.account-key", "azure.account.key"),
-    ("azure.account_key", "azure.account.key"),
-    ("azure.sas-token", "azure.sas.token"),
-    ("azure.sas_token", "azure.sas.token"),
-    ("azure.client-id", "azure.client.id"),
-    ("azure.client_id", "azure.client.id"),
-    ("azure.client-secret", "azure.client.secret"),
-    ("azure.client_secret", "azure.client.secret"),
-    ("azure.tenant-id", "azure.tenant.id"),
-    ("azure.tenant_id", "azure.tenant.id"),
-    ("azure.authority-host", "azure.authority.host"),
-    ("azure.authority_host", "azure.authority.host"),
+// Aliases for each canonical key are ordered from highest to lowest priority.
+// An explicitly supplied canonical key always takes precedence over its aliases.
+const KEY_ALIASES: &[(&str, &str)] = &[
+    ("azure.account.name", "azure.account-name"),
+    ("azure.account_name", "azure.account-name"),
+    ("azure.account.key", "azure.account-key"),
+    ("azure.account_key", "azure.account-key"),
+    ("azure.sas.token", "azure.sas-token"),
+    ("azure.sas_token", "azure.sas-token"),
+    ("azure.client.id", "azure.client-id"),
+    ("azure.client_id", "azure.client-id"),
+    ("azure.client.secret", "azure.client-secret"),
+    ("azure.client_secret", "azure.client-secret"),
+    ("azure.tenant.id", "azure.tenant-id"),
+    ("azure.tenant_id", "azure.tenant-id"),
+    ("azure.authority.host", "azure.authority-host"),
+    ("azure.authority_host", "azure.authority-host"),
 ];
 
 #[derive(Debug, Clone)]
@@ -56,7 +58,7 @@ pub struct AzdlsStorageConfig {
 }
 
 pub(crate) fn azdls_config_parse(props: HashMap<String, String>) -> Result<AzdlsStorageConfig> {
-    let normalized = normalize_storage_config(props, CONFIG_PREFIXES, "azure.", MIRRORED_KEYS);
+    let normalized = normalize_storage_config(props, CONFIG_PREFIXES, "azure.", KEY_ALIASES);
     let config = config_from_normalized(&normalized);
 
     Ok(AzdlsStorageConfig { config, normalized })
@@ -316,6 +318,44 @@ mod tests {
         assert_eq!(cfg.config.account_name.as_deref(), Some("account"));
         assert_eq!(cfg.config.client_secret.as_deref(), Some("secret"));
         assert_eq!(cfg.config.tenant_id.as_deref(), Some("tenant"));
+    }
+
+    #[test]
+    fn test_azdls_config_parse_underscore_aliases() {
+        type ConfigValue = for<'a> fn(&'a AzdlsConfig) -> Option<&'a str>;
+
+        let cases: &[(&str, ConfigValue)] = &[
+            ("azure.account_name", |cfg| cfg.account_name.as_deref()),
+            ("azure.account_key", |cfg| cfg.account_key.as_deref()),
+            ("azure.sas_token", |cfg| cfg.sas_token.as_deref()),
+            ("azure.client_id", |cfg| cfg.client_id.as_deref()),
+            ("azure.client_secret", |cfg| cfg.client_secret.as_deref()),
+            ("azure.tenant_id", |cfg| cfg.tenant_id.as_deref()),
+            ("azure.authority_host", |cfg| cfg.authority_host.as_deref()),
+        ];
+
+        for (alias, config_value) in cases {
+            let cfg = azdls_config_parse(make_props(&[(alias, "alias-value")])).unwrap();
+            assert_eq!(config_value(&cfg.config), Some("alias-value"), "{alias}");
+        }
+    }
+
+    #[test]
+    fn test_azdls_config_alias_priority() {
+        let cfg = azdls_config_parse(make_props(&[
+            ("azure.account-name", "canonical"),
+            ("azure.account.name", "dotted"),
+            ("azure.account_name", "underscore"),
+        ]))
+        .unwrap();
+        assert_eq!(cfg.config.account_name.as_deref(), Some("canonical"));
+
+        let cfg = azdls_config_parse(make_props(&[
+            ("azure.account.name", "dotted"),
+            ("azure.account_name", "underscore"),
+        ]))
+        .unwrap();
+        assert_eq!(cfg.config.account_name.as_deref(), Some("dotted"));
     }
 
     #[test]

--- a/crates/paimon/src/io/storage_config.rs
+++ b/crates/paimon/src/io/storage_config.rs
@@ -21,7 +21,7 @@ pub(super) fn normalize_storage_config(
     props: HashMap<String, String>,
     config_prefixes: &[&str],
     canonical_prefix: &str,
-    mirrored_keys: &[(&str, &str)],
+    key_aliases: &[(&str, &str)],
 ) -> HashMap<String, String> {
     let mut result = HashMap::new();
 
@@ -33,27 +33,15 @@ pub(super) fn normalize_storage_config(
         }
     }
 
-    let mirrored_additions: Vec<(String, String)> = mirrored_keys
-        .iter()
-        .flat_map(|(a, b)| {
-            let mut pairs = Vec::new();
-
-            if !result.contains_key(*b) {
-                if let Some(v) = result.get(*a) {
-                    pairs.push((b.to_string(), v.clone()));
-                }
-            }
-            if !result.contains_key(*a) {
-                if let Some(v) = result.get(*b) {
-                    pairs.push((a.to_string(), v.clone()));
-                }
-            }
-            pairs
-        })
-        .collect();
-
-    for (k, v) in mirrored_additions {
-        result.insert(k, v);
+    // Canonical keys always win. Aliases for the same canonical key are
+    // checked in declaration order, so callers can define their priority.
+    for (alias, canonical) in key_aliases {
+        if result.contains_key(*canonical) {
+            continue;
+        }
+        if let Some(value) = result.get(*alias).cloned() {
+            result.insert(canonical.to_string(), value);
+        }
     }
 
     result

--- a/crates/paimon/src/io/storage_cos.rs
+++ b/crates/paimon/src/io/storage_cos.rs
@@ -31,8 +31,8 @@ const COS_SECRET_ID: &str = "fs.cosn.userinfo.secretId";
 const COS_SECRET_KEY: &str = "fs.cosn.userinfo.secretKey";
 
 const CONFIG_PREFIXES: &[&str] = &["fs.cosn.", "cosn.", "cos."];
-const MIRRORED_KEYS: &[(&str, &str)] = &[
-    ("fs.cosn.endpoint", "fs.cosn.userinfo.endpoint"),
+const KEY_ALIASES: &[(&str, &str)] = &[
+    ("fs.cosn.userinfo.endpoint", "fs.cosn.endpoint"),
     ("fs.cosn.secret_id", "fs.cosn.userinfo.secretId"),
     ("fs.cosn.secret-id", "fs.cosn.userinfo.secretId"),
     ("fs.cosn.secret_key", "fs.cosn.userinfo.secretKey"),
@@ -40,7 +40,7 @@ const MIRRORED_KEYS: &[(&str, &str)] = &[
 ];
 
 pub(crate) fn cos_config_parse(props: HashMap<String, String>) -> Result<CosConfig> {
-    let normalized = normalize_storage_config(props, CONFIG_PREFIXES, "fs.cosn.", MIRRORED_KEYS);
+    let normalized = normalize_storage_config(props, CONFIG_PREFIXES, "fs.cosn.", KEY_ALIASES);
 
     let cfg = CosConfig {
         endpoint: normalized.get(COS_ENDPOINT).cloned(),

--- a/crates/paimon/src/io/storage_gcs.rs
+++ b/crates/paimon/src/io/storage_gcs.rs
@@ -33,34 +33,31 @@ const GCS_SERVICE_ACCOUNT: &str = "gcs.service-account";
 const GCS_ALLOW_ANONYMOUS: &str = "gcs.allow-anonymous";
 
 const CONFIG_PREFIXES: &[&str] = &["fs.gs.", "fs.gcs.", "gs.", "gcs."];
-const MIRRORED_KEYS: &[(&str, &str)] = &[
-    ("gcs.credential-path", "gcs.google_application_credentials"),
-    ("gcs.credential-path", "gcs.google-application-credentials"),
-    ("gcs.credential-path", "gcs.application-credentials"),
-    ("gcs.credential", "gcs.google_service_account_key"),
-    ("gcs.credential", "gcs.google-service-account-key"),
-    ("gcs.credential", "gcs.service-account-key"),
-    ("gcs.credential", "gcs.service_account_key"),
-    ("gcs.service-account", "gcs.google_service_account"),
-    ("gcs.service-account", "gcs.google-service-account"),
-    ("gcs.service-account", "gcs.service_account"),
-    ("gcs.predefined-acl", "gcs.predefined_acl"),
-    ("gcs.default-storage-class", "gcs.default_storage_class"),
-    ("gcs.allow-anonymous", "gcs.google_skip_signature"),
-    ("gcs.allow-anonymous", "gcs.google-skip-signature"),
-    ("gcs.allow_anonymous", "gcs.google_skip_signature"),
-    ("gcs.allow-anonymous", "gcs.allow_anonymous"),
-    ("gcs.allow-anonymous", "gcs.skip-signature"),
-    ("gcs.allow-anonymous", "gcs.skip_signature"),
-    ("gcs.skip-signature", "gcs.google_skip_signature"),
-    ("gcs.skip_signature", "gcs.google_skip_signature"),
-    ("gcs.disable-vm-metadata", "gcs.disable_vm_metadata"),
-    ("gcs.disable-config-load", "gcs.disable_config_load"),
+const KEY_ALIASES: &[(&str, &str)] = &[
+    ("gcs.google_application_credentials", "gcs.credential-path"),
+    ("gcs.google-application-credentials", "gcs.credential-path"),
+    ("gcs.application-credentials", "gcs.credential-path"),
+    ("gcs.google_service_account_key", "gcs.credential"),
+    ("gcs.google-service-account-key", "gcs.credential"),
+    ("gcs.service-account-key", "gcs.credential"),
+    ("gcs.service_account_key", "gcs.credential"),
+    ("gcs.google_service_account", "gcs.service-account"),
+    ("gcs.google-service-account", "gcs.service-account"),
+    ("gcs.service_account", "gcs.service-account"),
+    ("gcs.predefined_acl", "gcs.predefined-acl"),
+    ("gcs.default_storage_class", "gcs.default-storage-class"),
+    ("gcs.google_skip_signature", "gcs.allow-anonymous"),
+    ("gcs.google-skip-signature", "gcs.allow-anonymous"),
+    ("gcs.allow_anonymous", "gcs.allow-anonymous"),
+    ("gcs.skip-signature", "gcs.allow-anonymous"),
+    ("gcs.skip_signature", "gcs.allow-anonymous"),
+    ("gcs.disable_vm_metadata", "gcs.disable-vm-metadata"),
+    ("gcs.disable_config_load", "gcs.disable-config-load"),
 ];
 
 #[allow(clippy::field_reassign_with_default)]
 pub(crate) fn gcs_config_parse(props: HashMap<String, String>) -> Result<GcsConfig> {
-    let normalized = normalize_storage_config(props, CONFIG_PREFIXES, "gcs.", MIRRORED_KEYS);
+    let normalized = normalize_storage_config(props, CONFIG_PREFIXES, "gcs.", KEY_ALIASES);
 
     let mut cfg = GcsConfig::default();
     cfg.endpoint = normalized.get(GCS_ENDPOINT).cloned();

--- a/crates/paimon/src/io/storage_obs.rs
+++ b/crates/paimon/src/io/storage_obs.rs
@@ -31,7 +31,7 @@ const OBS_ACCESS_KEY_ID: &str = "fs.obs.access.key";
 const OBS_SECRET_ACCESS_KEY: &str = "fs.obs.secret.key";
 
 const CONFIG_PREFIXES: &[&str] = &["fs.obs.", "obs."];
-const MIRRORED_KEYS: &[(&str, &str)] = &[
+const KEY_ALIASES: &[(&str, &str)] = &[
     ("fs.obs.access-key-id", "fs.obs.access.key"),
     ("fs.obs.access_key_id", "fs.obs.access.key"),
     ("fs.obs.secret-access-key", "fs.obs.secret.key"),
@@ -40,7 +40,7 @@ const MIRRORED_KEYS: &[(&str, &str)] = &[
 
 #[allow(clippy::field_reassign_with_default)]
 pub(crate) fn obs_config_parse(props: HashMap<String, String>) -> Result<ObsConfig> {
-    let normalized = normalize_storage_config(props, CONFIG_PREFIXES, "fs.obs.", MIRRORED_KEYS);
+    let normalized = normalize_storage_config(props, CONFIG_PREFIXES, "fs.obs.", KEY_ALIASES);
 
     let mut cfg = ObsConfig::default();
     cfg.endpoint = normalized.get(OBS_ENDPOINT).cloned();

--- a/crates/paimon/src/io/storage_s3.rs
+++ b/crates/paimon/src/io/storage_s3.rs
@@ -63,14 +63,13 @@ const S3_REGION: &str = "s3.region";
 /// Reference: `S3FileIO.CONFIG_PREFIXES` in Java Paimon.
 const JAVA_CONFIG_PREFIXES: &[&str] = &["fs.s3a.", "s3a.", "s3."];
 
-/// Mirrored config keys — Java Paimon maps these interchangeably.
-/// Both directions are applied so users can use either form.
+/// External aliases mapped to the canonical keys read by [`S3Config`].
 ///
 /// Reference: `S3FileIO.MIRRORED_CONFIG_KEYS` in Java Paimon.
-const MIRRORED_KEYS: &[(&str, &str)] = &[
-    ("s3.access-key", "s3.access.key"),
-    ("s3.secret-key", "s3.secret.key"),
-    ("s3.path-style-access", "s3.path.style.access"),
+const KEY_ALIASES: &[(&str, &str)] = &[
+    ("s3.access.key", "s3.access-key"),
+    ("s3.secret.key", "s3.secret-key"),
+    ("s3.path.style.access", "s3.path-style-access"),
 ];
 
 /// Parse paimon catalog options into an [`S3Config`].
@@ -83,7 +82,7 @@ const MIRRORED_KEYS: &[(&str, &str)] = &[
 /// to path-style for S3-compatible stores like MinIO.
 #[allow(clippy::field_reassign_with_default)]
 pub(crate) fn s3_config_parse(props: HashMap<String, String>) -> Result<S3Config> {
-    let normalized = normalize_storage_config(props, JAVA_CONFIG_PREFIXES, "s3.", MIRRORED_KEYS);
+    let normalized = normalize_storage_config(props, JAVA_CONFIG_PREFIXES, "s3.", KEY_ALIASES);
 
     let mut cfg = S3Config::default();
 
@@ -186,7 +185,7 @@ mod tests {
             cfg.endpoint.as_deref(),
             Some("https://s3.eu-west-1.amazonaws.com")
         );
-        // `fs.s3a.access.key` → `s3.access.key`, then mirrored → `s3.access-key`
+        // `fs.s3a.access.key` → `s3.access.key`, then aliased → `s3.access-key`
         assert_eq!(cfg.access_key_id.as_deref(), Some("AKID2"));
         assert_eq!(cfg.secret_access_key.as_deref(), Some("SECRET2"));
     }
@@ -340,11 +339,9 @@ mod tests {
     }
 
     #[test]
-    fn test_mirrored_keys() {
-        // `s3.access.key` (dot form) should be mirrored from `s3.access-key` (dash form)
-        let props = make_props(&[("s3.access-key", "AKID")]);
-        let normalized =
-            normalize_storage_config(props, JAVA_CONFIG_PREFIXES, "s3.", MIRRORED_KEYS);
+    fn test_key_aliases() {
+        let props = make_props(&[("s3.access.key", "AKID")]);
+        let normalized = normalize_storage_config(props, JAVA_CONFIG_PREFIXES, "s3.", KEY_ALIASES);
         assert_eq!(
             normalized.get("s3.access.key").map(|s| s.as_str()),
             Some("AKID")


### PR DESCRIPTION
### Purpose

`normalize_storage_config` currently applies mirrored key pairs from a single
snapshot of the normalized properties. This cannot resolve aliases that require
more than one mirror step.

For Azure, underscore aliases are declared through a dotted intermediate key:

- `azure.account_name` → `azure.account.name`
- `azure.account.name` → `azure.account-name`

However, `AzdlsConfig` reads the hyphenated canonical key
`azure.account-name`. Because newly mirrored keys are not processed again,
`azure.account_name` is silently ignored. The same issue affects the other
declared Azure underscore aliases.

This change replaces symmetric mirroring with direct, ordered
`alias → canonical` mappings. It also defines deterministic precedence when
multiple forms are supplied:

1. An explicitly supplied canonical key
2. The first matching alias in declaration order

For Azure, dotted aliases are declared before underscore aliases, resulting in:

`canonical > dotted alias > underscore alias`

### Brief change log

- Change `normalize_storage_config` from symmetric one-pass mirroring to direct
  `alias → canonical` resolution.
- Preserve an explicitly supplied canonical value.
- Resolve multiple aliases in declaration order.
- Map every supported Azure dotted and underscore alias directly to the
  hyphenated key read by `AzdlsConfig`:
  - `account_name`
  - `account_key`
  - `sas_token`
  - `client_id`
  - `client_secret`
  - `tenant_id`
  - `authority_host`
- Update the S3, COS, OBS, and GCS alias tables to follow the same directional
  mapping contract.

### Tests

- Unit test `test_azdls_config_parse_underscore_aliases`
  (`storage_azdls.rs`): data-driven coverage for every declared Azure
  underscore alias and verification that each value reaches the corresponding
  `AzdlsConfig` field. **Fails on the pre-fix code.**
- Unit test `test_azdls_config_alias_priority` (`storage_azdls.rs`): verifies
  canonical keys take precedence over aliases and dotted aliases take
  precedence over underscore aliases.
- Existing storage configuration tests verify the directional alias conversion
  does not regress S3, COS, OBS, or GCS configuration parsing.
- Commands run locally:
  - `CARGO_INCREMENTAL=0 cargo test -p paimon --features storage-azdls --lib storage_azdls`
  - `CARGO_INCREMENTAL=0 cargo test -p paimon --no-default-features --features storage-s3,storage-cos,storage-azdls,storage-obs,storage-gcs --lib io::storage_`
  - `cargo fmt --all -- --check`
  - `git diff --check`

### API and Format

No public API or persisted data format changes.

Supported external storage configuration aliases now resolve directly to the
canonical keys consumed by each backend. When multiple forms of the same
setting are supplied, precedence is deterministic: the canonical key wins,
followed by aliases in declaration order.

### Documentation

No documentation changes required.
