### PR TITLE
fix(spec): reject aggregation on a sequence field for every merge engine

### DIFF
--- a/crates/paimon/src/spec/aggregation.rs
+++ b/crates/paimon/src/spec/aggregation.rs
@@ -181,9 +181,6 @@ impl<'a> AggregationConfig<'a> {
         fields: &[DataField],
         primary_keys: &[String],
     ) -> crate::Result<()> {
-        // Same source as the read path: `sequence.field` parsed by CoreOptions.
-        let core_options = CoreOptions::new(self.options);
-        let sequence_fields = core_options.sequence_fields();
         for (key, value) in self.options {
             let Some((col, kind)) = parse_field_scoped_option_key(key) else {
                 continue;
@@ -200,14 +197,6 @@ impl<'a> AggregationConfig<'a> {
                 });
             };
             if matches!(kind, FieldScopedOptionKind::AggregateFunction) {
-                if sequence_fields.contains(&col) {
-                    return Err(crate::Error::ConfigInvalid {
-                        message: format!(
-                            "Should not define aggregation on sequence field: '{col}'."
-                        ),
-                    });
-                }
-
                 if primary_keys.iter().any(|pk| pk == col) {
                     if !is_known_aggregator_name(value) {
                         return Err(crate::Error::ConfigInvalid {
@@ -399,6 +388,31 @@ pub(crate) fn validate_aggregator_for_type(
             ),
         })
     }
+}
+
+/// Reject `fields.<col>.aggregate-function` on a column listed in
+/// `sequence.field`, mirroring Java `SchemaValidation#validateSequenceField`,
+/// which checks `options.fieldAggFunc(field) == null` for every sequence field
+/// regardless of the configured merge engine.
+pub(crate) fn validate_no_aggregation_on_sequence_field(
+    options: &HashMap<String, String>,
+) -> crate::Result<()> {
+    let core_options = CoreOptions::new(options);
+    let sequence_fields = core_options.sequence_fields();
+    if sequence_fields.is_empty() {
+        return Ok(());
+    }
+
+    for field in sequence_fields {
+        let key = format!("{FIELDS_PREFIX}{field}{AGG_FUNCTION_SUFFIX}");
+        if options.contains_key(&key) {
+            return Err(crate::Error::ConfigInvalid {
+                message: format!("Should not define aggregation on sequence field: '{field}'."),
+            });
+        }
+    }
+
+    Ok(())
 }
 
 fn is_unsupported_aggregation_option(key: &str) -> bool {
@@ -605,22 +619,53 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_create_mode_rejects_aggregation_on_sequence_field() {
-        // Java rejects aggregation definitions on sequence fields during
-        // schema validation; the runtime still forces sequence fields to
-        // last_value when reading old or externally-created metadata.
+    fn test_rejects_aggregation_on_sequence_field_for_every_merge_engine() {
+        // Java rejects aggregation definitions on sequence fields inside
+        // `validateSequenceField`, which runs for every merge engine; the
+        // runtime still forces sequence fields to last_value when reading old
+        // or externally-created metadata.
+        for engine in [
+            None,
+            Some("deduplicate"),
+            Some("first-row"),
+            Some("partial-update"),
+            Some("aggregation"),
+        ] {
+            let mut options = HashMap::from([
+                ("sequence.field".to_string(), "amount".to_string()),
+                (
+                    "fields.amount.aggregate-function".to_string(),
+                    "listagg".to_string(),
+                ),
+            ]);
+            if let Some(engine) = engine {
+                options.insert(MERGE_ENGINE_OPTION.to_string(), engine.to_string());
+            }
+
+            let err = validate_no_aggregation_on_sequence_field(&options).unwrap_err();
+            assert!(
+                matches!(err, crate::Error::ConfigInvalid { ref message }
+                    if message.contains("sequence field") && message.contains("amount")),
+                "merge-engine={engine:?} should reject aggregation on a sequence field, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_accepts_aggregation_on_a_non_sequence_field() {
+        // Guard against over-rejecting: only the sequence field itself is
+        // off limits, other columns may carry an aggregate function.
         let options = aggregation_options(&[
             ("sequence.field", "amount"),
-            ("fields.amount.aggregate-function", "listagg"),
+            ("fields.price.aggregate-function", "sum"),
         ]);
-        let err = AggregationConfig::new(&options)
-            .validate_create_mode(&pk(), &sample_fields())
-            .unwrap_err();
-        assert!(
-            matches!(err, crate::Error::ConfigInvalid { ref message }
-                if message.contains("sequence field") && message.contains("amount")),
-            "expected sequence-field aggregation rejection, got {err:?}"
-        );
+        assert!(validate_no_aggregation_on_sequence_field(&options).is_ok());
+    }
+
+    #[test]
+    fn test_accepts_options_without_a_sequence_field() {
+        let options = aggregation_options(&[("fields.amount.aggregate-function", "sum")]);
+        assert!(validate_no_aggregation_on_sequence_field(&options).is_ok());
     }
 
     #[test]

--- a/crates/paimon/src/spec/mod.rs
+++ b/crates/paimon/src/spec/mod.rs
@@ -40,7 +40,8 @@ pub(crate) use partial_update::PartialUpdateConfig;
 
 mod aggregation;
 pub(crate) use aggregation::{
-    remove_field_scoped_options, rename_field_scoped_options, AggregationConfig,
+    remove_field_scoped_options, rename_field_scoped_options,
+    validate_no_aggregation_on_sequence_field, AggregationConfig,
 };
 
 mod data_type_casts;

--- a/crates/paimon/src/spec/schema.rs
+++ b/crates/paimon/src/spec/schema.rs
@@ -22,8 +22,9 @@ use crate::spec::core_options::{
 };
 use crate::spec::types::{ArrayType, DataType, MapType, MultisetType, RowType, VarCharType};
 use crate::spec::{
-    remove_field_scoped_options, rename_field_scoped_options, AggregationConfig, BlobType,
-    ColumnMove, ColumnMoveType, PartialUpdateConfig,
+    remove_field_scoped_options, rename_field_scoped_options,
+    validate_no_aggregation_on_sequence_field, AggregationConfig, BlobType, ColumnMove,
+    ColumnMoveType, PartialUpdateConfig,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -579,6 +580,7 @@ impl TableSchema {
         )?;
         PartialUpdateConfig::new(&new_schema.options)
             .validate_create_mode(!new_schema.primary_keys.is_empty())?;
+        validate_no_aggregation_on_sequence_field(&new_schema.options)?;
         AggregationConfig::new(&new_schema.options)
             .validate_create_mode(&new_schema.primary_keys, &new_schema.fields)?;
         Schema::validate_first_row_changelog_producer(&new_schema.options)?;
@@ -1088,6 +1090,7 @@ impl Schema {
         Self::validate_blob_fields(&fields, &partition_keys, &options)?;
         Self::validate_vector_store_fields(&fields, &partition_keys, &options)?;
         PartialUpdateConfig::new(&options).validate_create_mode(!primary_keys.is_empty())?;
+        validate_no_aggregation_on_sequence_field(&options)?;
         AggregationConfig::new(&options).validate_create_mode(&primary_keys, &fields)?;
         Self::validate_first_row_changelog_producer(&options)?;
         Self::validate_rowkind_field(&options, &primary_keys, &fields)?;
@@ -3391,6 +3394,55 @@ mod tests {
         );
 
         assert_primary_key_index_column_changes_rejected(&table_schema, "embedding", vector_type);
+    }
+
+    #[test]
+    fn test_create_schema_rejects_aggregation_on_sequence_field_without_agg_engine() {
+        // Java `validateSequenceField` checks `fieldAggFunc(field) == null` for
+        // every merge engine, so the default (deduplicate) engine must reject
+        // this too, not just `merge-engine=aggregation`.
+        let err = Schema::builder()
+            .column("id", DataType::Int(IntType::new()))
+            .column("ts", DataType::Int(IntType::new()))
+            .primary_key(["id"])
+            .option("sequence.field", "ts")
+            .option("fields.ts.aggregate-function", "sum")
+            .build()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, crate::Error::ConfigInvalid { ref message }
+                if message.contains("sequence field") && message.contains("ts")),
+            "aggregation on a sequence field should be rejected on the default \
+             merge engine, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_alter_set_aggregation_on_sequence_field_rejected_without_agg_engine() {
+        let table_schema = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("ts", DataType::Int(IntType::new()))
+                .primary_key(["id"])
+                .option("sequence.field", "ts")
+                .build()
+                .unwrap(),
+        );
+
+        let err = table_schema
+            .apply_changes(vec![crate::spec::SchemaChange::set_option(
+                "fields.ts.aggregate-function".to_string(),
+                "sum".to_string(),
+            )])
+            .unwrap_err();
+
+        assert!(
+            matches!(err, crate::Error::ConfigInvalid { ref message }
+                if message.contains("sequence field") && message.contains("ts")),
+            "alter adding aggregation on a sequence field should be rejected, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Java `SchemaValidation#validateSequenceField` checks `fieldAggFunc(field) == null`
for every field in `sequence.field`, and that validator runs for every merge
engine. The Rust equivalent lived inside
`AggregationConfig::validate_field_scoped_options`, which is only reached when
`merge-engine=aggregation` — so on the default deduplicate engine a schema
combining `sequence.field = 'ts'` with `fields.ts.aggregate-function = 'sum'` was
silently accepted and persisted.

**Fix**: hoist the check into a free `validate_no_aggregation_on_sequence_field`
keyed only on the option map, and call it from `Schema::new` and
`TableSchema::apply_changes` alongside the other sequence-field validations, so it
no longer depends on the merge engine. The existing aggregation-engine test is
widened to cover all five engines, plus create/alter tests on the default engine.
