### PR TITLE
ci: install cargo-about CLI on Intel macOS

### DIFF
--- a/.github/workflows/release-go-binding.yml
+++ b/.github/workflows/release-go-binding.yml
@@ -144,9 +144,14 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-about
+        if: matrix.runner != 'macos-15-intel'
         uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
         with:
           tool: cargo-about@0.9.1
+
+      - name: Install cargo-about on Intel macOS
+        if: matrix.runner == 'macos-15-intel'
+        run: cargo install cargo-about --version 0.9.1 --locked --features cli
 
       - name: Install zstd on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/release-go-binding.yml
+++ b/.github/workflows/release-go-binding.yml
@@ -151,7 +151,13 @@ jobs:
 
       - name: Install cargo-about on Intel macOS
         if: matrix.runner == 'macos-15-intel'
-        run: cargo install cargo-about --version 0.9.1 --locked --features cli
+        shell: bash
+        run: |
+          if cargo-about --version 2>/dev/null | grep -Fqx 'cargo-about 0.9.1'; then
+            echo 'cargo-about 0.9.1 is already installed'
+          else
+            cargo install cargo-about --version 0.9.1 --locked --features cli --force
+          fi
 
       - name: Install zstd on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/release_python_binding.yml
+++ b/.github/workflows/release_python_binding.yml
@@ -115,9 +115,14 @@ jobs:
           python-version: "3.11"
 
       - name: Install cargo-about
+        if: matrix.os != 'macos-15-intel'
         uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
         with:
           tool: cargo-about@0.9.1
+
+      - name: Install cargo-about on Intel macOS
+        if: matrix.os == 'macos-15-intel'
+        run: cargo install cargo-about --version 0.9.1 --locked --features cli
 
       - name: Set Python release version
         shell: bash


### PR DESCRIPTION
## What

- keep the prebuilt cargo-about install path on supported runners
- install cargo-about 0.9.1 with the required cli feature on macos-15-intel
- apply the fix to both Python and Go release workflows

## Why

The v0.3.0-rc1 Python release failed because taiki-e/install-action fell back to a source install on x86_64 macOS without enabling cargo-about's cli feature. The step reported success but did not install the cargo-about binary. The Go release workflow uses the same path.

Failed run: https://github.com/apache/paimon-rust/actions/runs/30012257692

## Verification

- parsed both modified workflows as YAML
- git diff --check