### PR TITLE
[umbrella] feat(datafusion): support REST format table partitions

### DIFF
--- a/crates/integrations/datafusion/src/format_partition_analyze.rs
+++ b/crates/integrations/datafusion/src/format_partition_analyze.rs
@@ -33,19 +33,7 @@ use crate::sql_context::{
 };
 
 /// `ANALYZE TABLE t [PARTITION (...)] COMPUTE STATISTICS [NOSCAN]` on a Format Table with
-/// catalog-managed partitions.
-///
-/// The registered partitions are measured from storage and each measured field replaces what
-/// the catalog holds, which is how a table catches up with writers the catalog never saw.
-/// NOSCAN stops at what a listing gives, file count, byte size and last file creation time,
-/// while a full ANALYZE also reads every file footer for its row count.
-///
-/// Analyzing never adds or removes a partition: it measures the ones registered when it
-/// listed them. There is no lock between that listing and the write, so a partition dropped
-/// in between can come back with its last measurement, the same last-writer-wins window every
-/// lock-free partition operation on these tables has.
-///
-/// Mirrors Java `PaimonAnalyzeFormatTablePartitionsCommand`.
+/// catalog-managed partitions. Mirrors Java `PaimonAnalyzeFormatTablePartitionsCommand`.
 pub(crate) async fn execute_analyze(
     ctx: &SQLContext,
     analyze: &Analyze,
@@ -140,9 +128,6 @@ pub(crate) async fn execute_analyze(
 
 /// `format-table.statistics.parallelism` from the session (`SET 'paimon.<key>'`), default 8.
 /// A value below one is read as one.
-///
-/// Like Java's Spark connector option of the same name, it is a session setting, not a table
-/// option.
 fn format_table_statistics_parallelism(ctx: &SQLContext) -> usize {
     const KEY: &str = "format-table.statistics.parallelism";
     ctx.dynamic_options()
@@ -154,13 +139,8 @@ fn format_table_statistics_parallelism(ctx: &SQLContext) -> usize {
         .unwrap_or(8)
 }
 
-/// The values an `ANALYZE ... PARTITION (...)` clause fixes, in partition-key order.
-///
-/// A column named without a value means every value of it, and the columns that carry a value
-/// must be a leading run of the partition keys: `PARTITION (dt = 'x', hour)` selects every hour of
-/// that day, while `PARTITION (hour = '00')` is rejected rather than quietly widened to more
-/// partitions than were asked for. Values are spelled the way ADD PARTITION writes them, so
-/// `p = '01'` selects the INT partition registered as `1`.
+/// The values an `ANALYZE ... PARTITION (...)` clause fixes, in partition-key order; valued
+/// columns must be a leading run of the keys, so `PARTITION (hour = '00')` is rejected.
 fn analyze_partition_prefix(
     expressions: &[SqlExpr],
     table: &paimon::Table,

--- a/crates/integrations/datafusion/src/format_partition_analyze.rs
+++ b/crates/integrations/datafusion/src/format_partition_analyze.rs
@@ -1,0 +1,216 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! ANALYZE TABLE for Format Tables with catalog-managed partitions.
+
+use std::collections::HashSet;
+
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::prelude::DataFrame;
+use datafusion::sql::sqlparser::ast::{Analyze, Expr as SqlExpr};
+use paimon::table::FormatTablePartitionStatsCollector;
+
+use crate::error::to_datafusion_error;
+use crate::format_partition_ddl::{
+    ensure_catalog_managed_format_table, has_custom_location, parse_format_partition_spec,
+};
+use crate::sql_context::{
+    normalize_schema_identifier, ok_result, partition_assignment, SQLContext,
+};
+
+/// `ANALYZE TABLE t [PARTITION (...)] COMPUTE STATISTICS [NOSCAN]` on a Format Table with
+/// catalog-managed partitions.
+///
+/// The registered partitions are measured from storage and each measured field replaces what
+/// the catalog holds, which is how a table catches up with writers the catalog never saw.
+/// NOSCAN stops at what a listing gives, file count, byte size and last file creation time,
+/// while a full ANALYZE also reads every file footer for its row count.
+///
+/// Analyzing never adds or removes a partition: it measures the ones registered when it
+/// listed them. There is no lock between that listing and the write, so a partition dropped
+/// in between can come back with its last measurement, the same last-writer-wins window every
+/// lock-free partition operation on these tables has.
+///
+/// Mirrors Java `PaimonAnalyzeFormatTablePartitionsCommand`.
+pub(crate) async fn execute_analyze(
+    ctx: &SQLContext,
+    analyze: &Analyze,
+    enable_ident_normalization: bool,
+) -> DFResult<DataFrame> {
+    let Some(table_name) = &analyze.table_name else {
+        return Err(DataFusionError::Plan(
+            "ANALYZE requires a table name".to_string(),
+        ));
+    };
+    if analyze.for_columns || !analyze.columns.is_empty() {
+        return Err(DataFusionError::NotImplemented(
+            "ANALYZE TABLE ... FOR COLUMNS is not supported: a Format Table has nowhere to \
+             keep column statistics"
+                .to_string(),
+        ));
+    }
+    if analyze.cache_metadata {
+        return Err(DataFusionError::NotImplemented(
+            "ANALYZE TABLE ... CACHE METADATA is not supported".to_string(),
+        ));
+    }
+    if !analyze.compute_statistics {
+        return Err(DataFusionError::Plan(
+            "ANALYZE TABLE requires COMPUTE STATISTICS".to_string(),
+        ));
+    }
+    SQLContext::ensure_partition_command_target(table_name, "ANALYZE TABLE")?;
+    let (catalog, _catalog_name, identifier) = ctx.resolve_catalog_and_table(table_name)?;
+    let table = catalog
+        .get_table(&identifier)
+        .await
+        .map_err(to_datafusion_error)?;
+    ensure_catalog_managed_format_table(&table, "ANALYZE TABLE")?;
+    let prefix = analyze_partition_prefix(
+        analyze.partitions.as_deref().unwrap_or_default(),
+        &table,
+        enable_ident_normalization,
+    )?;
+
+    let selected = catalog
+        .list_partitions(&identifier)
+        .await
+        .map_err(to_datafusion_error)?
+        .into_iter()
+        .filter(|partition| {
+            prefix
+                .iter()
+                .all(|(key, value)| partition.spec.get(key) == Some(value))
+        })
+        .collect::<Vec<_>>();
+    if selected.is_empty() && !prefix.is_empty() {
+        return Err(DataFusionError::Plan(format!(
+            "Partition {prefix:?} does not exist in table {}",
+            identifier.full_name()
+        )));
+    }
+    let custom_located = selected
+        .iter()
+        .filter(|partition| has_custom_location(partition))
+        .map(|partition| &partition.spec)
+        .collect::<Vec<_>>();
+    if !custom_located.is_empty() {
+        return Err(DataFusionError::NotImplemented(format!(
+            "ANALYZE TABLE cannot measure partitions with a custom location in Format Table \
+             {}: {custom_located:?}",
+            identifier.full_name()
+        )));
+    }
+    if selected.is_empty() {
+        return ok_result(ctx.ctx());
+    }
+
+    let specs = selected
+        .into_iter()
+        .map(|partition| partition.spec)
+        .collect::<Vec<_>>();
+    let statistics = FormatTablePartitionStatsCollector::new(
+        &table,
+        !analyze.noscan,
+        format_table_statistics_parallelism(ctx),
+    )
+    .collect(&specs)
+    .await
+    .map_err(to_datafusion_error)?;
+    catalog
+        .create_partitions_with_statistics(&identifier, specs, true, Some(statistics), true)
+        .await
+        .map_err(to_datafusion_error)?;
+    ok_result(ctx.ctx())
+}
+
+/// `format-table.statistics.parallelism` from the session (`SET 'paimon.<key>'`), default 8.
+/// A value below one is read as one.
+///
+/// Like Java's Spark connector option of the same name, it is a session setting, not a table
+/// option.
+fn format_table_statistics_parallelism(ctx: &SQLContext) -> usize {
+    const KEY: &str = "format-table.statistics.parallelism";
+    ctx.dynamic_options()
+        .read()
+        .unwrap()
+        .get(KEY)
+        .and_then(|value| value.trim().parse::<i64>().ok())
+        .map(|value| value.max(1) as usize)
+        .unwrap_or(8)
+}
+
+/// The values an `ANALYZE ... PARTITION (...)` clause fixes, in partition-key order.
+///
+/// A column named without a value means every value of it, and the columns that carry a value
+/// must be a leading run of the partition keys: `PARTITION (dt = 'x', hour)` selects every hour of
+/// that day, while `PARTITION (hour = '00')` is rejected rather than quietly widened to more
+/// partitions than were asked for. Values are spelled the way ADD PARTITION writes them, so
+/// `p = '01'` selects the INT partition registered as `1`.
+fn analyze_partition_prefix(
+    expressions: &[SqlExpr],
+    table: &paimon::Table,
+    enable_ident_normalization: bool,
+) -> DFResult<Vec<(String, String)>> {
+    let partition_keys = table.schema().partition_keys();
+    let mut named = HashSet::with_capacity(expressions.len());
+    let mut assignments = Vec::with_capacity(expressions.len());
+    for expression in expressions {
+        let column = match expression {
+            SqlExpr::Identifier(identifier) => {
+                normalize_schema_identifier(identifier, enable_ident_normalization)
+            }
+            other => {
+                let (column, _) = partition_assignment(other, enable_ident_normalization)?;
+                assignments.push(other.clone());
+                column
+            }
+        };
+        if !partition_keys.contains(&column) {
+            return Err(DataFusionError::Plan(format!(
+                "Column '{column}' is not a partition column"
+            )));
+        }
+        if !named.insert(column.clone()) {
+            return Err(DataFusionError::Plan(format!(
+                "Duplicate partition column '{column}'"
+            )));
+        }
+    }
+    let spec = parse_format_partition_spec(
+        &assignments,
+        table,
+        false,
+        Some("ANALYZE TABLE"),
+        enable_ident_normalization,
+    )?;
+    let leading = partition_keys
+        .iter()
+        .take_while(|key| spec.contains_key(key.as_str()))
+        .count();
+    if leading != spec.len() {
+        return Err(DataFusionError::Plan(format!(
+            "ANALYZE TABLE {} PARTITION must give values for a leading run of its partition \
+             columns {partition_keys:?}",
+            table.identifier().full_name()
+        )));
+    }
+    Ok(partition_keys[..leading]
+        .iter()
+        .map(|key| (key.clone(), spec[key].clone()))
+        .collect())
+}

--- a/crates/integrations/datafusion/src/format_partition_ddl.rs
+++ b/crates/integrations/datafusion/src/format_partition_ddl.rs
@@ -360,7 +360,7 @@ pub(crate) async fn drop_catalog_managed_partitions(
 
 /// Whether the catalog registered a partition at a location of its own rather than under the
 /// table directory.
-fn has_custom_location(partition: &paimon::spec::Partition) -> bool {
+pub(crate) fn has_custom_location(partition: &paimon::spec::Partition) -> bool {
     partition
         .options
         .as_ref()
@@ -386,9 +386,9 @@ pub(crate) fn ensure_catalog_managed_format_table(
     Ok(())
 }
 
-/// `mutating_operation` names the statement when it changes partitions (ADD or DROP PARTITION),
-/// which refuses a blank string for a string partition column.
-fn parse_format_partition_spec(
+/// `mutating_operation` names the statement when it changes partitions or their statistics (ADD
+/// or DROP PARTITION, ANALYZE TABLE), which refuses a blank string for a string partition column.
+pub(crate) fn parse_format_partition_spec(
     exprs: &[SqlExpr],
     table: &paimon::Table,
     require_complete: bool,

--- a/crates/integrations/datafusion/src/format_partition_repair.rs
+++ b/crates/integrations/datafusion/src/format_partition_repair.rs
@@ -90,9 +90,8 @@ async fn repair(
         )
         .await?;
     let registered_partitions = catalog.list_partitions(identifier).await?;
-    // A partition registered at a location of its own does not live under the table directory,
-    // so discovery never finds it there. Repair leaves it registered rather than reading that as
-    // a directory gone missing.
+    // A partition registered at a location of its own is never discovered under the table
+    // directory, so repair leaves it registered.
     let custom_located = registered_partitions
         .iter()
         .filter(|partition| {

--- a/crates/integrations/datafusion/src/format_partition_repair.rs
+++ b/crates/integrations/datafusion/src/format_partition_repair.rs
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! MSCK REPAIR TABLE for Format Tables with catalog-managed partitions.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::prelude::DataFrame;
+use datafusion::sql::sqlparser::ast::{AddDropSync, Msck};
+use paimon::catalog::{Catalog, Identifier};
+use paimon::spec::CoreOptions;
+use paimon::table::{FormatTablePartitionPaths, Table};
+
+use crate::error::to_datafusion_error;
+use crate::format_partition_ddl::ensure_catalog_managed_format_table;
+use crate::sql_context::{ok_result, SQLContext};
+
+pub(crate) async fn execute_msck(ctx: &SQLContext, msck: &Msck) -> DFResult<DataFrame> {
+    if !msck.repair {
+        return Err(DataFusionError::Plan(
+            "MSCK requires the REPAIR keyword".to_string(),
+        ));
+    }
+    SQLContext::ensure_partition_command_target(&msck.table_name, "MSCK REPAIR TABLE")?;
+    let (catalog, _catalog_name, identifier) = ctx.resolve_catalog_and_table(&msck.table_name)?;
+    let table = catalog
+        .get_table(&identifier)
+        .await
+        .map_err(to_datafusion_error)?;
+    ensure_catalog_managed_format_table(&table, "MSCK REPAIR TABLE")?;
+    let mode = match msck.partition_action {
+        None | Some(AddDropSync::ADD) => RepairMode::Add,
+        Some(AddDropSync::DROP) => RepairMode::Drop,
+        Some(AddDropSync::SYNC) => RepairMode::Sync,
+    };
+    repair(catalog.as_ref(), &identifier, &table, mode)
+        .await
+        .map_err(to_datafusion_error)?;
+    ok_result(ctx.ctx())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RepairMode {
+    Add,
+    Drop,
+    Sync,
+}
+
+async fn repair(
+    catalog: &dyn Catalog,
+    identifier: &Identifier,
+    table: &Table,
+    mode: RepairMode,
+) -> paimon::Result<()> {
+    let core_options = CoreOptions::new(table.schema().options());
+    let partition_paths = FormatTablePartitionPaths::new(
+        table.schema().partition_keys().iter().cloned(),
+        core_options.format_table_partition_only_value_in_path(),
+    );
+    let table_path = table.location();
+
+    if matches!(mode, RepairMode::Drop | RepairMode::Sync) {
+        // Discovery treats a missing root as empty. Destructive repair must fail
+        // instead, or it could unregister every catalog partition.
+        table.file_io().list_status(table_path).await?;
+    }
+
+    // Load both views before changing catalog metadata so a listing failure leaves
+    // metadata unchanged. Discovery preserves raw directory values such as month=01.
+    let discovered_specs = partition_paths
+        .discover(
+            table.file_io(),
+            table_path,
+            core_options.partition_default_name(),
+        )
+        .await?;
+    let registered_partitions = catalog.list_partitions(identifier).await?;
+    // A partition registered at a location of its own does not live under the table directory,
+    // so discovery never finds it there. Repair leaves it registered rather than reading that as
+    // a directory gone missing.
+    let custom_located = registered_partitions
+        .iter()
+        .filter(|partition| {
+            partition
+                .options
+                .as_ref()
+                .is_some_and(|options| options.contains_key("path"))
+        })
+        .map(|partition| partition_paths.partition_name(&partition.spec))
+        .collect::<paimon::Result<HashSet<_>>>()?;
+
+    let discovered_by_name = index_specs_by_name(&partition_paths, discovered_specs)?;
+    let registered_by_name = index_specs_by_name(
+        &partition_paths,
+        registered_partitions
+            .into_iter()
+            .map(|partition| partition.spec)
+            .collect(),
+    )?;
+
+    let to_register = if matches!(mode, RepairMode::Add | RepairMode::Sync) {
+        discovered_by_name
+            .iter()
+            .filter(|(name, _)| !registered_by_name.contains_key(*name))
+            .map(|(_, spec)| spec.clone())
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let to_unregister = if matches!(mode, RepairMode::Drop | RepairMode::Sync) {
+        registered_by_name
+            .iter()
+            .filter(|(name, _)| {
+                !discovered_by_name.contains_key(*name) && !custom_located.contains(*name)
+            })
+            .map(|(_, spec)| spec.clone())
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    if !to_register.is_empty() {
+        catalog
+            .create_partitions(identifier, to_register, true)
+            .await?;
+    }
+    if !to_unregister.is_empty() {
+        catalog.drop_partitions(identifier, to_unregister).await?;
+    }
+    Ok(())
+}
+
+fn index_specs_by_name(
+    partition_paths: &FormatTablePartitionPaths,
+    specs: Vec<HashMap<String, String>>,
+) -> paimon::Result<BTreeMap<String, HashMap<String, String>>> {
+    specs
+        .into_iter()
+        .map(|spec| Ok((partition_paths.partition_name(&spec)?, spec)))
+        .collect()
+}

--- a/crates/integrations/datafusion/src/format_partition_repair.rs
+++ b/crates/integrations/datafusion/src/format_partition_repair.rs
@@ -75,9 +75,8 @@ async fn repair(
     let table_path = table.location();
 
     if matches!(mode, RepairMode::Drop | RepairMode::Sync) {
-        // Discovery treats a missing root as empty. Destructive repair must fail
-        // instead, or it could unregister every catalog partition.
-        table.file_io().list_status(table_path).await?;
+        // Discovery reads a missing root as empty, which would unregister every partition.
+        ensure_table_root_is_directory(table).await?;
     }
 
     // Load both views before changing catalog metadata so a listing failure leaves
@@ -142,6 +141,31 @@ async fn repair(
         catalog.drop_partitions(identifier, to_unregister).await?;
     }
     Ok(())
+}
+
+/// Fail unless the table root is a directory; on object stores, a root holding objects counts.
+async fn ensure_table_root_is_directory(table: &Table) -> paimon::Result<()> {
+    let file_io = table.file_io();
+    let root = table.location();
+    let problem = match file_io.get_status(root).await {
+        Ok(status) if status.is_dir => return Ok(()),
+        Ok(_) => "is not a directory",
+        // A store without directory entries cannot stat the root but lists what it holds.
+        Err(_) => {
+            if !file_io.list_status(root).await?.is_empty() {
+                return Ok(());
+            }
+            "does not exist"
+        }
+    };
+    Err(paimon::Error::DataInvalid {
+        message: format!(
+            "MSCK REPAIR TABLE cannot drop partitions of Format Table {}: \
+             its location {root} {problem}",
+            table.identifier().full_name()
+        ),
+        source: None,
+    })
 }
 
 fn index_specs_by_name(

--- a/crates/integrations/datafusion/src/lib.rs
+++ b/crates/integrations/datafusion/src/lib.rs
@@ -43,6 +43,7 @@ mod catalog;
 mod delete;
 mod error;
 mod filter_pushdown;
+mod format_partition_analyze;
 mod format_partition_ddl;
 mod format_partition_repair;
 #[cfg(feature = "fulltext")]

--- a/crates/integrations/datafusion/src/lib.rs
+++ b/crates/integrations/datafusion/src/lib.rs
@@ -44,6 +44,7 @@ mod delete;
 mod error;
 mod filter_pushdown;
 mod format_partition_ddl;
+mod format_partition_repair;
 #[cfg(feature = "fulltext")]
 mod full_text_search;
 mod hybrid_search;

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -37,6 +37,7 @@
 //! - `ALTER TABLE db.t ADD [IF NOT EXISTS] PARTITION (...) [PARTITION (...)]`
 //! - `ALTER TABLE db.t DROP [IF EXISTS] PARTITION (...)`
 //! - `SHOW PARTITIONS db.t [PARTITION (...)]`
+//! - `MSCK REPAIR TABLE db.t [{ADD|DROP|SYNC} PARTITIONS]`
 //! - `CREATE VIEW [IF NOT EXISTS] view [(col, ...)] AS query`
 //! - `DROP VIEW [IF EXISTS] view`
 //! - `CREATE FUNCTION name(args) RETURNS type [LANGUAGE SQL] RETURN expression`
@@ -609,6 +610,7 @@ impl SQLContext {
                 self.handle_truncate_table(truncate, enable_ident_normalization)
                     .await
             }
+            Statement::Msck(msck) => crate::format_partition_repair::execute_msck(self, msck).await,
             Statement::CreateView(create_view) => {
                 if create_view.temporary {
                     // Temporary views are always handled by us (Paimon catalog temp storage)

--- a/crates/integrations/datafusion/src/sql_context.rs
+++ b/crates/integrations/datafusion/src/sql_context.rs
@@ -436,7 +436,6 @@ impl SQLContext {
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn dynamic_options(&self) -> &DynamicOptions {
         &self.dynamic_options
     }
@@ -611,6 +610,14 @@ impl SQLContext {
                     .await
             }
             Statement::Msck(msck) => crate::format_partition_repair::execute_msck(self, msck).await,
+            Statement::Analyze(analyze) => {
+                crate::format_partition_analyze::execute_analyze(
+                    self,
+                    analyze,
+                    enable_ident_normalization,
+                )
+                .await
+            }
             Statement::CreateView(create_view) => {
                 if create_view.temporary {
                     // Temporary views are always handled by us (Paimon catalog temp storage)

--- a/crates/integrations/datafusion/tests/rest_format_partition_sql.rs
+++ b/crates/integrations/datafusion/tests/rest_format_partition_sql.rs
@@ -484,6 +484,76 @@ async fn test_drop_partition_leaves_a_custom_location_in_place() {
     assert!(temp_dir.path().join("dt=b").is_dir());
 }
 
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_msck_repair_reconciles_registrations_with_directories() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(temp_dir.path().join("dt=2026-07-21")).unwrap();
+    let (_server, context) =
+        setup_rest_table(&temp_dir, format_table_schema(&[("dt", varchar())])).await;
+    common::exec(
+        &context,
+        &format!("ALTER TABLE {TABLE_NAME} ADD PARTITION (dt = '2026-07-22')"),
+    )
+    .await;
+
+    // ADD registers a directory the catalog does not know yet.
+    common::exec(
+        &context,
+        &format!("MSCK REPAIR TABLE {TABLE_NAME} ADD PARTITIONS"),
+    )
+    .await;
+    assert_eq!(
+        show_partitions(&context, "").await,
+        ["dt=2026-07-21", "dt=2026-07-22"]
+    );
+
+    // SYNC also unregisters a partition whose directory is gone, without deleting anything.
+    std::fs::remove_dir_all(temp_dir.path().join("dt=2026-07-22")).unwrap();
+    common::exec(
+        &context,
+        &format!("MSCK REPAIR TABLE {TABLE_NAME} SYNC PARTITIONS"),
+    )
+    .await;
+    assert_eq!(show_partitions(&context, "").await, ["dt=2026-07-21"]);
+    assert!(temp_dir.path().join("dt=2026-07-21").is_dir());
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_msck_repair_keeps_a_partition_at_a_custom_location() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let external_dir = tempfile::tempdir().unwrap();
+    let (server, context) =
+        setup_rest_table(&temp_dir, format_table_schema(&[("dt", varchar())])).await;
+    common::exec(
+        &context,
+        &format!("ALTER TABLE {TABLE_NAME} ADD PARTITION (dt = 'a') PARTITION (dt = 'b')"),
+    )
+    .await;
+    server.set_table_partition_options(
+        DATABASE,
+        TABLE,
+        &spec(&[("dt", "b")]),
+        HashMap::from([(
+            "path".to_string(),
+            format!("file://{}", external_dir.path().display()),
+        )]),
+    );
+
+    // Its directory is not under the table, so repair does not read it as missing.
+    std::fs::remove_dir_all(temp_dir.path().join("dt=b")).unwrap();
+    common::exec(
+        &context,
+        &format!("MSCK REPAIR TABLE {TABLE_NAME} SYNC PARTITIONS"),
+    )
+    .await;
+    assert_eq!(
+        server.table_partition_specs(DATABASE, TABLE),
+        vec![spec(&[("dt", "a")]), spec(&[("dt", "b")])]
+    );
+}
+
 /// `SQLContext::sql` futures have to stay `Send` for callers that box or spawn them; this stops
 /// compiling when a stream over borrowed items anywhere below a statement takes that away.
 #[allow(dead_code)]

--- a/crates/integrations/datafusion/tests/rest_format_partition_sql.rs
+++ b/crates/integrations/datafusion/tests/rest_format_partition_sql.rs
@@ -521,6 +521,45 @@ async fn test_msck_repair_reconciles_registrations_with_directories() {
 
 #[cfg(not(windows))]
 #[tokio::test]
+async fn test_msck_repair_refuses_to_drop_without_a_table_directory() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (server, context) =
+        setup_rest_table(&temp_dir, format_table_schema(&[("dt", varchar())])).await;
+    common::exec(
+        &context,
+        &format!("ALTER TABLE {TABLE_NAME} ADD PARTITION (dt = 'a')"),
+    )
+    .await;
+
+    // A moved root must not read as every partition directory gone.
+    let moved_dir = tempfile::tempdir().unwrap();
+    std::fs::rename(temp_dir.path(), moved_dir.path().join("events")).unwrap();
+    for action in ["DROP", "SYNC"] {
+        common::assert_sql_error(
+            &context,
+            &format!("MSCK REPAIR TABLE {TABLE_NAME} {action} PARTITIONS"),
+            "does not exist",
+        )
+        .await;
+    }
+
+    std::fs::write(temp_dir.path(), b"").unwrap();
+    for action in ["DROP", "SYNC"] {
+        common::assert_sql_error(
+            &context,
+            &format!("MSCK REPAIR TABLE {TABLE_NAME} {action} PARTITIONS"),
+            "is not a directory",
+        )
+        .await;
+    }
+    assert_eq!(
+        server.table_partition_specs(DATABASE, TABLE),
+        vec![spec(&[("dt", "a")])]
+    );
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
 async fn test_msck_repair_keeps_a_partition_at_a_custom_location() {
     let temp_dir = tempfile::tempdir().unwrap();
     let external_dir = tempfile::tempdir().unwrap();

--- a/crates/integrations/datafusion/tests/rest_format_partition_sql.rs
+++ b/crates/integrations/datafusion/tests/rest_format_partition_sql.rs
@@ -21,13 +21,17 @@ mod common;
 mod mock_server;
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
+use arrow_array::{Int64Array, RecordBatch};
+use arrow_schema::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
 use paimon::api::ConfigResponse;
 use paimon::catalog::RESTCatalog;
 use paimon::spec::{BigIntType, BooleanType, DataType, DateType, IntType, Schema, VarCharType};
 use paimon::{CatalogOptions, Options};
 use paimon_datafusion::SQLContext;
+use parquet::arrow::ArrowWriter;
 use tempfile::TempDir;
 
 use mock_server::{start_mock_server, RESTServer};
@@ -128,6 +132,66 @@ fn spec(values: &[(&str, &str)]) -> HashMap<String, String> {
         .iter()
         .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
         .collect()
+}
+
+const UNKNOWN: i64 = paimon::spec::Partition::UNKNOWN;
+
+/// The partitions the catalog holds, by partition name with keys in name order.
+fn partition_statistics(server: &RESTServer) -> HashMap<String, paimon::spec::Partition> {
+    server
+        .table_partitions(DATABASE, TABLE)
+        .into_iter()
+        .map(|partition| {
+            let mut entries = partition.spec.iter().collect::<Vec<_>>();
+            entries.sort();
+            let name = entries
+                .into_iter()
+                .map(|(key, value)| format!("{key}={value}"))
+                .collect::<Vec<_>>()
+                .join("/");
+            (name, partition)
+        })
+        .collect()
+}
+
+fn counts(partition: &paimon::spec::Partition) -> (i64, i64) {
+    (partition.record_count, partition.file_count)
+}
+
+fn write_ids(directory: &Path, ids: &[i64]) {
+    write_ids_file(&directory.join("part-0.parquet"), ids);
+}
+
+fn write_ids_file(path: &Path, ids: &[i64]) {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        "id",
+        ArrowDataType::Int64,
+        true,
+    )]));
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(Int64Array::from(ids.to_vec()))],
+    )
+    .unwrap();
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+}
+
+async fn ids(context: &SQLContext, sql: &str) -> Vec<i64> {
+    let mut ids = Vec::new();
+    for batch in context.sql(sql).await.unwrap().collect().await.unwrap() {
+        let values = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        ids.extend(values.iter().flatten());
+    }
+    ids.sort_unstable();
+    ids
 }
 
 #[cfg(not(windows))]
@@ -591,6 +655,280 @@ async fn test_msck_repair_keeps_a_partition_at_a_custom_location() {
         server.table_partition_specs(DATABASE, TABLE),
         vec![spec(&[("dt", "a")]), spec(&[("dt", "b")])]
     );
+}
+
+#[cfg(not(windows))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_analyze_measures_registered_partitions_and_replaces_their_statistics() {
+    let (temp_dir, server, context) = dt_hh_table(&[("a", "00"), ("a", "01"), ("b", "00")]).await;
+    write_ids_file(&temp_dir.path().join("dt=a/hh=00/part-0.parquet"), &[1, 2]);
+    write_ids_file(&temp_dir.path().join("dt=a/hh=00/part-1.parquet"), &[3]);
+    write_ids_file(&temp_dir.path().join("dt=a/hh=01/part-0.parquet"), &[4]);
+
+    // NOSCAN measures what a listing gives and leaves the row counts as they were.
+    common::exec(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} COMPUTE STATISTICS NOSCAN"),
+    )
+    .await;
+    let measured = partition_statistics(&server);
+    assert_eq!(counts(&measured["dt=a/hh=00"]), (UNKNOWN, 2));
+    assert_eq!(counts(&measured["dt=a/hh=01"]), (UNKNOWN, 1));
+    assert_eq!(counts(&measured["dt=b/hh=00"]), (UNKNOWN, 0));
+    assert!(measured["dt=a/hh=00"].file_size_in_bytes > 0);
+    assert!(measured["dt=a/hh=00"].last_file_creation_time > 0);
+    assert_eq!(measured["dt=b/hh=00"].file_size_in_bytes, 0);
+    assert_eq!(measured["dt=b/hh=00"].last_file_creation_time, UNKNOWN);
+
+    // A full ANALYZE reads every footer, and an empty partition holds exactly no rows.
+    common::exec(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} COMPUTE STATISTICS"),
+    )
+    .await;
+    let measured = partition_statistics(&server);
+    assert_eq!(counts(&measured["dt=a/hh=00"]), (3, 2));
+    assert_eq!(counts(&measured["dt=a/hh=01"]), (1, 1));
+    assert_eq!(counts(&measured["dt=b/hh=00"]), (0, 0));
+
+    // A later NOSCAN keeps the known row counts, and measuring again replaces rather than adds.
+    common::exec(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} COMPUTE STATISTICS NOSCAN"),
+    )
+    .await;
+    let remeasured = partition_statistics(&server);
+    assert_eq!(counts(&remeasured["dt=a/hh=00"]), (3, 2));
+    assert_eq!(counts(&remeasured["dt=a/hh=01"]), (1, 1));
+    assert_eq!(
+        remeasured["dt=a/hh=00"].file_size_in_bytes,
+        measured["dt=a/hh=00"].file_size_in_bytes
+    );
+
+    let calls = server.create_partitions_calls();
+    let (_, _, request) = calls.last().unwrap();
+    assert!(request.ignore_if_exists);
+    assert_eq!(request.replace_statistics, Some(true));
+    assert_eq!(server.table_partition_specs(DATABASE, TABLE).len(), 3);
+}
+
+#[cfg(not(windows))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_analyze_partition_clause_selects_a_leading_run_of_partition_values() {
+    let (temp_dir, server, context) = dt_hh_table(&[("a", "00"), ("a", "01"), ("b", "00")]).await;
+    for directory in ["dt=a/hh=00", "dt=a/hh=01", "dt=b/hh=00"] {
+        write_ids(&temp_dir.path().join(directory), &[1]);
+    }
+    let file_counts = |server: &RESTServer| {
+        let measured = partition_statistics(server);
+        ["dt=a/hh=00", "dt=a/hh=01", "dt=b/hh=00"].map(|name| measured[name].file_count)
+    };
+
+    common::exec(
+        &context,
+        &format!(
+            "ANALYZE TABLE {TABLE_NAME} PARTITION (dt = 'a', hh = '00') COMPUTE STATISTICS NOSCAN"
+        ),
+    )
+    .await;
+    assert_eq!(file_counts(&server), [1, UNKNOWN, UNKNOWN]);
+
+    // A column named without a value means every value of it.
+    common::exec(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} PARTITION (dt = 'a', hh) COMPUTE STATISTICS NOSCAN"),
+    )
+    .await;
+    assert_eq!(file_counts(&server), [1, 1, UNKNOWN]);
+    common::exec(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} PARTITION (dt, hh) COMPUTE STATISTICS NOSCAN"),
+    )
+    .await;
+    assert_eq!(file_counts(&server), [1, 1, 1]);
+
+    for (clause, message) in [
+        ("PARTITION (hh = '00')", "leading run"),
+        ("PARTITION (id = 1)", "not a partition column"),
+        ("PARTITION (dt = 'zzz')", "does not exist"),
+    ] {
+        common::assert_sql_error(
+            &context,
+            &format!("ANALYZE TABLE {TABLE_NAME} {clause} COMPUTE STATISTICS NOSCAN"),
+            message,
+        )
+        .await;
+    }
+}
+
+#[cfg(not(windows))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_analyze_reads_a_partition_value_as_its_column_type() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let schema = format_table_schema(&[("p", DataType::Int(IntType::new()))]);
+    let (server, context) = setup_rest_table(&temp_dir, schema).await;
+    common::exec(
+        &context,
+        &format!("ALTER TABLE {TABLE_NAME} ADD PARTITION (p = 1)"),
+    )
+    .await;
+    write_ids(&temp_dir.path().join("p=1"), &[1]);
+
+    common::exec(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} PARTITION (p = '01') COMPUTE STATISTICS NOSCAN"),
+    )
+    .await;
+
+    assert_eq!(partition_statistics(&server)["p=1"].file_count, 1);
+}
+
+#[cfg(not(windows))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_analyze_and_scan_count_only_the_files_a_reader_returns() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (server, context) =
+        setup_rest_table(&temp_dir, format_table_schema(&[("dt", varchar())])).await;
+    common::exec(
+        &context,
+        &format!("ALTER TABLE {TABLE_NAME} ADD PARTITION (dt = 'a')"),
+    )
+    .await;
+    let partition = temp_dir.path().join("dt=a");
+    write_ids_file(&partition.join("part-0.parquet"), &[1]);
+    // What committers and tools leave beside the data: staging trees, markers, hidden files.
+    write_ids_file(&partition.join("_temporary/0/part-9.parquet"), &[9]);
+    write_ids_file(&partition.join("__magic_job-1/tasks/part-8.parquet"), &[8]);
+    write_ids_file(&partition.join(".part-7.parquet"), &[7]);
+    std::fs::write(partition.join("_SUCCESS"), b"").unwrap();
+    std::fs::write(partition.join("notes.txt"), b"not data").unwrap();
+
+    common::exec(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} COMPUTE STATISTICS"),
+    )
+    .await;
+
+    assert_eq!(counts(&partition_statistics(&server)["dt=a"]), (1, 1));
+    assert_eq!(
+        ids(
+            &context,
+            &format!("SELECT id FROM {TABLE_NAME} WHERE dt = 'a'")
+        )
+        .await,
+        vec![1]
+    );
+}
+
+#[cfg(not(windows))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_analyze_leaves_a_row_count_unknown_rather_than_short() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (server, context) =
+        setup_rest_table(&temp_dir, format_table_schema(&[("dt", varchar())])).await;
+    common::exec(
+        &context,
+        &format!("ALTER TABLE {TABLE_NAME} ADD PARTITION (dt = 'a')"),
+    )
+    .await;
+    write_ids_file(&temp_dir.path().join("dt=a/part-0.parquet"), &[1, 2]);
+    std::fs::write(
+        temp_dir.path().join("dt=a/part-1.parquet"),
+        b"not a parquet footer",
+    )
+    .unwrap();
+
+    common::exec(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} COMPUTE STATISTICS"),
+    )
+    .await;
+
+    // A sum missing one file, reported as exact, would be worse than no number.
+    assert_eq!(counts(&partition_statistics(&server)["dt=a"]), (UNKNOWN, 2));
+}
+
+#[cfg(not(windows))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_analyze_refuses_what_it_cannot_measure() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (server, context) =
+        setup_rest_table(&temp_dir, format_table_schema(&[("dt", varchar())])).await;
+    for dt in ["a", "b"] {
+        common::exec(
+            &context,
+            &format!("ALTER TABLE {TABLE_NAME} ADD PARTITION (dt = '{dt}')"),
+        )
+        .await;
+        write_ids(&temp_dir.path().join(format!("dt={dt}")), &[1]);
+    }
+
+    common::assert_sql_error(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} COMPUTE STATISTICS FOR COLUMNS id"),
+        "FOR COLUMNS",
+    )
+    .await;
+
+    // A blank string names the default partition, which the statement would measure instead.
+    common::assert_sql_error(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} PARTITION (dt = '') COMPUTE STATISTICS"),
+        "empty or whitespace-only string for partition column 'dt'",
+    )
+    .await;
+
+    server.set_table_partition_options(
+        DATABASE,
+        TABLE,
+        &spec(&[("dt", "b")]),
+        HashMap::from([("path".to_string(), "file:///elsewhere/b".to_string())]),
+    );
+    common::assert_sql_error(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} COMPUTE STATISTICS NOSCAN"),
+        "custom location",
+    )
+    .await;
+    assert!(partition_statistics(&server)
+        .values()
+        .all(|partition| partition.file_count == UNKNOWN));
+
+    // A non-positive parallelism is read as one rather than failing the statement.
+    common::exec(
+        &context,
+        "SET \"paimon.format-table.statistics.parallelism\" = '0'",
+    )
+    .await;
+    common::exec(
+        &context,
+        &format!("ANALYZE TABLE {TABLE_NAME} PARTITION (dt = 'a') COMPUTE STATISTICS"),
+    )
+    .await;
+    assert_eq!(counts(&partition_statistics(&server)["dt=a"]), (1, 1));
+
+    // Without catalog-managed partitions there is no catalog to write the numbers to.
+    let plain = Schema::builder()
+        .column("dt", varchar())
+        .column("id", DataType::BigInt(BigIntType::new()))
+        .partition_keys(["dt"])
+        .option("type", "format-table")
+        .option("file.format", "parquet")
+        .build()
+        .unwrap();
+    server.add_table_with_schema(
+        DATABASE,
+        "plain",
+        plain,
+        &format!("file://{}/plain", temp_dir.path().display()),
+    );
+    server.set_table_external(DATABASE, "plain", false);
+    common::assert_sql_error(
+        &context,
+        "ANALYZE TABLE paimon.default.plain COMPUTE STATISTICS",
+        "catalog-managed",
+    )
+    .await;
 }
 
 /// `SQLContext::sql` futures have to stay `Send` for callers that box or spawn them; this stops

