### PR TITLE
fix(spec): say precision, not length, in two type-parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 [Latest Version]: https://img.shields.io/crates/v/paimon.svg
 [crates.io]: https://crates.io/crates/paimon
 
-The rust implementation of Apache Paimon. 
+The Rust implementation of Apache Paimon.
 
 ## Issue Tracker
 
@@ -35,7 +35,7 @@ See [GitHub Issues](https://github.com/apache/paimon-rust/issues)
 Apache Paimon Rust is an exciting project currently under active development. Whether you're looking to use it in your projects or contribute to its growth, there are several ways you can get involved:
 
 - Follow the [Contributing Guide](CONTRIBUTING.md) to contribute.
-- Create new [Issue](https://github.com/apache/paimon-rust/issues/new) for bug reportor or feature request.
+- Create new [Issue](https://github.com/apache/paimon-rust/issues/new) for bug report or feature request.
 - Start discussion thread at [dev mailing list](mailto:dev@paimon.apache.org) ([subscribe](<mailto:dev-subscribe@paimon.apache.org?subject=(send%20this%20email%20to%20subscribe)>) / [unsubscribe](<mailto:dev-unsubscribe@paimon.apache.org?subject=(send%20this%20email%20to%20unsubscribe)>) / [archives](https://lists.apache.org/list.html?dev@paimon.apache.org))
 - Talk to community directly at [Slack #paimon channel](https://join.slack.com/t/the-asf/shared_invite/zt-2l9rns8pz-H8PE2Xnz6KraVd2Ap40z4g).
 

--- a/crates/paimon/src/spec/types.rs
+++ b/crates/paimon/src/spec/types.rs
@@ -1105,8 +1105,9 @@ impl FromStr for LocalZonedTimestampType {
                 .trim()
                 .parse::<u32>()
                 .map_err(|_| Error::DataTypeInvalid {
-                    message: "Invalid LocalZonedTimestamp length. Unable to parse length as a u32."
-                        .to_string(),
+                    message:
+                        "Invalid LocalZonedTimestamp precision. Unable to parse precision as a u32."
+                            .to_string(),
                 })?;
 
         let nullable = !s[close_bracket..].contains("NOT NULL");
@@ -1242,7 +1243,8 @@ impl FromStr for TimeType {
                 .trim()
                 .parse::<u32>()
                 .map_err(|_| Error::DataTypeInvalid {
-                    message: "Invalid TIME length. Unable to parse length as a u32.".to_string(),
+                    message: "Invalid TIME precision. Unable to parse precision as a u32."
+                        .to_string(),
                 })?;
 
         let nullable = !s[close_bracket..].contains("NOT NULL");


### PR DESCRIPTION
`LocalZonedTimestampType::from_str` and `TimeType::from_str` both parse a
`precision_str` into a `precision` field, but report `"Invalid <T> length. Unable to
parse length as a u32."` The sibling `TimestampType::from_str` already has the right
wording, so this copies it. `BINARY`, `CHAR`, `VARBINARY` and `VARCHAR` keep
"length" — those really are lengths.

Also a README typo (`bug reportor` -> `bug report`), `rust` -> `Rust` in the tagline
to match `docs/mkdocs.yml`, and a trailing space.
