### PR TITLE
fix(table): fail closed for query-auth batch vector search

### DIFF
--- a/crates/paimon/src/table/vector_search_builder.rs
+++ b/crates/paimon/src/table/vector_search_builder.rs
@@ -643,6 +643,10 @@ impl<'a> BatchVectorSearchBuilder<'a> {
     }
 
     pub async fn execute(&self) -> crate::Result<Vec<SearchResult>> {
+        // Fail closed before validation and empty-table fast paths: batch search
+        // returns data-derived results outside `TableScan`/`TableRead`.
+        CoreOptions::new(self.table.schema().options()).ensure_read_authorized()?;
+
         let vector_column =
             self.vector_column
                 .as_deref()
@@ -2361,6 +2365,55 @@ mod tests {
             err.to_string().contains("Limit must be between 1"),
             "unexpected error: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_batch_vector_search_auth_check_precedes_validation() {
+        let table = crate::table::query_auth_table();
+        let err = table
+            .new_batch_vector_search_builder()
+            .execute()
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, crate::Error::Unsupported { ref message } if message.contains("query-auth.enabled")),
+            "batch vector search must check query auth before validating parameters"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_vector_search_empty_table_fails_closed_when_query_auth_enabled() {
+        let table = crate::table::query_auth_table();
+        let err = table
+            .new_batch_vector_search_builder()
+            .with_vector_column("id")
+            .with_query_vectors(vec![vec![1.0]])
+            .with_limit(1)
+            .execute()
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, crate::Error::Unsupported { ref message } if message.contains("query-auth.enabled")),
+            "batch vector search must fail closed before the empty-table fast path"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_vector_search_empty_table_unchanged_without_query_auth() {
+        let table = vector_test_table();
+        let results = table
+            .new_batch_vector_search_builder()
+            .with_vector_column("embedding")
+            .with_query_vectors(vec![vec![1.0]])
+            .with_limit(1)
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Purpose

`BatchVectorSearchBuilder::execute` does not currently call
`CoreOptions::ensure_read_authorized`.

Although the single-vector, full-text, and hybrid search entry points perform
this check, callers can invoke the public batch vector search builder directly
and bypass query authorization.

In particular, an empty table with `query-auth.enabled = true` reaches the
no-snapshot fast path and returns an empty `SearchResult` instead of
`Error::Unsupported`. Parameter validation can also run before authorization.
This violates the client's declared fail-closed behavior and could allow
data-derived results to be returned without enforcing the server-provided row
filter or column masking.

This change moves the authorization guard to the beginning of the batch
`execute` path, before parameter validation, search fast paths, and snapshot
handling.

The current Rust read path does not apply authorization grants, row filters, or
column masks, so this preserves the existing fail-closed behavior: every batch
search against a table with `query-auth.enabled = true` is rejected with
`Error::Unsupported`.

### Brief change log

- Call `CoreOptions::ensure_read_authorized` at the beginning of
  `BatchVectorSearchBuilder::execute`.
- Ensure authorization is checked before:
  - Parameter validation
  - Batch search fast paths
  - Empty-snapshot handling
- Add regression coverage verifying:
  - Query authorization takes precedence over invalid or missing parameters.
  - An empty query-auth-enabled table is rejected instead of returning an empty
    result.
  - Empty-table behavior is unchanged when query authorization is disabled.

### Tests

- Unit test `test_batch_vector_search_auth_check_precedes_validation`
  (`vector_search_builder.rs`): verifies batch authorization runs before
  parameter validation. **Fails on the pre-fix code.**
- Unit test
  `test_batch_vector_search_empty_table_fails_closed_when_query_auth_enabled`
  (`vector_search_builder.rs`): verifies a query-auth-enabled empty table
  returns `Error::Unsupported` instead of taking the no-snapshot fast path.
  **Fails on the pre-fix code.**
- Unit test
  `test_batch_vector_search_empty_table_unchanged_without_query_auth`
  (`vector_search_builder.rs`): verifies a non-protected empty table still
  returns one empty result per query.
- Commands run locally:
  - `cargo test -p paimon batch_vector_search --lib`
  - `cargo test -p paimon query_auth --lib`
  - `cargo test -p paimon table::vector_search_builder::tests --lib`
  - `cargo fmt --all -- --check`
  - `git diff --check`

### API and Format

No public API or persisted data format changes.

The behavior of the public batch vector search builder changes only for tables
with `query-auth.enabled = true`: these searches now fail closed with
`Error::Unsupported`, consistently with the other read and search entry
points.

### Documentation

No documentation changes required.
