### PR TITLE
feat(python): add abort method to TableCommit for write rollback

### DIFF
--- a/bindings/python/src/write.rs
+++ b/bindings/python/src/write.rs
@@ -175,38 +175,76 @@ pub struct PyTableCommit {
     commit_user: String,
 }
 
+/// Collect and validate commit messages from a Python iterable, returning the
+/// inner Rust `CommitMessage` values. Shared by `commit` and `abort`.
+fn collect_and_validate_messages<'py>(
+    messages: &Bound<'py, PyAny>,
+    table_location: &str,
+    commit_user: &str,
+    method: &str,
+) -> PyResult<Vec<CommitMessage>> {
+    let mut inner_messages = Vec::new();
+    let iter = messages.try_iter().map_err(|_| {
+        PyTypeError::new_err(format!(
+            "{method}() expects a sequence of CommitMessage objects"
+        ))
+    })?;
+    for item in iter {
+        let item = item?;
+        let msg: PyRef<'py, PyCommitMessage> = item.extract().map_err(|_| {
+            PyTypeError::new_err(format!(
+                "{method}() expects a sequence of CommitMessage objects"
+            ))
+        })?;
+        if msg.table_location != table_location {
+            return Err(PyValueError::new_err(format!(
+                "commit message was prepared for a different table \
+                 (message table '{}', committer table '{}')",
+                msg.table_location, table_location
+            )));
+        }
+        if msg.commit_user != commit_user {
+            return Err(PyValueError::new_err(
+                "commit message was prepared by a different WriteBuilder \
+                 (writer and committer must come from the same \
+                 table.new_write_builder() so they share one commit_user)"
+                    .to_string(),
+            ));
+        }
+        inner_messages.push(msg.inner.clone());
+    }
+    Ok(inner_messages)
+}
+
 #[pymethods]
 impl PyTableCommit {
     /// Commit the given commit messages. Empty input is a no-op success.
     fn commit(&self, py: Python<'_>, messages: &Bound<'_, PyAny>) -> PyResult<()> {
-        let mut inner_messages = Vec::new();
-        let iter = messages.try_iter().map_err(|_| {
-            PyTypeError::new_err("commit() expects a sequence of CommitMessage objects")
-        })?;
-        for item in iter {
-            let item = item?;
-            let msg: PyRef<PyCommitMessage> = item.extract().map_err(|_| {
-                PyTypeError::new_err("commit() expects a sequence of CommitMessage objects")
-            })?;
-            if msg.table_location != self.table_location {
-                return Err(PyValueError::new_err(format!(
-                    "commit message was prepared for a different table \
-                     (message table '{}', committer table '{}')",
-                    msg.table_location, self.table_location
-                )));
-            }
-            if msg.commit_user != self.commit_user {
-                return Err(PyValueError::new_err(
-                    "commit message was prepared by a different WriteBuilder \
-                     (writer and committer must come from the same \
-                     table.new_write_builder() so they share one commit_user)"
-                        .to_string(),
-                ));
-            }
-            inner_messages.push(msg.inner.clone());
-        }
+        let inner_messages = collect_and_validate_messages(
+            messages,
+            &self.table_location,
+            &self.commit_user,
+            "commit",
+        )?;
         let rt = runtime();
         py.detach(|| rt.block_on(async { self.inner.commit(inner_messages).await }))
+            .map_err(to_py_err)
+    }
+
+    /// Abort a prepared commit by deleting newly written data, changelog and
+    /// index files. Deletion is best-effort: missing files or storage errors
+    /// are silently ignored so abort cleanup never masks the original write
+    /// failure. After abort the data must not be committed — the files no
+    /// longer exist.
+    fn abort(&self, py: Python<'_>, messages: &Bound<'_, PyAny>) -> PyResult<()> {
+        let inner_messages = collect_and_validate_messages(
+            messages,
+            &self.table_location,
+            &self.commit_user,
+            "abort",
+        )?;
+        let rt = runtime();
+        py.detach(|| rt.block_on(async { self.inner.abort(&inner_messages).await }))
             .map_err(to_py_err)
     }
 }

--- a/bindings/python/tests/test_write.py
+++ b/bindings/python/tests/test_write.py
@@ -177,3 +177,74 @@ def test_commit_different_builder_same_table_raises():
         messages = write.prepare_commit()
         with pytest.raises(ValueError):
             table.new_write_builder().new_commit().commit(messages)
