### PR TITLE
fix(spec): implement Display for BinaryTableStats

### DIFF
--- a/crates/paimon/src/spec/stats.rs
+++ b/crates/paimon/src/spec/stats.rs
@@ -137,8 +137,15 @@ impl BinaryTableStats {
 }
 
 impl Display for BinaryTableStats {
-    fn fmt(&self, _: &mut Formatter<'_>) -> std::fmt::Result {
-        todo!()
+    /// `min_values`/`max_values` are serialized `BinaryRow`s that cannot be decoded without
+    /// the column types, so they print as raw bytes (same convention as `DataFileMeta`'s
+    /// `minKey`/`keyStats` fields).
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "BinaryTableStats{{minValues={:?}, maxValues={:?}, nullCounts={:?}}}",
+            self.min_values, self.max_values, self.null_counts
+        )
     }
 }
 
@@ -235,5 +242,30 @@ mod tests {
         let bytes = stats.to_simple_stats_row_data();
         let back = BinaryTableStats::from_simple_stats_row_data(&bytes).unwrap();
         assert_eq!(back.to_simple_stats_row_data(), bytes);
+    }
+
+    #[test]
+    fn display_formats_labeled_fields() {
+        let stats = BinaryTableStats::new(
+            vec![0, 0, 0, 2, 1],
+            vec![0, 0, 0, 2, 9],
+            vec![Some(0), None, Some(3)],
+        );
+        assert_eq!(
+            format!("{stats}"),
+            "BinaryTableStats{minValues=[0, 0, 0, 2, 1], maxValues=[0, 0, 0, 2, 9], \
+             nullCounts=[Some(0), None, Some(3)]}"
+        );
+    }
+
+    #[test]
+    fn display_empty_stats_does_not_panic() {
+        let stats = BinaryTableStats::empty();
+        let rendered = format!("{stats}");
+        assert!(
+            rendered.starts_with("BinaryTableStats{minValues=[")
+                && rendered.ends_with("nullCounts=[]}"),
+            "unexpected empty-stats rendering: {rendered}"
+        );
     }
 }


### PR DESCRIPTION
### Purpose

Linked issue: close #631

The `Display` impl for `BinaryTableStats` in `spec/stats.rs` is the repository's only `todo!()` and would panic if any code path ever formats stats through `Display` (logging, debugging, error messages). This implements it.

### Brief change log

Implement `Display` for `BinaryTableStats` as a labeled summary, following the convention of `DataFileMeta`'s `Display`:

```
BinaryTableStats{minValues=[0, 0, 0, 2, 1], maxValues=[0, 0, 0, 2, 9], nullCounts=[Some(0), None, Some(3)]}
```

- `min_values`/`max_values` are serialized `BinaryRow`s that cannot be decoded without the column types, so they print as raw bytes — the same convention `DataFileMeta` uses for its `minKey`/`keyStats` fields.
- `null_counts` items are `Option<i64>` (`None` = unknown), which `{:?}` renders naturally.

### Assumptions and notes for reviewers

- **No current caller formats stats via `Display`**: `ManifestFileMeta` and `DataFileMeta` print `BinaryTableStats` fields via `{:?}` (Debug), so this change is preventive — it removes a panic landmine rather than fixing a live crash. The alternative (deleting the unused impl) was considered and rejected: `BinaryTableStats` is a public spec-layer type and `Display` is a basic debugging capability, so implementing it is the additive, non-breaking choice.
- **The output format is a proposal**: raw bytes mirror the `DataFileMeta` convention; a byte-length summary (e.g. `minValues=12 bytes`) would also work. Happy to switch if reviewers prefer.

### Tests

- `spec::stats::tests::display_formats_labeled_fields` — exact output for known bytes, including `Some`/`None` null-count mixes
- `spec::stats::tests::display_empty_stats_does_not_panic` — `BinaryTableStats::empty()` boundary case

`cargo test -p paimon --lib spec::` passes (450 tests); `cargo fmt` and `clippy` are clean.

### API and Format

No API or storage format change; this fills in a previously unimplemented trait method.

### Documentation

No documentation update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)