### PR TITLE
fix(row): guard timestamp conversion against overflow from corrupt data

### DIFF
--- a/crates/paimon/src/arrow/format/row.rs
+++ b/crates/paimon/src/arrow/format/row.rs
@@ -1777,11 +1777,27 @@ fn read_timestamp_value(input: &mut BlockInput<'_>, unit: TimeUnit) -> crate::Re
         TimeUnit::Millisecond => millis,
         TimeUnit::Microsecond => {
             let nanos = i64::from(input.read_var_u32()?);
-            millis * 1_000 + nanos / 1_000
+            millis
+                .checked_mul(1_000)
+                .and_then(|v| v.checked_add(nanos / 1_000))
+                .ok_or_else(|| Error::DataInvalid {
+                    message: format!(
+                        ".row timestamp microsecond conversion overflow: millis={millis}, nanos={nanos}"
+                    ),
+                    source: None,
+                })?
         }
         TimeUnit::Nanosecond => {
             let nanos = i64::from(input.read_var_u32()?);
-            millis * 1_000_000 + nanos
+            millis
+                .checked_mul(1_000_000)
+                .and_then(|v| v.checked_add(nanos))
+                .ok_or_else(|| Error::DataInvalid {
+                    message: format!(
+                        ".row timestamp nanosecond conversion overflow: millis={millis}, nanos={nanos}"
+                    ),
+                    source: None,
+                })?
         }
         TimeUnit::Second => millis / 1_000,
     })
@@ -3504,5 +3520,60 @@ mod tests {
             DataField::new(3, "g".to_string(), DataType::Double(DoubleType::new())),
         ])
         .unwrap();
+    }
+
+    #[test]
+    fn read_timestamp_rejects_overflow() {
+        // Millis = i64::MAX triggers overflow in microsecond/nanosecond conversion
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&i64::MAX.to_le_bytes()); // millis (8 bytes LE)
+        buf.push(0); // nanos_of_milli = 0 (varint 1 byte)
+
+        let new_input = || BlockInput {
+            data: &buf,
+            position: 0,
+            data_end: buf.len(),
+        };
+
+        // Microsecond path: millis * 1_000 overflows
+        let result = read_timestamp_value(&mut new_input(), TimeUnit::Microsecond);
+        assert!(matches!(result, Err(Error::DataInvalid { .. })));
+
+        // Nanosecond path: millis * 1_000_000 overflows
+        let result = read_timestamp_value(&mut new_input(), TimeUnit::Nanosecond);
+        assert!(matches!(result, Err(Error::DataInvalid { .. })));
+    }
+
+    #[test]
+    fn read_timestamp_accepts_boundary_values() {
+        // Maximum millis that still fits into microsecond precision
+        let max_safe_micros = i64::MAX / 1_000;
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&max_safe_micros.to_le_bytes());
+        buf.push(0);
+
+        let mut input = BlockInput {
+            data: &buf,
+            position: 0,
+            data_end: buf.len(),
+        };
+        let result = read_timestamp_value(&mut input, TimeUnit::Microsecond);
+        assert!(result.is_ok());
+
+        // Maximum millis that still fits into nanosecond precision
+        let max_safe_nanos = i64::MAX / 1_000_000;
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&max_safe_nanos.to_le_bytes());
+        buf.push(0);
+
+        let mut input = BlockInput {
+            data: &buf,
+            position: 0,
+            data_end: buf.len(),
+        };
+        let result = read_timestamp_value(&mut input, TimeUnit::Nanosecond);
+        assert!(result.is_ok());
     }
 }

--- a/crates/paimon/src/arrow/format/row.rs
+++ b/crates/paimon/src/arrow/format/row.rs
@@ -1777,27 +1777,23 @@ fn read_timestamp_value(input: &mut BlockInput<'_>, unit: TimeUnit) -> crate::Re
         TimeUnit::Millisecond => millis,
         TimeUnit::Microsecond => {
             let nanos = i64::from(input.read_var_u32()?);
-            millis
-                .checked_mul(1_000)
-                .and_then(|v| v.checked_add(nanos / 1_000))
-                .ok_or_else(|| Error::DataInvalid {
-                    message: format!(
-                        ".row timestamp microsecond conversion overflow: millis={millis}, nanos={nanos}"
-                    ),
-                    source: None,
-                })?
+            let value = millis as i128 * 1_000i128 + (nanos / 1_000) as i128;
+            i64::try_from(value).map_err(|_| Error::DataInvalid {
+                message: format!(
+                    ".row timestamp microsecond conversion overflow: millis={millis}, nanos={nanos}"
+                ),
+                source: None,
+            })?
         }
         TimeUnit::Nanosecond => {
             let nanos = i64::from(input.read_var_u32()?);
-            millis
-                .checked_mul(1_000_000)
-                .and_then(|v| v.checked_add(nanos))
-                .ok_or_else(|| Error::DataInvalid {
-                    message: format!(
-                        ".row timestamp nanosecond conversion overflow: millis={millis}, nanos={nanos}"
-                    ),
-                    source: None,
-                })?
+            let value = millis as i128 * 1_000_000i128 + nanos as i128;
+            i64::try_from(value).map_err(|_| Error::DataInvalid {
+                message: format!(
+                    ".row timestamp nanosecond conversion overflow: millis={millis}, nanos={nanos}"
+                ),
+                source: None,
+            })?
         }
         TimeUnit::Second => millis / 1_000,
     })
