### PR TITLE
feat(python): add BETWEEN/NOT BETWEEN predicate support

### DIFF
--- a/bindings/python/src/predicate.rs
+++ b/bindings/python/src/predicate.rs
@@ -1633,9 +1633,9 @@ value = datetime.datetime(2024, 1, 1, tzinfo=FloatingTz())",
                 let dict = leaf_dict(py, "between", "id", &lits);
                 let err = dict_to_predicate(&dict, &fields, true).unwrap_err();
                 assert!(
-+                    err.is_instance_of::<PyValueError>(py),
-+                    "between with {n} lits"
-+                );
+                    err.is_instance_of::<PyValueError>(py),
+                    "between with {n} lits"
+                );
             }
         });
     }
@@ -1649,9 +1649,9 @@ value = datetime.datetime(2024, 1, 1, tzinfo=FloatingTz())",
                 let dict = leaf_dict(py, "notBetween", "id", &lits);
                 let err = dict_to_predicate(&dict, &fields, true).unwrap_err();
                 assert!(
-+                    err.is_instance_of::<PyValueError>(py),
-+                    "notBetween with {n} lits"
-+                );
+                    err.is_instance_of::<PyValueError>(py),
+                    "notBetween with {n} lits"
+                );
             }
         });
     }

--- a/bindings/python/src/predicate.rs
+++ b/bindings/python/src/predicate.rs
@@ -524,6 +524,30 @@ fn leaf_to_predicate(
             };
             pb.like(&field, ds.pop().unwrap(), escape)
         }
+        "between" => {
+            let mut ds = to_datums(literals_obj)?;
+            if ds.len() != 2 {
+                return Err(PyValueError::new_err(format!(
+                    "'between' expects exactly 2 literals (low, high), got {}",
+                    ds.len()
+                )));
+            }
+            let high = ds.pop().unwrap();
+            let low = ds.pop().unwrap();
+            pb.between(&field, low, high)
+        }
+        "notBetween" => {
+            let mut ds = to_datums(literals_obj)?;
+            if ds.len() != 2 {
+                return Err(PyValueError::new_err(format!(
+                    "'notBetween' expects exactly 2 literals (low, high), got {}",
+                    ds.len()
+                )));
+            }
+            let high = ds.pop().unwrap();
+            let low = ds.pop().unwrap();
+            pb.not_between(&field, low, high)
+        }
         other => {
             return Err(PyNotImplementedError::new_err(format!(
                 "unknown or unsupported predicate operator '{other}'"
@@ -1563,6 +1587,85 @@ value = datetime.datetime(2024, 1, 1, tzinfo=FloatingTz())",
             let v = 9_999_999_999i64.into_pyobject(py).unwrap();
             let err = py_to_datum(&v, &DataType::Int(Default::default())).unwrap_err();
             assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+        });
+    }
+
+    // ---- between / notBetween ----
+
+    #[test]
+    fn between_leaf_converts() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = leaf_dict(py, "between", "id", &[10, 20]);
+            let pred = dict_to_predicate(&dict, &fields, true).unwrap();
+            match &pred {
+                Predicate::Leaf { op, literals, .. } => {
+                    assert_eq!(*op, PredicateOperator::Between);
+                    assert_eq!(literals, &[Datum::Int(10), Datum::Int(20)]);
+                }
+                other => panic!("expected Leaf, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn not_between_leaf_converts() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = leaf_dict(py, "notBetween", "id", &[10, 20]);
+            let pred = dict_to_predicate(&dict, &fields, true).unwrap();
+            match &pred {
+                Predicate::Leaf { op, literals, .. } => {
+                    assert_eq!(*op, PredicateOperator::NotBetween);
+                    assert_eq!(literals, &[Datum::Int(10), Datum::Int(20)]);
+                }
+                other => panic!("expected Leaf, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn between_rejects_wrong_literal_count() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            for n in [0, 1, 3] {
+                let lits: Vec<i64> = (0..n).collect();
+                let dict = leaf_dict(py, "between", "id", &lits);
+                let err = dict_to_predicate(&dict, &fields, true).unwrap_err();
+                assert!(err.is_instance_of::<PyValueError>(py), "between with {n} lits");
+            }
+        });
+    }
+
+    #[test]
+    fn not_between_rejects_wrong_literal_count() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            for n in [0, 1, 3] {
+                let lits: Vec<i64> = (0..n).collect();
+                let dict = leaf_dict(py, "notBetween", "id", &lits);
+                let err = dict_to_predicate(&dict, &fields, true).unwrap_err();
+                assert!(err.is_instance_of::<PyValueError>(py), "notBetween with {n} lits");
+            }
+        });
+    }
+
+    #[test]
+    fn between_with_string_field_accepts_string_literals() {
+        Python::attach(|py| {
+            let fields = test_fields();
+            let dict = str_leaf_dict(py, "between", "name", &["alpha", "omega"]);
+            let pred = dict_to_predicate(&dict, &fields, true).unwrap();
+            match &pred {
+                Predicate::Leaf { op, literals, .. } => {
+                    assert_eq!(*op, PredicateOperator::Between);
+                    assert_eq!(
+                        literals,
+                        &[Datum::String("alpha".into()), Datum::String("omega".into())]
+                    );
+                }
+                other => panic!("expected Leaf, got {other:?}"),
+            }
         });
     }
 }

--- a/bindings/python/src/predicate.rs
+++ b/bindings/python/src/predicate.rs
@@ -1632,7 +1632,10 @@ value = datetime.datetime(2024, 1, 1, tzinfo=FloatingTz())",
                 let lits: Vec<i64> = (0..n).collect();
                 let dict = leaf_dict(py, "between", "id", &lits);
                 let err = dict_to_predicate(&dict, &fields, true).unwrap_err();
-                assert!(err.is_instance_of::<PyValueError>(py), "between with {n} lits");
+                assert!(
++                    err.is_instance_of::<PyValueError>(py),
++                    "between with {n} lits"
++                );
             }
         });
     }
@@ -1645,7 +1648,10 @@ value = datetime.datetime(2024, 1, 1, tzinfo=FloatingTz())",
                 let lits: Vec<i64> = (0..n).collect();
                 let dict = leaf_dict(py, "notBetween", "id", &lits);
                 let err = dict_to_predicate(&dict, &fields, true).unwrap_err();
-                assert!(err.is_instance_of::<PyValueError>(py), "notBetween with {n} lits");
+                assert!(
++                    err.is_instance_of::<PyValueError>(py),
++                    "notBetween with {n} lits"
++                );
             }
         });
     }


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
The Python dict-format predicate parser was missing `BETWEEN` and `NOT BETWEEN` operators, which are standard SQL comparison operators already supported in the C bindings (`paimon_predicate_between` / `paimon_predicate_not_between`) and the core `PredicateBuilder`. This PR adds them to close the gap.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
- Add `between` and `notBetween` match arms in `leaf_to_predicate()`, each requiring exactly 2 literals (low, high), delegating to `PredicateBuilder::between` / `not_between`
- Add 5 unit tests covering successful conversion (int and string fields), wrong literal count rejection, and literal value
  verification

### Tests

<!-- List unit tests or integration cases to verify this change -->
- `cargo check -p pypaimon_rust`
- `cargo test -p pypaimon_rust -- predicate`
- `cargo clippy --all-targets --workspace --features fulltext,vortex -- -D warnings`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