--- a/crates/paimon/src/arrow/format/mod.rs
+++ b/crates/paimon/src/arrow/format/mod.rs
@@ -30,7 +30,7 @@ pub(crate) use parquet::ParquetFormatWriter;
 
 use super::ParquetReadBudget;
 use super::RowFilterFactory;
-use crate::io::{FileRead, OutputFile};
+use crate::io::{FileIO, FileRead, OutputFile};
 use crate::spec::stats::BinaryTableStats;
 use crate::spec::{DataField, Predicate};
 use crate::table::{ArrowRecordBatchStream, RowRange};
@@ -155,6 +155,31 @@ impl FormatWriteResult {
                 columns,
             }),
         }
+    }
+}
+
+/// Rows in a data file of the given format, read from its footer alone, or `None` when the
+/// format keeps no row count there and every row would have to be decoded to count them.
+pub(crate) async fn read_file_row_count(
+    file_io: &FileIO,
+    format: &str,
+    path: &str,
+    file_size: u64,
+) -> crate::Result<Option<i64>> {
+    match format.to_ascii_lowercase().as_str() {
+        "parquet" => {
+            let reader = file_io.new_input(path)?.reader().await?;
+            parquet::read_row_count(Box::new(reader), file_size)
+                .await
+                .map(Some)
+        }
+        "orc" => {
+            let reader = file_io.new_input(path)?.reader().await?;
+            orc::read_row_count(Box::new(reader), file_size)
+                .await
+                .map(Some)
+        }
+        _ => Ok(None),
     }
 }
 