+
+
+def test_abort_cleans_up_written_data():
+    # Write data, prepare commit, abort — the written files should be deleted
+    # and reading back should return zero rows.
+    with tempfile.TemporaryDirectory() as warehouse:
+        ctx = _make_empty_table(warehouse)
+        table = _get_table(warehouse)
+        wb = table.new_write_builder()
+        write = wb.new_write()
+        write.write_arrow(_batch([1, 2, 3], ["a", "b", "c"]))
+        messages = write.prepare_commit()
+        assert len(messages) >= 1
+        wb.new_commit().abort(messages)
+        # After abort, no snapshot was committed — the table should be empty.
+        batches = ctx.sql("SELECT COUNT(*) AS cnt FROM paimon.wdb.t")
+        assert batches[0].column(0).to_pylist() == [0]
+
+
+def test_abort_empty_messages_noop():
+    with tempfile.TemporaryDirectory() as warehouse:
+        ctx = _make_empty_table(warehouse)
+        table = _get_table(warehouse)
+        wb = table.new_write_builder()
+        messages = wb.new_write().prepare_commit()  # no write
+        assert messages == []
+        wb.new_commit().abort(messages)  # no-op success
+        batches = ctx.sql("SELECT COUNT(*) AS cnt FROM paimon.wdb.t")
+        assert batches[0].column(0).to_pylist() == [0]
+
+
+def test_abort_non_message_raises_typeerror():
+    with tempfile.TemporaryDirectory() as warehouse:
+        _make_empty_table(warehouse)
+        table = _get_table(warehouse)
+        with pytest.raises(TypeError):
+            table.new_write_builder().new_commit().abort([object()])
+        with pytest.raises(TypeError):
+            table.new_write_builder().new_commit().abort(42)
+
+
+def test_abort_cross_table_messages_raises():
+    with tempfile.TemporaryDirectory() as warehouse:
+        ctx = SQLContext()
+        ctx.register_catalog("paimon", {"warehouse": warehouse})
+        ctx.sql("CREATE SCHEMA paimon.wdb")
+        ctx.sql("CREATE TABLE paimon.wdb.t1 (id INT, name STRING)")
+        ctx.sql("CREATE TABLE paimon.wdb.t2 (id INT, name STRING)")
+        catalog = PaimonCatalog({"warehouse": warehouse})
+        t1 = catalog.get_table("wdb.t1")
+        t2 = catalog.get_table("wdb.t2")
+        batch = pa.record_batch(
+            [pa.array([1], pa.int32()), pa.array(["a"], pa.string())],
+            names=["id", "name"],
+        )
+        w1 = t1.new_write_builder().new_write()
+        w1.write_arrow(batch)
+        messages = w1.prepare_commit()
+        with pytest.raises(ValueError):
+            t2.new_write_builder().new_commit().abort(messages)
+
+
+def test_abort_different_builder_same_table_raises():
+    with tempfile.TemporaryDirectory() as warehouse:
+        _make_empty_table(warehouse)
+        table = _get_table(warehouse)
+        write = table.new_write_builder().new_write()
+        write.write_arrow(_batch([1], ["a"]))
+        messages = write.prepare_commit()
+        with pytest.raises(ValueError):
+            table.new_write_builder().new_commit().abort(messages)


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
The Python binding is missing write rollback support. The core Rust TableCommit has an `abort()` method and the C binding already exposes it via `paimon_table_commit_abort`, but Python users have no way to clean up data files after a failed write. This PR adds `abort()` to the Python binding so callers can delete newly written files (data, changelog, index) before a commit is persisted.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
  - Extract message collection and validation into `collect_and_validate_messages` helper, shared by `commit()` and `abort()`
  - Add `PyTableCommit::abort()` — calls through to `TableCommit::abort()`, best-effort file deletion (storage errors silently ignored)
  - Add 5 unit tests covering the abort lifecycle and all validation paths

### Tests

<!-- List unit tests or integration cases to verify this change -->
New abort-specific tests in `bindings/python/tests/test_write.py`:

  | Test | Covers |                                                                                                                   
  | ---- | ------ |
  | `test_abort_cleans_up_written_data` | Write → abort → table is empty |
  | `test_abort_empty_messages_noop` | Abort with no messages succeeds |
  | `test_abort_non_message_raises_typeerror` | Non-message input raises `TypeError` |
  | `test_abort_cross_table_messages_raises` | Messages from a different table rejected (`ValueError`) |
  | `test_abort_different_builder_same_table_raises` | Messages from a different `WriteBuilder` rejected (`ValueError`) |

Run with:                                                                                                                           
  cd bindings/python
  .venv/bin/maturin develop --release
  .venv/bin/python -m pytest tests/test_write.py -v -k abort

### API and Format

<!-- Does this change affect API or storage format -->
New method on TableCommit:                                                                                                          

  table.new_write_builder().new_commit().abort(messages)

  - messages: a sequence of CommitMessage objects returned by prepare_commit()
  - Returns None on success
  - Raises TypeError if messages is not iterable or contains non-CommitMessage items
  - Raises ValueError if messages were prepared for a different table or by a different WriteBuilder
  - Deletion is best-effort — no error is raised for missing files or storage failures
  - Empty messages is a no-op

### Documentation

