### PR TITLE
fix(table): enable global index by default

### DIFF
--- a/crates/paimon/src/spec/core_options.rs
+++ b/crates/paimon/src/spec/core_options.rs
@@ -540,7 +540,7 @@ impl<'a> CoreOptions<'a> {
         self.options
             .get(GLOBAL_INDEX_ENABLED_OPTION)
             .map(|value| value.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 
     pub fn global_index_search_mode(&self) -> crate::Result<GlobalIndexSearchMode> {
@@ -1357,6 +1357,17 @@ mod tests {
                 HashMap::from([(GLOBAL_INDEX_SEARCH_MODE_OPTION.to_string(), raw.to_string())]);
             let core = CoreOptions::new(&options);
             assert_eq!(core.global_index_search_mode().unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn test_global_index_enabled_defaults_and_overrides() {
+        assert!(CoreOptions::new(&HashMap::new()).global_index_enabled());
+
+        for (raw, expected) in [("true", true), ("false", false)] {
+            let options =
+                HashMap::from([(GLOBAL_INDEX_ENABLED_OPTION.to_string(), raw.to_string())]);
+            assert_eq!(CoreOptions::new(&options).global_index_enabled(), expected);
         }
     }
 

--- a/crates/paimon/src/table/btree_global_index_build_builder.rs
+++ b/crates/paimon/src/table/btree_global_index_build_builder.rs
@@ -1240,6 +1240,33 @@ mod tests {
         .unwrap()
         .unwrap();
         assert_eq!(row_ranges, vec![RowRange::new(0, 0), RowRange::new(2, 2)]);
+
+        // Reopen the same table without an explicit global-index override and
+        // verify that the regular scan path still uses the committed index.
+        let mut options = table.schema().options().clone();
+        assert_eq!(
+            options.remove("global-index.enabled"),
+            Some("true".to_string())
+        );
+        let scan_table = Table::new(
+            table.file_io().clone(),
+            table.identifier().clone(),
+            table.location().to_string(),
+            table.schema().copy_with_replaced_options(options),
+            None,
+        );
+        let predicate = PredicateBuilder::new(scan_table.schema().fields())
+            .equal("name", crate::spec::Datum::String("alice".to_string()))
+            .unwrap();
+        let mut read_builder = scan_table.new_read_builder();
+        read_builder.with_filter(predicate);
+        let plan = read_builder.new_scan().plan().await.unwrap();
+
+        assert_eq!(plan.splits().len(), 1);
+        assert_eq!(
+            plan.splits()[0].row_ranges(),
+            Some(&[RowRange::new(0, 0), RowRange::new(2, 2)][..])
+        );
     }
 
     #[tokio::test]

--- a/docs/src/sql.md
+++ b/docs/src/sql.md
@@ -1923,7 +1923,7 @@ deletion vectors enabled.
 |---|---:|---|
 | `row-tracking.enabled` | `false` | Enables stable row ids required by global index files. |
 | `data-evolution.enabled` | `false` | Enables row-id-aware table evolution and partial-column writes. |
-| `global-index.enabled` | `false` | Enables global index metadata and global-index-aware reads. |
+| `global-index.enabled` | `true` | Enables global index metadata and global-index-aware reads. |
 | `global-index.row-count-per-shard` | `100000` | Maximum row count per vector global-index shard. |
 | `sorted-index.records-per-range` | `100000` | Maximum row count per BTree range. |
 | `btree-index.fallback-scan-max-size` | `256mb` | Maximum total size of selected BTree global-index files for fallback scans used by range/between and suffix/contains/complex LIKE predicates; `0` disables BTree fallback index scans. |


### PR DESCRIPTION
## Summary

Align the Rust `global-index.enabled` default with Java Paimon and PyPaimon. When the option is absent, Rust scans can now use existing global indexes; an explicit `false` still disables them.

## Changes

- Default `global-index.enabled` to `true` when it is not configured.
- Cover the default and explicit `true` / `false` overrides at the option layer.
- Exercise the regular table-scan path without an explicit override and verify that it reads the committed BTree index row ranges.
- Update the SQL option reference with the corrected default.

## Testing

- `cargo test --locked -p paimon --lib` (1800 passed, 1 ignored)
- `cargo test --locked -p paimon --lib table::btree_global_index_build_builder::tests` (23 passed)
- Parent/head regression check: parent returns no row ranges; this PR returns `[0,0]` and `[2,2]`
- `cargo fmt --all -- --check`
- `cargo clippy --locked -p paimon --all-targets -- -D warnings`