--- a/crates/paimon/src/arrow/format/orc.rs
+++ b/crates/paimon/src/arrow/format/orc.rs
@@ -368,6 +368,29 @@ fn build_range_row_selection(
     )
 }
 
+/// Rows in an ORC file, read from its footer alone.
+pub(crate) async fn read_row_count(
+    reader: Box<dyn FileRead>,
+    file_size: u64,
+) -> crate::Result<i64> {
+    let builder = ArrowReaderBuilder::try_new_async(OrcFileReader::new(file_size, reader))
+        .await
+        .map_err(|error| Error::UnexpectedError {
+            message: format!("Failed to open ORC file: {error}"),
+            source: Some(Box::new(error)),
+        })?;
+    let rows = builder
+        .file_metadata()
+        .stripe_metadatas()
+        .iter()
+        .map(|stripe| stripe.number_of_rows())
+        .sum::<u64>();
+    i64::try_from(rows).map_err(|_| Error::DataInvalid {
+        message: format!("ORC file holds {rows} rows, more than a row count can carry"),
+        source: None,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // OrcFileReader — adapts paimon FileRead to orc-rust AsyncChunkReader
 // ---------------------------------------------------------------------------

--- a/crates/paimon/src/arrow/format/parquet.rs
+++ b/crates/paimon/src/arrow/format/parquet.rs
@@ -1964,6 +1964,23 @@ const METADATA_SIZE_HINT: usize = 512 * 1024;
 /// avoid excessive small IO requests whose per-request overhead dominates.
 const IO_BLOCK_SIZE: u64 = 4 * 1024 * 1024;
 
+/// Rows in a Parquet file, read from its footer alone.
+pub(crate) async fn read_row_count(
+    reader: Box<dyn FileRead>,
+    file_size: u64,
+) -> crate::Result<i64> {
+    let reader = ArrowFileReader::new(file_size, Arc::from(reader));
+    let metadata = ParquetMetaDataReader::new()
+        .with_prefetch_hint(Some(METADATA_SIZE_HINT))
+        .load_and_finish(reader, file_size)
+        .await
+        .map_err(|error| Error::UnexpectedError {
+            message: format!("Failed to read the Parquet footer: {error}"),
+            source: Some(Box::new(error)),
+        })?;
+    Ok(metadata.file_metadata().num_rows())
+}
+
 impl ArrowFileReader {
     fn new(file_size: u64, r: Arc<dyn FileRead>) -> Self {
         Self { file_size, r }

--- a/crates/paimon/src/spec/mod.rs
+++ b/crates/paimon/src/spec/mod.rs
@@ -99,7 +99,7 @@ mod partition;
 pub use partition::Partition;
 mod partition_utils;
 pub(crate) use partition_utils::{
-    bucket_path, bucket_path_under, escape_path_name, PartitionComputer,
+    bucket_path, bucket_path_under, escape_path_name, unescape_path_name, PartitionComputer,
 };
 mod predicate;
 pub(crate) use predicate::datum_cmp;

--- a/crates/paimon/src/spec/partition_utils.rs
+++ b/crates/paimon/src/spec/partition_utils.rs
@@ -522,6 +522,37 @@ pub(crate) fn escape_path_name(path: &str) -> String {
     sb
 }
 
+/// Unescape a path component following Java `PartitionPathUtils.unescapePathName`.
+pub(crate) fn unescape_path_name(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if i + 2 >= bytes.len() {
+                return None;
+            }
+            let hi = hex_value(bytes[i + 1])?;
+            let lo = hex_value(bytes[i + 2])?;
+            out.push((hi << 4) | lo);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 /// Check if a character needs escaping in partition path names.
 ///
 /// Matches Java `PartitionPathUtils.CHAR_TO_ESCAPE`:
@@ -689,6 +720,14 @@ mod tests {
         assert_eq!(escape_path_name("a\x01b"), "a%01b");
         assert_eq!(escape_path_name("a\nb"), "a%0Ab");
         assert_eq!(escape_path_name("a\x7Fb"), "a%7Fb");
+    }
+
+    #[test]
+    fn test_unescape_path_name() {
+        assert_eq!(unescape_path_name("a%2Fb"), Some("a/b".to_string()));
+        assert_eq!(unescape_path_name("%E4%B8%AD"), Some("中".to_string()));
+        assert_eq!(unescape_path_name("a%ZZb"), None);
+        assert_eq!(unescape_path_name("a%b"), None);
     }
 
     // ======================== PartitionComputer tests ========================

--- a/crates/paimon/src/table/format_partition.rs
+++ b/crates/paimon/src/table/format_partition.rs
@@ -22,7 +22,8 @@ use std::collections::HashMap;
 
 use chrono::NaiveDate;
 
-use crate::spec::{escape_path_name, DataType, Datum};
+use crate::io::FileIO;
+use crate::spec::{escape_path_name, unescape_path_name, DataType, Datum};
 
 const UNIX_EPOCH_DAYS_FROM_CE: i32 = 719_163;
 
@@ -110,6 +111,68 @@ impl FormatTablePartitionPaths {
             .join("/"))
     }
 
+    /// Discover complete raw partition specs from the table directory.
+    ///
+    /// Hidden directories whose names begin with `.` or `_`, segments that do
+    /// not match the configured layout, and paths shallower than the declared
+    /// partition depth are ignored. In value-only layouts, the configured
+    /// default-partition directory is the only hidden-name exception.
+    /// A matching segment that is malformed or not canonically escaped returns
+    /// an error rather than being skipped, because its catalog spec would not
+    /// resolve back to the same physical path.
+    /// Results are sorted and deduplicated by canonical `key=value/...` name.
+    pub async fn discover(
+        &self,
+        file_io: &FileIO,
+        table_path: &str,
+        default_partition_name: &str,
+    ) -> crate::Result<Vec<HashMap<String, String>>> {
+        let default_partition_path_name = self
+            .only_value_in_path
+            .then(|| escape_path_name(default_partition_name));
+        let mut frontier = vec![(table_path.trim_end_matches('/').to_string(), HashMap::new())];
+        for key in &self.partition_keys {
+            let mut next = Vec::new();
+            for (path, spec) in frontier {
+                let statuses = match file_io.list_status(&path).await {
+                    Ok(statuses) => statuses,
+                    Err(error) if is_storage_not_found(&error) => continue,
+                    Err(error) => return Err(error),
+                };
+                for status in statuses {
+                    if !status.is_dir {
+                        continue;
+                    }
+                    let Some(segment) = last_path_segment(&status.path) else {
+                        continue;
+                    };
+                    let is_value_only_default =
+                        default_partition_path_name.as_deref() == Some(segment);
+                    if (segment.starts_with('.') || segment.starts_with('_'))
+                        && !is_value_only_default
+                    {
+                        continue;
+                    }
+                    let Some(value) = self.partition_value_from_segment(key, segment)? else {
+                        continue;
+                    };
+                    let mut child_spec = spec.clone();
+                    child_spec.insert(key.clone(), value);
+                    next.push((status.path.trim_end_matches('/').to_string(), child_spec));
+                }
+            }
+            frontier = next;
+        }
+
+        let mut partitions = frontier
+            .into_iter()
+            .map(|(_, spec)| Ok((self.partition_name(&spec)?, spec)))
+            .collect::<crate::Result<Vec<_>>>()?;
+        partitions.sort_by(|left, right| left.0.cmp(&right.0));
+        partitions.dedup_by(|left, right| left.0 == right.0);
+        Ok(partitions.into_iter().map(|(_, spec)| spec).collect())
+    }
+
     fn ordered_values<'a>(&self, spec: &'a HashMap<String, String>) -> crate::Result<Vec<&'a str>> {
         if spec.len() != self.partition_keys.len() {
             return Err(crate::Error::DataInvalid {
@@ -147,6 +210,44 @@ impl FormatTablePartitionPaths {
             self.partition_keys
         )
     }
+
+    fn partition_value_from_segment(
+        &self,
+        key: &str,
+        segment: &str,
+    ) -> crate::Result<Option<String>> {
+        let value = if self.only_value_in_path {
+            decode_canonical_path_name(segment)?
+        } else {
+            let Some((segment_key, value)) = segment.split_once('=') else {
+                return Ok(None);
+            };
+            let decoded_key = decode_canonical_path_name(segment_key)?;
+            if decoded_key != key {
+                return Ok(None);
+            }
+            decode_canonical_path_name(value)?
+        };
+        Ok(Some(value))
+    }
+}
+
+fn decode_canonical_path_name(value: &str) -> crate::Result<String> {
+    let decoded = unescape_path_name(value).ok_or_else(|| crate::Error::DataInvalid {
+        message: format!("Invalid escaped partition path segment {value:?}"),
+        source: None,
+    })?;
+    let canonical = escape_path_name(&decoded);
+    if canonical != value {
+        return Err(crate::Error::DataInvalid {
+            message: format!(
+                "Partition path segment {value:?} cannot round-trip through catalog metadata; \
+                 its canonical escaped form is {canonical:?}"
+            ),
+            source: None,
+        });
+    }
+    Ok(decoded)
 }
 
 /// Parse a raw Format Table partition value from a path or catalog registration.
@@ -230,6 +331,18 @@ fn parse_partition_date(value: &str) -> Option<i32> {
 fn format_partition_date(epoch_days: i32) -> Option<String> {
     NaiveDate::from_num_days_from_ce_opt(epoch_days.checked_add(UNIX_EPOCH_DAYS_FROM_CE)?)
         .map(|date| date.format("%Y-%m-%d").to_string())
+}
+
+fn is_storage_not_found(error: &crate::Error) -> bool {
+    matches!(
+        error,
+        crate::Error::IoUnexpected { source, .. }
+            if source.kind() == opendal::ErrorKind::NotFound
+    )
+}
+
+fn last_path_segment(path: &str) -> Option<&str> {
+    path.trim_end_matches('/').rsplit('/').next()
 }
 
 #[cfg(test)]
@@ -348,5 +461,19 @@ mod tests {
         // Escaping a value would inject the pattern's only wildcard, so pushdown is skipped
         // rather than silently widened.
         assert_eq!(paths.name_prefix_pattern(&["2026/07".to_string()]), None);
+    }
+
+    #[test]
+    fn test_storage_not_found_matches_only_not_found() {
+        for (kind, expected) in [
+            (opendal::ErrorKind::NotFound, true),
+            (opendal::ErrorKind::PermissionDenied, false),
+        ] {
+            let error = crate::Error::IoUnexpected {
+                message: "list partition directory".to_string(),
+                source: Box::new(opendal::Error::new(kind, "test")),
+            };
+            assert_eq!(is_storage_not_found(&error), expected);
+        }
     }
 }

--- a/crates/paimon/src/table/format_partition.rs
+++ b/crates/paimon/src/table/format_partition.rs
@@ -111,16 +111,8 @@ impl FormatTablePartitionPaths {
             .join("/"))
     }
 
-    /// Discover complete raw partition specs from the table directory.
-    ///
-    /// Hidden directories whose names begin with `.` or `_`, segments that do
-    /// not match the configured layout, and paths shallower than the declared
-    /// partition depth are ignored. In value-only layouts, the configured
-    /// default-partition directory is the only hidden-name exception.
-    /// A matching segment that is malformed or not canonically escaped returns
-    /// an error rather than being skipped, because its catalog spec would not
-    /// resolve back to the same physical path.
-    /// Results are sorted and deduplicated by canonical `key=value/...` name.
+    /// Discover complete raw partition specs from the table directory, sorted and deduplicated.
+    /// Skips hidden or non-matching entries; a malformed or non-canonical segment is an error.
     pub async fn discover(
         &self,
         file_io: &FileIO,

--- a/crates/paimon/src/table/format_partition_stats.rs
+++ b/crates/paimon/src/table/format_partition_stats.rs
@@ -28,20 +28,7 @@ use crate::arrow::format::read_file_row_count;
 use crate::io::FileStatus;
 use crate::spec::{CoreOptions, Partition, PartitionStatistics};
 
-/// Measures what the partitions of a Format Table currently hold.
-///
-/// File count, byte size and last file creation time come from a directory listing. The row
-/// count needs every file's footer, which no listing opens, so it is asked for rather than
-/// assumed. A partition holding nothing measures as an exact zero, with no last file to date.
-///
-/// It lists through the listing the scan uses, so a measurement counts exactly the files a
-/// reader would return and committer staging trees are left out. A listing failure aborts the
-/// whole collection: a truncated listing looks exactly like a partition that lost files.
-///
-/// The result is a whole-partition measurement, so a catalog should replace what it holds with
-/// it rather than add it up. It never decides that a partition should exist; it measures the
-/// ones it is given.
-///
+/// Measures whole partitions of a Format Table through the listing a scan uses.
 /// Mirrors Java `FormatTablePartitionStatsCollector`.
 #[derive(Debug)]
 pub struct FormatTablePartitionStatsCollector<'a> {
@@ -52,10 +39,7 @@ pub struct FormatTablePartitionStatsCollector<'a> {
 
 impl<'a> FormatTablePartitionStatsCollector<'a> {
     /// Measure `table`, reading file footers for row counts only when `with_record_count` is set.
-    ///
-    /// `parallelism` bounds the storage requests in flight: partition listings and footer reads
-    /// share it, so it applies to one large partition as much as to many small ones. A value below
-    /// one is read as one.
+    /// `parallelism` bounds listings and footer reads together; a value below one is read as one.
     pub fn new(table: &'a Table, with_record_count: bool, parallelism: usize) -> Self {
         Self {
             table,
@@ -159,9 +143,8 @@ impl<'a> FormatTablePartitionStatsCollector<'a> {
             .collect()
             .await;
 
-        // A partition with no files counted nothing and so holds exactly zero rows. One file
-        // whose count is unknown makes the whole partition unknown rather than short: a sum
-        // missing a file, reported as exact, is worse than no number at all.
+        // A partition with no files holds exactly zero rows; one file whose count is unknown
+        // makes the whole partition unknown rather than short.
         let mut record_counts = vec![Some(0i64); listings.len()];
         for (index, count) in counts {
             record_counts[index] = match (record_counts[index], count) {

--- a/crates/paimon/src/table/format_partition_stats.rs
+++ b/crates/paimon/src/table/format_partition_stats.rs
@@ -1,0 +1,203 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Measures the partitions of a Format Table with catalog-managed partitions.
+
+use std::collections::HashMap;
+
+use futures::{StreamExt, TryStreamExt};
+
+use super::format_partition::FormatTablePartitionPaths;
+use super::format_table_scan::{list_format_table_data_files, supported_format_table_extension};
+use super::Table;
+use crate::arrow::format::read_file_row_count;
+use crate::io::FileStatus;
+use crate::spec::{CoreOptions, Partition, PartitionStatistics};
+
+/// Measures what the partitions of a Format Table currently hold.
+///
+/// File count, byte size and last file creation time come from a directory listing. The row
+/// count needs every file's footer, which no listing opens, so it is asked for rather than
+/// assumed. A partition holding nothing measures as an exact zero, with no last file to date.
+///
+/// It lists through the listing the scan uses, so a measurement counts exactly the files a
+/// reader would return and committer staging trees are left out. A listing failure aborts the
+/// whole collection: a truncated listing looks exactly like a partition that lost files.
+///
+/// The result is a whole-partition measurement, so a catalog should replace what it holds with
+/// it rather than add it up. It never decides that a partition should exist; it measures the
+/// ones it is given.
+///
+/// Mirrors Java `FormatTablePartitionStatsCollector`.
+#[derive(Debug)]
+pub struct FormatTablePartitionStatsCollector<'a> {
+    table: &'a Table,
+    with_record_count: bool,
+    parallelism: usize,
+}
+
+impl<'a> FormatTablePartitionStatsCollector<'a> {
+    /// Measure `table`, reading file footers for row counts only when `with_record_count` is set.
+    ///
+    /// `parallelism` bounds the storage requests in flight: partition listings and footer reads
+    /// share it, so it applies to one large partition as much as to many small ones. A value below
+    /// one is read as one.
+    pub fn new(table: &'a Table, with_record_count: bool, parallelism: usize) -> Self {
+        Self {
+            table,
+            with_record_count,
+            parallelism: parallelism.max(1),
+        }
+    }
+
+    /// Measure the given complete partition specs. The result is aligned with `partitions` one for
+    /// one, so it can be sent to the catalog together with the same specs.
+    pub async fn collect(
+        &self,
+        partitions: &[HashMap<String, String>],
+    ) -> crate::Result<Vec<PartitionStatistics>> {
+        if partitions.is_empty() {
+            return Ok(Vec::new());
+        }
+        if !self.table.has_catalog_managed_partitions() {
+            return Err(crate::Error::Unsupported {
+                message: format!(
+                    "Format Table {} does not have catalog-managed partitions, so its partitions \
+                     cannot be measured",
+                    self.table.identifier().full_name()
+                ),
+            });
+        }
+        let options = CoreOptions::new(self.table.schema().options());
+        let format_extension = supported_format_table_extension(&options.file_format())?;
+        let partition_paths = FormatTablePartitionPaths::new(
+            self.table.schema().partition_keys().iter().cloned(),
+            options.format_table_partition_only_value_in_path(),
+        );
+        let table_path = options
+            .path()
+            .unwrap_or_else(|| self.table.location())
+            .trim_end_matches('/');
+        let directories = partitions
+            .iter()
+            .map(|spec| {
+                partition_paths
+                    .relative_path(spec)
+                    .map(|relative_path| format!("{table_path}/{relative_path}"))
+            })
+            .collect::<crate::Result<Vec<_>>>()?;
+
+        let file_io = self.table.file_io();
+        // Each future owns what it lists. A stream over borrowed items would leave the future of
+        // any SQL statement that measures partitions without a provable `Send`.
+        let listings: Vec<Vec<FileStatus>> = futures::stream::iter(directories)
+            .map(|directory| async move {
+                // Each directory is a complete partition, so no partition level lies below it.
+                list_format_table_data_files(file_io, &directory, 0, format_extension).await
+            })
+            .buffered(self.parallelism)
+            .try_collect()
+            .await?;
+
+        let record_counts = if self.with_record_count {
+            self.count_rows(&options.file_format(), &listings).await
+        } else {
+            vec![Partition::UNKNOWN; listings.len()]
+        };
+
+        Ok(partitions
+            .iter()
+            .zip(&listings)
+            .zip(record_counts)
+            .map(|((spec, files), record_count)| statistics(spec, files, record_count))
+            .collect())
+    }
+
+    /// The rows each listed partition holds. Every file of every partition goes through one
+    /// bounded stream, so a partition with many files is counted with all of it.
+    async fn count_rows(&self, file_format: &str, listings: &[Vec<FileStatus>]) -> Vec<i64> {
+        let file_io = self.table.file_io();
+        let files = listings
+            .iter()
+            .enumerate()
+            .flat_map(|(index, files)| {
+                files
+                    .iter()
+                    .map(move |file| (index, file.path.clone(), file.size))
+            })
+            .collect::<Vec<_>>();
+        let counts: Vec<(usize, Option<i64>)> = futures::stream::iter(files)
+            .map(|(index, path, size)| async move {
+                let count = match read_file_row_count(file_io, file_format, &path, size).await {
+                    Ok(count) => count,
+                    Err(error) => {
+                        log::warn!(
+                            "Failed to read the row count of {path} in table {}; the row count \
+                             of its partition stays unknown: {error}",
+                            self.table.identifier().full_name()
+                        );
+                        None
+                    }
+                };
+                (index, count)
+            })
+            .buffered(self.parallelism)
+            .collect()
+            .await;
+
+        // A partition with no files counted nothing and so holds exactly zero rows. One file
+        // whose count is unknown makes the whole partition unknown rather than short: a sum
+        // missing a file, reported as exact, is worse than no number at all.
+        let mut record_counts = vec![Some(0i64); listings.len()];
+        for (index, count) in counts {
+            record_counts[index] = match (record_counts[index], count) {
+                (Some(total), Some(count)) => total.checked_add(count),
+                _ => None,
+            };
+        }
+        record_counts
+            .into_iter()
+            .map(|count| count.unwrap_or(Partition::UNKNOWN))
+            .collect()
+    }
+}
+
+/// What the listed files of a partition add up to.
+fn statistics(
+    spec: &HashMap<String, String>,
+    files: &[FileStatus],
+    record_count: i64,
+) -> PartitionStatistics {
+    let file_size_in_bytes = files
+        .iter()
+        .map(|file| i64::try_from(file.size).unwrap_or(i64::MAX))
+        .fold(0i64, i64::saturating_add);
+    let last_file_creation_time = files
+        .iter()
+        .filter_map(|file| file.last_modified)
+        .map(|modified| modified.timestamp_millis())
+        .max()
+        .unwrap_or(Partition::UNKNOWN);
+    PartitionStatistics {
+        spec: spec.clone(),
+        record_count,
+        file_size_in_bytes,
+        file_count: files.len() as i64,
+        last_file_creation_time,
+        total_buckets: Partition::UNKNOWN_TOTAL_BUCKETS,
+    }
+}

--- a/crates/paimon/src/table/format_table_scan.rs
+++ b/crates/paimon/src/table/format_table_scan.rs
@@ -107,29 +107,22 @@ impl<'a> FormatTableScan<'a> {
                 let partition_levels_below_root = partition_fields
                     .len()
                     .saturating_sub(root_segments.len().saturating_sub(table_depth));
-                let statuses = self
-                    .list_status_recursive_if_exists(&scan_root.path)
-                    .await?;
+                let files = list_format_table_data_files(
+                    self.table.file_io(),
+                    &scan_root.path,
+                    partition_levels_below_root,
+                    format_extension,
+                )
+                .await?;
                 let mut splits = Vec::new();
-                for status in statuses {
-                    if is_hidden_below_partitions(
-                        &root_segments,
-                        partition_levels_below_root,
-                        &status.path,
-                    ) {
-                        continue;
-                    }
-                    if let Some(split) = self
-                        .status_to_split(
-                            status,
-                            table_path,
-                            format_extension,
-                            schema_id,
-                            partition_fields,
-                            scan_root.partition.clone(),
-                        )
-                        .await?
-                    {
+                for status in files {
+                    if let Some(split) = self.status_to_split(
+                        status,
+                        table_path,
+                        schema_id,
+                        partition_fields,
+                        scan_root.partition.clone(),
+                    )? {
                         splits.push(split);
                     }
                 }
@@ -363,27 +356,11 @@ impl<'a> FormatTableScan<'a> {
         }
     }
 
-    async fn list_status_recursive_if_exists(
-        &self,
-        path: &str,
-    ) -> crate::Result<Vec<crate::io::FileStatus>> {
-        match self.table.file_io().list_status_recursive(path).await {
-            Ok(statuses) => Ok(statuses),
-            Err(err) => {
-                if !self.table.file_io().exists(path).await.unwrap_or(true) {
-                    Ok(Vec::new())
-                } else {
-                    Err(err)
-                }
-            }
-        }
-    }
-
-    async fn status_to_split(
+    /// The split reading one file that [`list_format_table_data_files`] returned.
+    fn status_to_split(
         &self,
         status: crate::io::FileStatus,
         table_path: &str,
-        format_extension: &str,
         schema_id: i64,
         partition_fields: &[DataField],
         known_partition: BinaryRow,
@@ -393,17 +370,6 @@ impl<'a> FormatTableScan<'a> {
         };
         let parent = parent.to_string();
         let file_name = file_name.to_string();
-        if !is_format_table_data_file_name(&file_name) {
-            return Ok(None);
-        }
-        if !file_name.to_ascii_lowercase().ends_with(format_extension) {
-            return Ok(None);
-        }
-        let status = if status.size == 0 {
-            self.table.file_io().get_status(&status.path).await?
-        } else {
-            status
-        };
         let file_size = i64::try_from(status.size).map_err(|_| crate::Error::DataInvalid {
             message: format!(
                 "Format table file '{}' is too large to fit in i64 metadata",
@@ -481,6 +447,51 @@ struct ScanRoot {
 
 fn is_format_table_data_file_name(file_name: &str) -> bool {
     !file_name.is_empty() && !file_name.starts_with('.') && !file_name.starts_with('_')
+}
+
+/// The data files a Format Table scan reads below `root`: files whose own name is not hidden and
+/// ends with the format's extension, outside any entry that [`is_hidden_below_partitions`] skips.
+/// `partition_levels_below_root` is how many partition levels still lie under `root`.
+///
+/// A root that does not exist holds no files. Any other listing failure is returned, since a
+/// partial listing cannot be told apart from a partition that lost files. `ANALYZE TABLE`
+/// measures a partition through this listing, so it counts exactly the files a scan reads.
+pub(crate) async fn list_format_table_data_files(
+    file_io: &crate::io::FileIO,
+    root: &str,
+    partition_levels_below_root: usize,
+    format_extension: &str,
+) -> crate::Result<Vec<crate::io::FileStatus>> {
+    let statuses = match file_io.list_status_recursive(root).await {
+        Ok(statuses) => statuses,
+        Err(error) => {
+            if !file_io.exists(root).await.unwrap_or(true) {
+                return Ok(Vec::new());
+            }
+            return Err(error);
+        }
+    };
+    let root_segments = path_segments(root);
+    let mut files = Vec::with_capacity(statuses.len());
+    for status in statuses {
+        if is_hidden_below_partitions(&root_segments, partition_levels_below_root, &status.path) {
+            continue;
+        }
+        let is_data_file = split_parent_and_file(&status.path).is_some_and(|(_, file_name)| {
+            is_format_table_data_file_name(file_name)
+                && file_name.to_ascii_lowercase().ends_with(format_extension)
+        });
+        if !is_data_file {
+            continue;
+        }
+        let status = if status.size == 0 {
+            file_io.get_status(&status.path).await?
+        } else {
+            status
+        };
+        files.push(status);
+    }
+    Ok(files)
 }
 
 /// Whether a listed file is, or lies inside, an entry whose name starts with `.` or `_` below
@@ -843,7 +854,7 @@ fn supported_format_table_formats() -> Vec<&'static str> {
     ]
 }
 
-fn supported_format_table_extension(format: &str) -> crate::Result<&'static str> {
+pub(crate) fn supported_format_table_extension(format: &str) -> crate::Result<&'static str> {
     match format.to_ascii_lowercase().as_str() {
         "parquet" => Ok(".parquet"),
         "orc" => Ok(".orc"),
@@ -1090,6 +1101,50 @@ mod tests {
         assert_eq!(
             planned_files(&table, Some(null_partition)).await,
             vec!["__DEFAULT_PARTITION__/part-0.parquet"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_data_file_listing_returns_what_a_partition_scan_reads() {
+        let table = format_table("memory:/data_file_listing", &["dt"], &[]);
+        write_files(
+            &table,
+            &[
+                "dt=a/part-0.parquet",
+                "dt=a/_temporary/0/part-1.parquet",
+                "dt=a/__magic_job_1/tasks/part-2.parquet",
+                "dt=a/.part-3.parquet",
+                "dt=a/_SUCCESS",
+                "dt=a/notes.txt",
+            ],
+        )
+        .await;
+        let file_names = |files: Vec<crate::io::FileStatus>| {
+            files
+                .iter()
+                .filter_map(|file| {
+                    split_parent_and_file(&file.path).map(|(_, name)| name.to_string())
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let partition = format!("{}/dt=a", table.location());
+        let listed = list_format_table_data_files(table.file_io(), &partition, 0, ".parquet")
+            .await
+            .unwrap();
+        assert_eq!(file_names(listed), vec!["part-0.parquet"]);
+        assert_eq!(
+            planned_files(&table, Some(partition_set(&table, &[&[Some("a")]]))).await,
+            vec!["dt=a/part-0.parquet"]
+        );
+
+        // A partition whose directory is gone holds no files rather than failing the listing.
+        let missing = format!("{}/dt=b", table.location());
+        assert!(
+            list_format_table_data_files(table.file_io(), &missing, 0, ".parquet")
+                .await
+                .unwrap()
+                .is_empty()
         );
     }
 

--- a/crates/paimon/src/table/format_table_scan.rs
+++ b/crates/paimon/src/table/format_table_scan.rs
@@ -449,13 +449,8 @@ fn is_format_table_data_file_name(file_name: &str) -> bool {
     !file_name.is_empty() && !file_name.starts_with('.') && !file_name.starts_with('_')
 }
 
-/// The data files a Format Table scan reads below `root`: files whose own name is not hidden and
-/// ends with the format's extension, outside any entry that [`is_hidden_below_partitions`] skips.
-/// `partition_levels_below_root` is how many partition levels still lie under `root`.
-///
-/// A root that does not exist holds no files. Any other listing failure is returned, since a
-/// partial listing cannot be told apart from a partition that lost files. `ANALYZE TABLE`
-/// measures a partition through this listing, so it counts exactly the files a scan reads.
+/// The non-hidden files with the format's extension that a Format Table scan reads below `root`.
+/// A missing root holds no files; any other listing failure is returned, never a partial list.
 pub(crate) async fn list_format_table_data_files(
     file_io: &crate::io::FileIO,
     root: &str,

--- a/crates/paimon/src/table/format_table_scan.rs
+++ b/crates/paimon/src/table/format_table_scan.rs
@@ -26,9 +26,9 @@ use super::{Plan, RESTEnv, ScanTrace, Table};
 use crate::api::RestError;
 use crate::spec::stats::BinaryTableStats;
 use crate::spec::{
-    escape_path_name, extract_datum, BinaryRow, BinaryRowBuilder, CoreOptions, DataField,
-    DataFileMeta, DataType, Datum, Partition, PartitionComputer, Predicate, PredicateOperator,
-    PATH_OPTION,
+    escape_path_name, extract_datum, unescape_path_name, BinaryRow, BinaryRowBuilder, CoreOptions,
+    DataField, DataFileMeta, DataType, Datum, Partition, PartitionComputer, Predicate,
+    PredicateOperator, PATH_OPTION,
 };
 use crate::table::partition_filter::PartitionFilter;
 use crate::table::source::{DataSplitBuilder, RowRange};
@@ -828,36 +828,6 @@ fn partition_segment_value(segment: &str, key: &str) -> Option<String> {
         unescape_path_name(segment_value)
     } else {
         None
-    }
-}
-
-fn unescape_path_name(value: &str) -> Option<String> {
-    let bytes = value.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' {
-            if i + 2 >= bytes.len() {
-                return None;
-            }
-            let hi = hex_value(bytes[i + 1])?;
-            let lo = hex_value(bytes[i + 2])?;
-            out.push((hi << 4) | lo);
-            i += 3;
-        } else {
-            out.push(bytes[i]);
-            i += 1;
-        }
-    }
-    String::from_utf8(out).ok()
-}
-
-fn hex_value(byte: u8) -> Option<u8> {
-    match byte {
-        b'0'..=b'9' => Some(byte - b'0'),
-        b'a'..=b'f' => Some(byte - b'a' + 10),
-        b'A'..=b'F' => Some(byte - b'A' + 10),
-        _ => None,
     }
 }
 

--- a/crates/paimon/src/table/mod.rs
+++ b/crates/paimon/src/table/mod.rs
@@ -41,6 +41,7 @@ mod data_file_reader;
 mod data_file_writer;
 mod dedicated_format_file_writer;
 mod format_partition;
+mod format_partition_stats;
 mod format_read_builder;
 mod format_table_read;
 mod format_table_scan;
@@ -121,6 +122,7 @@ pub use data_evolution_writer::{DataEvolutionDeleteWriter, DataEvolutionWriter};
 pub use format_partition::{
     format_partition_value, parse_format_partition_value, FormatTablePartitionPaths,
 };
+pub use format_partition_stats::FormatTablePartitionStatsCollector;
 #[cfg(feature = "fulltext")]
 pub use full_text_search_builder::FullTextSearchBuilder;
 use futures::stream::BoxStream;

--- a/crates/paimon/tests/format_partition_test.rs
+++ b/crates/paimon/tests/format_partition_test.rs
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+#[cfg(not(windows))]
+use std::path::Path;
+
+use paimon::io::FileIO;
+use paimon::table::FormatTablePartitionPaths;
+
+#[cfg(not(windows))]
+async fn discover_partitions(
+    root: &Path,
+    partition_keys: &[&str],
+    only_value_in_path: bool,
+    default_partition_name: &str,
+) -> paimon::Result<Vec<HashMap<String, String>>> {
+    let table_path = format!("file://{}", root.display());
+    let file_io = FileIO::from_path(&table_path)?.build()?;
+    FormatTablePartitionPaths::new(partition_keys.iter().copied(), only_value_in_path)
+        .discover(&file_io, &table_path, default_partition_name)
+        .await
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn discover_format_partitions_returns_complete_sorted_specs() {
+    let tmp = tempfile::tempdir().unwrap();
+    for relative in [
+        "dt=2026-07-22/hour=10",
+        "dt=2026-07-21/hour=09",
+        "dt=2026-07-20",
+        ".staging/dt=2026-07-19/hour=08",
+    ] {
+        std::fs::create_dir_all(tmp.path().join(relative)).unwrap();
+    }
+
+    let partitions =
+        discover_partitions(tmp.path(), &["dt", "hour"], false, "__DEFAULT_PARTITION__")
+            .await
+            .unwrap();
+
+    assert_eq!(
+        partitions,
+        vec![
+            HashMap::from([
+                ("dt".to_string(), "2026-07-21".to_string()),
+                ("hour".to_string(), "09".to_string()),
+            ]),
+            HashMap::from([
+                ("dt".to_string(), "2026-07-22".to_string()),
+                ("hour".to_string(), "10".to_string()),
+            ]),
+        ]
+    );
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn discover_format_partitions_treats_missing_root_as_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let partitions = discover_partitions(
+        &tmp.path().join("missing"),
+        &["dt"],
+        false,
+        "__DEFAULT_PARTITION__",
+    )
+    .await
+    .unwrap();
+
+    assert!(partitions.is_empty());
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn discover_value_only_partitions_rejects_parent_traversal_value() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("%2E%2E")).unwrap();
+
+    let error = discover_partitions(tmp.path(), &["dt"], true, "__DEFAULT_PARTITION__")
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains(".."),
+        "expected traversal value in error, got: {error}"
+    );
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn discover_value_only_partitions_keeps_hidden_default_directory() {
+    for (default_name, directory, ignored_directory) in [
+        ("__DEFAULT_PARTITION__", "__DEFAULT_PARTITION__", None),
+        (".NULL", ".NULL", Some(".staging")),
+        ("_NULL/%NA", "_NULL%2F%25NA", Some("_temporary")),
+    ] {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(directory)).unwrap();
+        if let Some(ignored_directory) = ignored_directory {
+            std::fs::create_dir_all(tmp.path().join(ignored_directory)).unwrap();
+        }
+
+        let partitions = discover_partitions(tmp.path(), &["dt"], true, default_name)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            partitions,
+            vec![HashMap::from([(
+                "dt".to_string(),
+                default_name.to_string()
+            )])],
+            "{default_name}"
+        );
+    }
+}

--- a/crates/paimon/tests/mock_server.rs
+++ b/crates/paimon/tests/mock_server.rs
@@ -1455,6 +1455,17 @@ impl RESTServer {
             .unwrap_or_default()
     }
 
+    /// Return the partitions registered for a table, statistics included, in registration order.
+    pub fn table_partitions(&self, database: &str, table: &str) -> Vec<Partition> {
+        self.inner
+            .lock()
+            .unwrap()
+            .partitions
+            .get(&format!("{database}.{table}"))
+            .cloned()
+            .unwrap_or_default()
+    }
+
     /// Set whether a stored table is external.
     pub fn set_table_external(&self, database: &str, table: &str, is_external: bool) {
         let key = format!("{database}.{table}");

--- a/docs/src/sql.md
+++ b/docs/src/sql.md
@@ -40,7 +40,7 @@ Mosaic support is always available and currently read-only. SQL queries can read
 SQL support has two layers:
 
 - DataFusion provides the parser, query planner, optimizer, execution engine, expressions, scalar functions, aggregate functions, and window functions. SQL statements that `SQLContext` does not intercept are delegated to DataFusion. This includes the DataFusion SQL surface for `SELECT` queries, CTEs (including recursive CTEs), subqueries, joins including `LATERAL` joins, SQL lambda functions, grouping, `HAVING`, window clauses, `QUALIFY`, set operations, `ORDER BY`, `LIMIT`/`OFFSET`, `EXPLAIN`, information-schema commands such as `SHOW TABLES`, `DESCRIBE`, `COPY`, and ordinary `INSERT`.
-- Paimon-specific table management and row-level writes are implemented by `SQLContext`. This includes Paimon `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, `CREATE TEMPORARY TABLE`, `CREATE TEMPORARY VIEW`, REST Catalog persistent `CREATE VIEW`, `DROP VIEW`, and `CREATE FUNCTION`, `DROP TEMPORARY TABLE` / `VIEW`, `INSERT OVERWRITE ... PARTITION`, `UPDATE`, `DELETE`, `MERGE INTO`, `TRUNCATE TABLE`, `ALTER TABLE ... ADD PARTITION`, `ALTER TABLE ... DROP PARTITION`, `SHOW PARTITIONS`, `MSCK REPAIR TABLE`, `CALL sys.*`, Paimon time travel, and `SET` / `RESET 'paimon.*'`.
+- Paimon-specific table management and row-level writes are implemented by `SQLContext`. This includes Paimon `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, `CREATE TEMPORARY TABLE`, `CREATE TEMPORARY VIEW`, REST Catalog persistent `CREATE VIEW`, `DROP VIEW`, and `CREATE FUNCTION`, `DROP TEMPORARY TABLE` / `VIEW`, `INSERT OVERWRITE ... PARTITION`, `UPDATE`, `DELETE`, `MERGE INTO`, `TRUNCATE TABLE`, `ALTER TABLE ... ADD PARTITION`, `ALTER TABLE ... DROP PARTITION`, `SHOW PARTITIONS`, `MSCK REPAIR TABLE`, `ANALYZE TABLE`, `CALL sys.*`, Paimon time travel, and `SET` / `RESET 'paimon.*'`.
 
 Not every DataFusion DDL/DML statement maps to a Paimon table operation. For Paimon catalogs, `CREATE EXTERNAL TABLE`, `LOCATION`, `CREATE MATERIALIZED VIEW`, and persistent `CREATE TABLE AS SELECT` are rejected or not implemented. Persistent `CREATE FUNCTION` is supported only for the REST Catalog SQL scalar form documented below. DataFusion `COPY` can export query results to files; it does not create or commit Paimon table files.
 
@@ -984,6 +984,41 @@ listing both complete before any change is made, so a listing failure cannot tur
 truncated view of the table into a `DROP` diff. There is no dry-run and no scope
 argument — repair always covers the whole table. A partition at a custom location is
 never unregistered by repair.
+
+### ANALYZE TABLE
+
+Measure what the registered partitions hold and report it to the catalog:
+
+```sql
+ANALYZE TABLE paimon.my_db.events COMPUTE STATISTICS NOSCAN;  -- files, size, last file time
+ANALYZE TABLE paimon.my_db.events COMPUTE STATISTICS;         -- also row counts
+ANALYZE TABLE paimon.my_db.events PARTITION (dt = '2024-01-01') COMPUTE STATISTICS;
+```
+
+Each partition is measured through the listing a scan uses, so it counts exactly the files
+a query reads and leaves staging entries such as `_temporary` out. `NOSCAN` stops at the
+listing: it reports the file count, the total size and the latest file modification time.
+Without `NOSCAN` the row count is also read from each file's footer, which Parquet and ORC
+keep; for other formats it stays unknown. A footer that cannot be read leaves the row count
+of its partition unknown rather than short, and a partition without files holds exactly
+zero rows. A field the statement does not measure, such as the row count under `NOSCAN`,
+is reported as unknown (`-1`).
+
+The measurement replaces the statistics the catalog holds for each partition; it never
+adds or removes a partition. `PARTITION (...)` must give values for a leading run of the
+partition keys and selects every registered partition under them: on a `(dt, region)`
+table, `PARTITION (dt = '2024-01-01')` measures every region of that date, while
+`PARTITION (region = 'us')` is rejected. It is an error when no registered partition
+matches. A selected partition at a custom location fails the statement, and
+`FOR COLUMNS` is not supported.
+
+A listing failure fails the statement before anything is reported.
+`format-table.statistics.parallelism` (default 8) bounds the storage requests in flight,
+listings and footer reads alike. Set it for the session:
+
+```sql
+SET 'paimon.format-table.statistics.parallelism' = '16';
+```
 
 ## Procedures
 

--- a/docs/src/sql.md
+++ b/docs/src/sql.md
@@ -40,7 +40,7 @@ Mosaic support is always available and currently read-only. SQL queries can read
 SQL support has two layers:
 
 - DataFusion provides the parser, query planner, optimizer, execution engine, expressions, scalar functions, aggregate functions, and window functions. SQL statements that `SQLContext` does not intercept are delegated to DataFusion. This includes the DataFusion SQL surface for `SELECT` queries, CTEs (including recursive CTEs), subqueries, joins including `LATERAL` joins, SQL lambda functions, grouping, `HAVING`, window clauses, `QUALIFY`, set operations, `ORDER BY`, `LIMIT`/`OFFSET`, `EXPLAIN`, information-schema commands such as `SHOW TABLES`, `DESCRIBE`, `COPY`, and ordinary `INSERT`.
-- Paimon-specific table management and row-level writes are implemented by `SQLContext`. This includes Paimon `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, `CREATE TEMPORARY TABLE`, `CREATE TEMPORARY VIEW`, REST Catalog persistent `CREATE VIEW`, `DROP VIEW`, and `CREATE FUNCTION`, `DROP TEMPORARY TABLE` / `VIEW`, `INSERT OVERWRITE ... PARTITION`, `UPDATE`, `DELETE`, `MERGE INTO`, `TRUNCATE TABLE`, `ALTER TABLE ... ADD PARTITION`, `ALTER TABLE ... DROP PARTITION`, `SHOW PARTITIONS`, `CALL sys.*`, Paimon time travel, and `SET` / `RESET 'paimon.*'`.
+- Paimon-specific table management and row-level writes are implemented by `SQLContext`. This includes Paimon `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, `CREATE TEMPORARY TABLE`, `CREATE TEMPORARY VIEW`, REST Catalog persistent `CREATE VIEW`, `DROP VIEW`, and `CREATE FUNCTION`, `DROP TEMPORARY TABLE` / `VIEW`, `INSERT OVERWRITE ... PARTITION`, `UPDATE`, `DELETE`, `MERGE INTO`, `TRUNCATE TABLE`, `ALTER TABLE ... ADD PARTITION`, `ALTER TABLE ... DROP PARTITION`, `SHOW PARTITIONS`, `MSCK REPAIR TABLE`, `CALL sys.*`, Paimon time travel, and `SET` / `RESET 'paimon.*'`.
 
 Not every DataFusion DDL/DML statement maps to a Paimon table operation. For Paimon catalogs, `CREATE EXTERNAL TABLE`, `LOCATION`, `CREATE MATERIALIZED VIEW`, and persistent `CREATE TABLE AS SELECT` are rejected or not implemented. Persistent `CREATE FUNCTION` is supported only for the REST Catalog SQL scalar form documented below. DataFusion `COPY` can export query results to files; it does not create or commit Paimon table files.
 
@@ -967,6 +967,23 @@ the catalog never deletes data. If the deletion fails the partition is already i
 and the directory may survive; repair the file system and remove it there rather than
 re-registering it. A partition at a custom location is only unregistered; its directory
 is left where it is.
+
+### MSCK REPAIR TABLE
+
+Reconcile the catalog registrations with the directories that actually exist:
+
+```sql
+MSCK REPAIR TABLE paimon.my_db.events;                  -- same as ADD PARTITIONS
+MSCK REPAIR TABLE paimon.my_db.events ADD PARTITIONS;   -- register discovered directories
+MSCK REPAIR TABLE paimon.my_db.events DROP PARTITIONS;  -- unregister vanished directories
+MSCK REPAIR TABLE paimon.my_db.events SYNC PARTITIONS;  -- both
+```
+
+Repair is metadata-only: it never deletes data. Directory discovery and the catalog
+listing both complete before any change is made, so a listing failure cannot turn a
+truncated view of the table into a `DROP` diff. There is no dry-run and no scope
+argument — repair always covers the whole table. A partition at a custom location is
+never unregistered by repair.
 
 ## Procedures
 


### PR DESCRIPTION
### Purpose

A Format Table loaded from REST Catalog can have its partitions managed by the catalog instead of discovered from the directory layout. This draft PR shows the complete Rust support for such tables in one place. **It is not meant to be merged**: every change reaches `main` through the child PRs below, and this branch follows the top of the child stack so the whole feature can be read and tried together.

### Child PRs

| # | PR | Scope | Status |
|---|----|-------|--------|
| 1 | #811 | Keep Format Table partition columns out of Parquet decoder filters | Merged in `7cb6f8a` |
| 2 | #813 | Skip committer staging files and list partition directories concurrently | Merged in `0496577` |
| 3 | #812 | REST partition registration, lookup and statistics APIs | Merged in `2bb2abb` |
| 4 | #814 | Read the registered partitions of a catalog-managed Format Table | Merged in `6824487` |
| 5 | #816 | `SHOW PARTITIONS`, `ALTER TABLE ... ADD / DROP PARTITION`, `Catalog::drop_partitions` | Merged in `cecd3dc` |
| 6 | #817 | `MSCK REPAIR TABLE`, partition directory discovery | Open, based on `main` |
| 7 | #815 | `ANALYZE TABLE ... COMPUTE STATISTICS [NOSCAN]` | Open, depends on #817 |

Review happens in the child PRs; comments here are welcome but will be carried over to the child that owns the code.

### Brief change log

Merged on `main`:

- `SHOW PARTITIONS table [PARTITION (...)]`, `ALTER TABLE table ADD [IF NOT EXISTS] PARTITION (...)` and `ALTER TABLE table DROP [IF EXISTS] PARTITION (...)`. DROP follows Java `resolveFormatTablePartitionsForDrop`: several specifications, partial specifications expanded to every registered match, values compared as the catalog holds them, registrations removed before directories, and a partition at a custom location only unregistered. Partition literals are read with the column type as Java `TypeUtils.castFromString` reads partition strings. `Catalog::drop_partitions`, which `RESTCatalog` refuses for tables without catalog-managed partitions (#816).
- REST Catalog APIs for paginated partition listing, create/drop registration (1000-entry batches), `list-by-names`, `list-by-filter`, and partition statistics reported with a create (`partitionStatistics` / `replaceStatistics`); a partition listed without statistics decodes them as unknown (-1) (#812).
- Eligible internal Format Tables load immutable REST partition metadata and scan only registered partitions. A scan sends its partition predicate to `list-by-filter` with a partition-name pattern built from leading CHAR/VARCHAR equalities, falls back to the paged listing when the catalog answers 501, and fails on a partition registered at a custom location (#814).
- Partition directories are listed concurrently, bounded by `format-table.scan.list-parallelism`, and entries starting with `.` or `_` below a partition directory, such as `_temporary` and `__magic_*`, are skipped (#813).
- A filter on a Format Table partition column that cannot become a partition predicate is no longer installed as a Parquet decoder filter, where it read the missing file column and returned no rows (#811).

In review:

- #817: `MSCK REPAIR TABLE table [{ADD|DROP|SYNC} PARTITIONS]` reconciles registrations with the directories that exist. Discovery and the catalog listing both finish before any change, DROP and SYNC fail unless the table root is a directory, and a partition at a custom location is never unregistered.
- #815: `ANALYZE TABLE table [PARTITION (...)] COMPUTE STATISTICS [NOSCAN]` measures registered partitions from storage and replaces the statistics the catalog holds. `NOSCAN` reports file count, size and last file creation time; a full run also reads Parquet and ORC footers for row counts. `format-table.statistics.parallelism` (default 8) bounds the work.

Following review on #816, each statement lives in its own module under `crates/integrations/datafusion/src/`: `format_partition_ddl.rs` (#816), `format_partition_repair.rs` (#817) and `format_partition_analyze.rs` (#815). `sql_context.rs` only dispatches them.

### Tests

Each child PR lists its tests. Commands run on the top of the stack (#815's head, the same tree as this branch):

```
cargo fmt --all -- --check
cargo clippy --locked --all-targets --workspace --features fulltext,vortex -- -D warnings
cargo test --locked -p paimon --all-targets --features fulltext,vortex
cargo test --locked --no-fail-fast -p paimon-datafusion --all-targets
cargo test --locked -p paimon-rest-server --all-targets
```

fmt and clippy pass. `paimon`: 2967 tests pass. `paimon-rest-server`: 10 tests pass. `paimon-datafusion`: 781 pass, including the 16 tests in `rest_format_partition_sql.rs`, and 39 fail. The failures are the 39 tests that also fail by name on `main` in this environment, because they read fixture tables provisioned by `make docker-up` (two also need the lumina native library).

Before the split, the branch was also validated end to end against a Bennett REST catalog server with a local file warehouse (10,000 registered partitions through `SHOW PARTITIONS`, ADD, MSCK ADD/SYNC, filtered reads, ANALYZE NOSCAN and full, and DROP). That run has not been repeated on the restructured stack.

### Additions without a direct Java counterpart

Listed in each child PR: #816 (SQL literal conversion, the `SHOW PARTITIONS` parser, the `RESTCatalog::drop_partitions` refusal, the `Send` check on `SQLContext::sql`), #817 (repair safeguards) and #815 (footer row counts, in-process measurement).

### API and Format

Changes still in review:

- New `Catalog::drop_partitions`, with a default implementation that returns `Unsupported` (#816).
- `paimon::table::FormatTablePartitionPaths` (with `discover` from #817), `format_partition_value` and `parse_format_partition_value` become public (#816).
- New public `paimon::table::FormatTablePartitionStatsCollector` and option `format-table.statistics.parallelism` (#815).

The API changes that merged with #812 are described there. The storage format is unchanged.

### Documentation

`docs/src/sql.md` gains a Format Table Partitions section covering the `metastore.partitioned-table` prerequisite, `SHOW` / `ADD` / `DROP PARTITION`, `MSCK REPAIR TABLE`, `ANALYZE TABLE`, how partition values are read, and how a partition at a custom location is treated. Each child PR adds its own part.

### Scope and limitations

- Applies only to partitioned internal REST Format Tables with `metastore.partitioned-table=true` and a non-`engine` implementation.
- Several `DROP PARTITION` specifications are written as repeated clauses, `DROP PARTITION (...), DROP PARTITION (...)`; sqlparser 0.62 cannot parse the Hive form `DROP PARTITION (...), (...)`.
- Reading a partition from its custom location is not implemented yet; such partitions fail closed.
- Partition row counts reported by ANALYZE are not yet used for DataFusion scan statistics (apache/paimon#9351 on the Java side).
- Writing Format Tables from the Rust client is still unsupported; `INSERT INTO` fails before anything is written or registered.
- A TIME partition value must be given as an integer. Partition columns typed DECIMAL, TIMESTAMP, FLOAT, DOUBLE or BINARY remain unsupported on this path.