@@ -3524,7 +3520,7 @@ mod tests {
 
     #[test]
     fn read_timestamp_rejects_overflow() {
-        // Millis = i64::MAX triggers overflow in microsecond/nanosecond conversion
+        // Millis = i64::MAX triggers overflow in final microsecond/nanosecond conversion
         let mut buf = Vec::new();
         buf.extend_from_slice(&i64::MAX.to_le_bytes()); // millis (8 bytes LE)
         buf.push(0); // nanos_of_milli = 0 (varint 1 byte)
@@ -3535,13 +3531,54 @@ mod tests {
             data_end: buf.len(),
         };
 
-        // Microsecond path: millis * 1_000 overflows
         let result = read_timestamp_value(&mut new_input(), TimeUnit::Microsecond);
         assert!(matches!(result, Err(Error::DataInvalid { .. })));
 
-        // Nanosecond path: millis * 1_000_000 overflows
         let result = read_timestamp_value(&mut new_input(), TimeUnit::Nanosecond);
         assert!(matches!(result, Err(Error::DataInvalid { .. })));
+    }
+
+    #[test]
+    fn read_timestamp_i64_min_negative_boundary_converts() {
+        // A writer can encode i64::MIN microseconds using Euclidean division:
+        //   millis = floor(i64::MIN / 1000)  = -9_223_372_036_854_776
+        //   nanos  = rem_euclid(1000) * 1000  = 192_000
+        // The intermediate product millis*1000 = -9_223_372_036_854_776_000
+        // which temporarily falls below i64::MIN, but the final value
+        // (-9_223_372_036_854_776_000 + 192) = i64::MIN fits in i64.
+        // Before the i128 fix, checked_mul would reject this valid roundtrip.
+
+        // Microsecond path: millis = floor(i64::MIN / 1000), nanos = 192_000
+        let millis = i64::MIN.div_euclid(1_000); // floor = -9_223_372_036_854_776
+        let nanos = (i64::MIN.rem_euclid(1_000) * 1_000) as u32; // 192_000
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&millis.to_le_bytes());
+        write_var_u32(&mut buf, nanos);
+
+        let mut input = BlockInput {
+            data: &buf,
+            position: 0,
+            data_end: buf.len(),
+        };
+        let result = read_timestamp_value(&mut input, TimeUnit::Microsecond).unwrap();
+        assert_eq!(result, i64::MIN);
+
+        // Nanosecond path: millis = floor(i64::MIN / 1_000_000), nanos = 224_192
+        let millis = i64::MIN.div_euclid(1_000_000); // floor = -9_223_372_036_855
+        let nanos = i64::MIN.rem_euclid(1_000_000) as u32; // 224_192
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&millis.to_le_bytes());
+        write_var_u32(&mut buf, nanos);
+
+        let mut input = BlockInput {
+            data: &buf,
+            position: 0,
+            data_end: buf.len(),
+        };
+        let result = read_timestamp_value(&mut input, TimeUnit::Nanosecond).unwrap();
+        assert_eq!(result, i64::MIN);
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
`read_timestamp_value` performs unchecked multiplication `(* 1_000 / * 1_000_000)` on the millis value read from `.row` files when converting to microsecond or nanosecond precision. A corrupt or malicious file can supply an arbitrary i64 (e.g. `i64::MAX`), causing a panic in debug builds or silent wrapping in release builds. This PR replaces bare arithmetic with checked_mul + checked_add, returning `Error::DataInvalid` on overflow.

<!-- What is the purpose of the change -->

### Brief change log
- Microsecond and Nanosecond arms of read_timestamp_value: replaced bare operators with `checked_mul` + `checked_add` + `ok_or_else`,  returning `DataInvalid` with millis and nanos context on overflow 

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List unit tests or integration cases to verify this change -->
- `cargo clippy --all-targets --workspace --features fulltext,vortex -- -D warnings`
- `cargo test -p paimon --all-targets --features fulltext,vortex`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
