### PR TITLE
docs: align the global index reference with the supported types and options

### DIFF
--- a/docs/src/sql.md
+++ b/docs/src/sql.md
@@ -1049,7 +1049,9 @@ CALL sys.drop_global_index(
 );
 ```
 
-BTree and bitmap global indexes can be dropped through this procedure currently.
+`index_type` accepts every type the create procedures build: `btree`, `bitmap`,
+`lumina` (or `lumina-vector-ann`), and the vindex types `ivf-flat` and `ivf-pq`.
+It defaults to `btree`.
 
 ### create_lumina_index
 
@@ -1976,6 +1978,8 @@ deletion vectors enabled.
 | `btree-index.fallback-scan-max-size` | `256mb` | Maximum total size of selected BTree global-index files for fallback scans used by range/between and suffix/contains/complex LIKE predicates; `0` disables BTree fallback index scans. |
 | `bitmap-index.fallback-scan-max-size` | `256mb` | Maximum total size of selected bitmap global-index files for fallback scans used by range/between and suffix/contains/complex LIKE predicates; `0` disables bitmap fallback index scans. |
 | `global-index.search-mode` | `fast` | Global index coverage mode for reads: `fast`, `full`, or `detail`. |
+| `global-index.thread-num` | `32` | Number of threads used to search global index fields concurrently; must be greater than 0. |
+| `global-index.column-update-action` | `THROW_ERROR` | What a commit does when it updates an indexed column: `THROW_ERROR` rejects the commit, `DROP_PARTITION_INDEX` drops the affected partition index instead. |
 
 ### Variant Shredding Options
 


### PR DESCRIPTION
`drop_global_index` documented only BTree and bitmap, but the drop path accepts
every type the create procedures build — `SUPPORTED_GLOBAL_INDEX_TYPES_FOR_DROP` is
`"btree, bitmap, lumina, lumina-vector-ann, ivf-flat, ivf-pq"`, enforced through
`normalize_global_index_type_for_drop`, and
`test_drop_global_index_accepts_lumina_type` / `..._vindex_type` already cover the
wider set.

The Global Index Options table also omitted two options the code reads:
`global-index.thread-num` (default 32, used by the concurrent vector-search path)
and `global-index.column-update-action` (default `THROW_ERROR`, used when a commit
updates an indexed column).
