### PR TITLE
fix(schema): enforce executable type evolution

### DIFF
--- a/bindings/c/src/tests.rs
+++ b/bindings/c/src/tests.rs
@@ -2085,6 +2085,7 @@ fn build_pk_vector_table(path: &str, vectors: &[[f32; PK_DIM]]) -> Table {
                     &[(&data_file_name, row_count)],
                 )),
                 index_meta: None,
+                build_schema_id: None,
             }),
         };
 

--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -17,6 +17,7 @@
 
 //! Paimon table provider for DataFusion.
 
+use std::collections::HashSet;
 use std::fmt::Write as _;
 use std::sync::Arc;
 
@@ -32,7 +33,7 @@ use datafusion::logical_expr::dml::InsertOp;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use datafusion::physical_plan::ExecutionPlan;
 use paimon::spec::{
-    BigIntType, CoreOptions, DataField, DataType, ROW_ID_FIELD_ID, ROW_ID_FIELD_NAME,
+    BigIntType, CoreOptions, DataField, DataType, Predicate, ROW_ID_FIELD_ID, ROW_ID_FIELD_NAME,
 };
 use paimon::table::Table;
 
@@ -164,6 +165,42 @@ impl PaimonTableProvider {
     pub fn table(&self) -> &Table {
         &self.table
     }
+
+    async fn predicate_involves_type_evolution(&self, predicate: &Predicate) -> bool {
+        if self.table.schema().id() == 0 {
+            return false;
+        }
+        let evolved_field_ids = await_with_runtime(
+            self.table
+                .schema_manager()
+                .type_evolved_field_ids(self.table.schema()),
+        )
+        .await
+        .ok()
+        .flatten();
+        predicate_references_field_ids(
+            predicate,
+            self.table.schema().fields(),
+            evolved_field_ids.as_deref(),
+        )
+    }
+}
+
+fn predicate_references_field_ids(
+    predicate: &Predicate,
+    fields: &[DataField],
+    field_ids: Option<&HashSet<i32>>,
+) -> bool {
+    let Some(field_ids) = field_ids else {
+        return true;
+    };
+    let mut indices = HashSet::new();
+    predicate.collect_leaf_field_indices(&mut indices);
+    indices.into_iter().any(|index| {
+        fields
+            .get(index)
+            .is_some_and(|field| field_ids.contains(&field.id()))
+    })
 }
 
 /// Build a `CREATE TABLE` DDL string for a Paimon table.
@@ -423,6 +460,10 @@ impl TableProvider for PaimonTableProvider {
         // Plan splits eagerly so we know partition count upfront.
         let filter_analysis =
             analyze_filters(filters, self.table.schema().fields(), case_sensitive);
+        let requires_schema_evolution_residual = match &filter_analysis.pushed_predicate {
+            Some(predicate) => self.predicate_involves_type_evolution(predicate).await,
+            None => false,
+        };
         let mut read_builder = self.table.new_read_builder();
         read_builder.with_case_sensitive(case_sensitive);
         if let Some(indices) = projection {
@@ -436,7 +477,8 @@ impl TableProvider for PaimonTableProvider {
         if let Some(filter) = filter_analysis.pushed_predicate.clone() {
             read_builder.with_filter(filter);
         }
-        let pushed_limit = limit.filter(|_| !filter_analysis.requires_residual);
+        let pushed_limit = limit
+            .filter(|_| !filter_analysis.requires_residual && !requires_schema_evolution_residual);
         if let Some(limit) = pushed_limit {
             read_builder.with_limit(limit);
         }
@@ -451,6 +493,7 @@ impl TableProvider for PaimonTableProvider {
 
         let target = state.config_options().execution.target_partitions;
         let filter_exact = !filter_analysis.requires_residual
+            && !requires_schema_evolution_residual
             && filter_analysis
                 .pushed_predicate
                 .as_ref()
@@ -547,6 +590,75 @@ mod tests {
     fn test_bucket_round_robin_single_bucket() {
         let result = bucket_round_robin(vec![1, 2, 3], 1);
         assert_eq!(result, vec![vec![1, 2, 3]]);
+    }
+
+    #[test]
+    fn test_non_type_schema_version_preserves_exact_partition_pushdown() {
+        use paimon::io::FileIOBuilder;
+        use paimon::spec::{IntType, Schema as PaimonSchema, TableSchema};
+
+        let schema = PaimonSchema::builder()
+            .column("pt", DataType::Int(IntType::new()))
+            .column("value", DataType::Int(IntType::new()))
+            .partition_keys(["pt"])
+            .build()
+            .unwrap();
+        let table = Table::new(
+            FileIOBuilder::new("memory").build().unwrap(),
+            Identifier::new("default", "evolved_filter"),
+            "memory:/evolved_filter".to_string(),
+            TableSchema::new(1, &schema),
+            None,
+        );
+        let provider = PaimonTableProvider::try_new(table).unwrap();
+        let filter = col("pt").eq(lit(1));
+
+        assert_eq!(
+            provider.supports_filters_pushdown(&[&filter]).unwrap(),
+            vec![TableProviderFilterPushDown::Exact]
+        );
+    }
+
+    #[test]
+    fn test_type_evolution_predicate_detection_uses_stable_ids() {
+        use paimon::spec::{
+            Datum, IntType, PredicateBuilder, Schema as PaimonSchema, SchemaChange,
+        };
+
+        let schema = PaimonSchema::builder()
+            .column("id", DataType::Int(IntType::new()))
+            .column("value", DataType::Int(IntType::new()))
+            .build()
+            .unwrap();
+        let initial = paimon::spec::TableSchema::new(0, &schema);
+        let renamed = initial
+            .apply_changes(vec![SchemaChange::rename_column(
+                "value".to_string(),
+                "renamed_value".to_string(),
+            )])
+            .unwrap();
+
+        let evolved = renamed
+            .apply_changes(vec![SchemaChange::update_column_type(
+                "id".to_string(),
+                DataType::BigInt(BigIntType::new()),
+            )])
+            .unwrap();
+        let evolved_ids = HashSet::from([evolved.fields()[0].id()]);
+
+        let builder = PredicateBuilder::new(evolved.fields());
+        let evolved_filter = builder.equal("id", Datum::Long(1)).unwrap();
+        let unchanged_filter = builder.equal("renamed_value", Datum::Int(1)).unwrap();
+        assert!(predicate_references_field_ids(
+            &evolved_filter,
+            evolved.fields(),
+            Some(&evolved_ids)
+        ));
+        assert!(!predicate_references_field_ids(
+            &unchanged_filter,
+            evolved.fields(),
+            Some(&evolved_ids)
+        ));
     }
 
     fn get_test_warehouse() -> String {

--- a/crates/integrations/datafusion/tests/procedures.rs
+++ b/crates/integrations/datafusion/tests/procedures.rs
@@ -217,6 +217,38 @@ async fn test_create_global_index_builds_btree_and_filter_reads() {
 }
 
 #[tokio::test]
+async fn test_alter_type_rejects_persisted_global_index_dependency_before_commit() {
+    let (_tmp, sql_context) = setup_btree_global_index_table("btree_alter_type_guard").await;
+    exec(
+        &sql_context,
+        "INSERT INTO paimon.test_db.btree_alter_type_guard (id, name) VALUES (1, 'alice')",
+    )
+    .await;
+    exec(
+        &sql_context,
+        "CALL sys.create_global_index(table => 'test_db.btree_alter_type_guard', index_column => 'id', index_type => 'btree')",
+    )
+    .await;
+
+    assert_sql_error(
+        &sql_context,
+        "ALTER TABLE paimon.test_db.btree_alter_type_guard ALTER COLUMN id TYPE BIGINT",
+        "persisted global index 'btree' depends on field id",
+    )
+    .await;
+
+    let schema_count = row_count(
+        &sql_context,
+        "SELECT * FROM paimon.test_db.`btree_alter_type_guard$schemas`",
+    )
+    .await;
+    assert_eq!(
+        schema_count, 1,
+        "failed ALTER must not write schema metadata"
+    );
+}
+
+#[tokio::test]
 async fn test_create_global_index_btree_string_fallback_scan_reads() {
     let (_tmp, sql_context) = setup_btree_global_index_table("btree_string_fallback").await;
     exec(

--- a/crates/integrations/datafusion/tests/read_tables.rs
+++ b/crates/integrations/datafusion/tests/read_tables.rs
@@ -1575,6 +1575,7 @@ mod fulltext_tests {
                 extra_field_ids: None,
                 index_meta: None,
                 source_meta: None,
+                build_schema_id: None,
             }),
         }];
         TableCommit::new(table, "test-user".to_string())

--- a/crates/integrations/datafusion/tests/sql_context_tests.rs
+++ b/crates/integrations/datafusion/tests/sql_context_tests.rs
@@ -22,6 +22,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use datafusion::arrow::array::{Array, Int64Array};
+use datafusion::arrow::util::display::array_value_to_string;
 use datafusion::catalog::CatalogProvider;
 use datafusion::datasource::MemTable;
 use paimon::catalog::{list_partitions_from_file_system, Identifier};
@@ -1315,6 +1316,260 @@ async fn test_alter_table_update_column_type_and_nullability() {
         .expect("ALTER COLUMN DROP NOT NULL should succeed");
     let table = catalog.get_table(&identifier).await.unwrap();
     assert!(table.schema().fields()[1].data_type().is_nullable());
+}
+
+#[tokio::test]
+async fn test_alter_type_reads_old_and_new_writes_with_natural_predicate() {
+    let (_tmp, catalog) = create_test_env();
+    let sql_context = create_sql_context(catalog.clone()).await;
+
+    sql_context
+        .sql("CREATE SCHEMA paimon.mydb")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    sql_context
+        .sql("CREATE TABLE paimon.mydb.type_evolution (id INT, name CHAR(10))")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    sql_context
+        .sql(
+            "INSERT INTO paimon.mydb.type_evolution VALUES \
+             (1, 'abcdefghij'), (2, 'uvwxyzabcd')",
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    sql_context
+        .sql("ALTER TABLE paimon.mydb.type_evolution ALTER COLUMN name TYPE CHAR(5)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    sql_context
+        .sql("INSERT INTO paimon.mydb.type_evolution VALUES (3, 'klmnopqrst')")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let batches = sql_context
+        .sql("SELECT id, name FROM paimon.mydb.type_evolution ORDER BY id")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let rows = batches
+        .iter()
+        .flat_map(|batch| {
+            (0..batch.num_rows()).map(|row| {
+                (
+                    array_value_to_string(batch.column(0).as_ref(), row).unwrap(),
+                    array_value_to_string(batch.column(1).as_ref(), row).unwrap(),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        rows,
+        vec![
+            ("1".to_string(), "abcde".to_string()),
+            ("2".to_string(), "uvwxy".to_string()),
+            ("3".to_string(), "klmno".to_string()),
+        ]
+    );
+
+    let batches = sql_context
+        .sql("SELECT id, name FROM paimon.mydb.type_evolution WHERE name = 'abcde'")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let rows = batches
+        .iter()
+        .flat_map(|batch| {
+            (0..batch.num_rows()).map(|row| {
+                (
+                    array_value_to_string(batch.column(0).as_ref(), row).unwrap(),
+                    array_value_to_string(batch.column(1).as_ref(), row).unwrap(),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(rows, vec![("1".to_string(), "abcde".to_string())]);
+}
+
+#[tokio::test]
+async fn test_alter_type_rejects_unexecutable_historical_cast_before_commit() {
+    let (_tmp, catalog) = create_test_env();
+    let sql_context = create_sql_context(catalog.clone()).await;
+    let identifier = Identifier::new("mydb", "chained_type_evolution");
+
+    sql_context
+        .sql("CREATE SCHEMA paimon.mydb")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    sql_context
+        .sql("CREATE TABLE paimon.mydb.chained_type_evolution (id INT, value FLOAT)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    sql_context
+        .sql("INSERT INTO paimon.mydb.chained_type_evolution VALUES (1, 1.5)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    sql_context
+        .sql("ALTER TABLE paimon.mydb.chained_type_evolution ALTER COLUMN value TYPE INT")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let error = sql_context
+        .sql(
+            "ALTER TABLE paimon.mydb.chained_type_evolution \
+             ALTER COLUMN value TYPE DECIMAL(10, 2)",
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("historical schema 0 requires an unimplemented schema evolution cast"),
+        "{error:?}"
+    );
+
+    let table = catalog.get_table(&identifier).await.unwrap();
+    assert_eq!(table.schema().id(), 1);
+    assert!(matches!(
+        table.schema().fields()[1].data_type(),
+        DataType::Int(_)
+    ));
+    assert_eq!(table.schema_manager().list_all().await.unwrap().len(), 2);
+
+    let batches = sql_context
+        .sql("SELECT id, value FROM paimon.mydb.chained_type_evolution")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        array_value_to_string(batches[0].column(0).as_ref(), 0).unwrap(),
+        "1"
+    );
+    assert_eq!(
+        array_value_to_string(batches[0].column(1).as_ref(), 0).unwrap(),
+        "1"
+    );
+}
+
+#[tokio::test]
+async fn test_unrelated_schema_change_does_not_normalize_existing_char_column() {
+    let (_tmp, catalog) = create_test_env();
+    let sql_context = create_sql_context(catalog).await;
+
+    sql_context
+        .sql("CREATE SCHEMA paimon.mydb")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    sql_context
+        .sql("CREATE TABLE paimon.mydb.unchanged_char (id INT, name CHAR(5))")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    sql_context
+        .sql("ALTER TABLE paimon.mydb.unchanged_char ADD COLUMN note INT")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    sql_context
+        .sql("INSERT INTO paimon.mydb.unchanged_char VALUES (1, 'abcdefghij', 7)")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    let batches = sql_context
+        .sql("SELECT name FROM paimon.mydb.unchanged_char")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+        1
+    );
+    assert_eq!(
+        array_value_to_string(batches[0].column(0).as_ref(), 0).unwrap(),
+        "abcdefghij"
+    );
+}
+
+#[tokio::test]
+async fn test_unsupported_alter_type_fails_before_schema_commit() {
+    let (_tmp, catalog) = create_test_env();
+    let sql_context = create_sql_context(catalog.clone()).await;
+    let identifier = Identifier::new("mydb", "unsupported_type_evolution");
+
+    catalog
+        .create_database("mydb", false, Default::default())
+        .await
+        .unwrap();
+    let schema = paimon::spec::Schema::builder()
+        .column("id", DataType::Int(IntType::new()))
+        .column("flag", DataType::Boolean(paimon::spec::BooleanType::new()))
+        .build()
+        .unwrap();
+    catalog
+        .create_table(&identifier, schema, false)
+        .await
+        .unwrap();
+
+    let error = sql_context
+        .sql("ALTER TABLE paimon.mydb.unsupported_type_evolution ALTER COLUMN flag TYPE DATE")
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("cannot be converted"),
+        "{error:?}"
+    );
+
+    let table = catalog.get_table(&identifier).await.unwrap();
+    assert_eq!(table.schema().id(), 0);
+    assert!(matches!(
+        table.schema().fields()[1].data_type(),
+        DataType::Boolean(_)
+    ));
 }
 
 #[tokio::test]

--- a/crates/integrations/datafusion/tests/variant_pushdown.rs
+++ b/crates/integrations/datafusion/tests/variant_pushdown.rs
@@ -133,6 +133,46 @@ async fn variant_get_projection_pushes_extractions_into_scan() {
 }
 
 #[tokio::test]
+async fn variant_get_projection_reads_files_from_an_older_schema() {
+    let (_tmp, sql_context) = setup_shredded_variant_table_with_rows().await;
+    common::exec(
+        &sql_context,
+        "ALTER TABLE paimon.test_db.t ADD COLUMN unrelated INT",
+    )
+    .await;
+
+    let sql = r#"
+        SELECT id, variant_get(payload, '$.age', 'int') AS age
+        FROM paimon.test_db.t
+        ORDER BY id
+    "#;
+    let df = sql_context.sql(sql).await.unwrap();
+    let plan = df.create_physical_plan().await.unwrap();
+    let plan_text = displayable(plan.as_ref()).indent(true).to_string();
+    assert!(
+        plan_text.contains("PushedVariants=[payload=[$.age]]"),
+        "plan should push the variant extraction for old-schema files, got:\n{plan_text}"
+    );
+
+    let batches = sql_context.sql(sql).await.unwrap().collect().await.unwrap();
+    assert_eq!(batches.len(), 1);
+    let ids = batches[0]
+        .column_by_name("id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let ages = batches[0]
+        .column_by_name("age")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    assert_eq!(ids.values(), &[1, 2]);
+    assert_eq!(ages.values(), &[27, 32]);
+}
+
+#[tokio::test]
 async fn variant_get_filter_pushes_extraction_into_scan() {
     let (_tmp, sql_context) = setup_shredded_variant_table_with_rows().await;
     let sql = r#"

--- a/crates/paimon/src/arrow/filtering.rs
+++ b/crates/paimon/src/arrow/filtering.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::arrow::schema_evolution::create_index_mapping;
+use crate::arrow::schema_evolution::{create_index_mapping, same_type_ignoring_nullability};
 pub(crate) use crate::predicate_stats::{predicates_may_match_with_schema, StatsAccessor};
 use crate::spec::{DataField, Predicate, PredicateOperator};
 
@@ -23,90 +23,210 @@ use crate::spec::{DataField, Predicate, PredicateOperator};
 /// Predicates referencing fields not present in the file are resolved based on
 /// NULL semantics: the missing column is treated as all-NULL, so `IS NULL`
 /// becomes `AlwaysTrue` and all other operators become `AlwaysFalse`.
+/// Predicates on a field whose physical file type differs from the current
+/// logical type are omitted unless their literals can be safely devolved. This
+/// implementation deliberately does not devolve literals yet.
+pub(crate) struct FilePredicateRemap {
+    /// Predicates that are safe to evaluate against the physical file schema.
+    pub(crate) predicates: Vec<Predicate>,
+    /// Whether any predicate was omitted because it references a type-evolved
+    /// field. The caller must evaluate the original current-schema predicates
+    /// after converting the decoded batch when this is true.
+    pub(crate) requires_current_schema_residual: bool,
+}
+
+/// Result of remapping one predicate subtree.
+///
+/// `predicate` may contain a safe weakening for positive filtering contexts.
+/// `exact` is false when any descendant was omitted, which prevents that
+/// weakening from being inverted under `NOT`.
+struct RemapResult {
+    predicate: Option<Predicate>,
+    exact: bool,
+}
+
+impl RemapResult {
+    fn exact(predicate: Predicate) -> Self {
+        Self {
+            predicate: Some(predicate),
+            exact: true,
+        }
+    }
+
+    fn omitted() -> Self {
+        Self {
+            predicate: None,
+            exact: false,
+        }
+    }
+}
+
 pub(crate) fn remap_predicates_to_file(
     predicates: &[Predicate],
     table_fields: &[DataField],
     file_fields: &[DataField],
-) -> Vec<Predicate> {
+) -> FilePredicateRemap {
     let mapping = build_field_mapping(table_fields, file_fields);
-    predicates
+    let mut requires_current_schema_residual = false;
+    let predicates = predicates
         .iter()
-        .map(|p| remap_predicate(p, &mapping))
-        .collect()
+        .filter_map(|predicate| {
+            remap_predicate(
+                predicate,
+                &mapping,
+                table_fields,
+                file_fields,
+                &mut requires_current_schema_residual,
+            )
+            .predicate
+        })
+        .collect();
+    FilePredicateRemap {
+        predicates,
+        requires_current_schema_residual,
+    }
 }
 
-fn remap_predicate(predicate: &Predicate, mapping: &[Option<usize>]) -> Predicate {
+fn remap_predicate(
+    predicate: &Predicate,
+    mapping: &[Option<usize>],
+    table_fields: &[DataField],
+    file_fields: &[DataField],
+    requires_current_schema_residual: &mut bool,
+) -> RemapResult {
     match predicate {
         Predicate::Leaf {
-            column,
             index,
-            data_type,
             op,
             literals,
+            ..
         } => {
             match mapping.get(*index).copied().flatten() {
-                Some(file_index) => Predicate::Leaf {
-                    column: column.clone(),
-                    index: file_index,
-                    data_type: data_type.clone(),
-                    op: *op,
-                    literals: literals.clone(),
-                },
+                Some(file_index) => {
+                    let Some(table_field) = table_fields.get(*index) else {
+                        return RemapResult::omitted();
+                    };
+                    let Some(file_field) = file_fields.get(file_index) else {
+                        return RemapResult::omitted();
+                    };
+                    if !same_type_ignoring_nullability(
+                        table_field.data_type(),
+                        file_field.data_type(),
+                    ) {
+                        *requires_current_schema_residual = true;
+                        return RemapResult::omitted();
+                    }
+                    RemapResult::exact(Predicate::Leaf {
+                        column: file_field.name().to_string(),
+                        index: file_index,
+                        data_type: file_field.data_type().clone(),
+                        op: *op,
+                        literals: literals.clone(),
+                    })
+                }
                 // Column missing from file → all values are NULL.
                 None => match op {
-                    PredicateOperator::IsNull => Predicate::AlwaysTrue,
-                    _ => Predicate::AlwaysFalse,
+                    PredicateOperator::IsNull => RemapResult::exact(Predicate::AlwaysTrue),
+                    _ => RemapResult::exact(Predicate::AlwaysFalse),
                 },
             }
         }
         Predicate::And(children) => {
             let remapped: Vec<_> = children
                 .iter()
-                .map(|c| remap_predicate(c, mapping))
+                .map(|child| {
+                    remap_predicate(
+                        child,
+                        mapping,
+                        table_fields,
+                        file_fields,
+                        requires_current_schema_residual,
+                    )
+                })
                 .collect();
-            if remapped.iter().any(|p| matches!(p, Predicate::AlwaysFalse)) {
-                Predicate::AlwaysFalse
+            let exact = remapped.iter().all(|result| result.exact);
+            let remapped: Vec<_> = remapped
+                .into_iter()
+                .filter_map(|result| result.predicate)
+                .collect();
+            let predicate = if remapped
+                .iter()
+                .any(|predicate| matches!(predicate, Predicate::AlwaysFalse))
+            {
+                Some(Predicate::AlwaysFalse)
             } else {
                 let filtered: Vec<_> = remapped
                     .into_iter()
-                    .filter(|p| !matches!(p, Predicate::AlwaysTrue))
+                    .filter(|predicate| !matches!(predicate, Predicate::AlwaysTrue))
                     .collect();
                 match filtered.len() {
-                    0 => Predicate::AlwaysTrue,
-                    1 => filtered.into_iter().next().unwrap(),
-                    _ => Predicate::and(filtered),
+                    0 => exact.then_some(Predicate::AlwaysTrue),
+                    1 => filtered.into_iter().next(),
+                    _ => Some(Predicate::and(filtered)),
                 }
-            }
+            };
+            RemapResult { predicate, exact }
         }
         Predicate::Or(children) => {
             let remapped: Vec<_> = children
                 .iter()
-                .map(|c| remap_predicate(c, mapping))
+                .map(|child| {
+                    remap_predicate(
+                        child,
+                        mapping,
+                        table_fields,
+                        file_fields,
+                        requires_current_schema_residual,
+                    )
+                })
                 .collect();
-            if remapped.iter().any(|p| matches!(p, Predicate::AlwaysTrue)) {
-                Predicate::AlwaysTrue
+            let exact = remapped.iter().all(|result| result.exact);
+            if remapped.iter().any(|result| result.predicate.is_none()) {
+                return RemapResult {
+                    predicate: None,
+                    exact,
+                };
+            }
+            let remapped: Vec<_> = remapped
+                .into_iter()
+                .filter_map(|result| result.predicate)
+                .collect();
+            let predicate = if remapped
+                .iter()
+                .any(|predicate| matches!(predicate, Predicate::AlwaysTrue))
+            {
+                Some(Predicate::AlwaysTrue)
             } else {
                 let filtered: Vec<_> = remapped
                     .into_iter()
-                    .filter(|p| !matches!(p, Predicate::AlwaysFalse))
+                    .filter(|predicate| !matches!(predicate, Predicate::AlwaysFalse))
                     .collect();
                 match filtered.len() {
-                    0 => Predicate::AlwaysFalse,
-                    1 => filtered.into_iter().next().unwrap(),
-                    _ => Predicate::or(filtered),
+                    0 => Some(Predicate::AlwaysFalse),
+                    1 => filtered.into_iter().next(),
+                    _ => Some(Predicate::or(filtered)),
                 }
-            }
+            };
+            RemapResult { predicate, exact }
         }
         Predicate::Not(inner) => {
-            let remapped = remap_predicate(inner, mapping);
-            match remapped {
-                Predicate::AlwaysTrue => Predicate::AlwaysFalse,
-                Predicate::AlwaysFalse => Predicate::AlwaysTrue,
-                other => Predicate::Not(Box::new(other)),
+            let remapped = remap_predicate(
+                inner,
+                mapping,
+                table_fields,
+                file_fields,
+                requires_current_schema_residual,
+            );
+            if !remapped.exact {
+                return RemapResult::omitted();
+            }
+            match remapped.predicate {
+                Some(predicate) => RemapResult::exact(Predicate::negate(predicate)),
+                None => RemapResult::omitted(),
             }
         }
-        Predicate::AlwaysTrue => Predicate::AlwaysTrue,
-        Predicate::AlwaysFalse => Predicate::AlwaysFalse,
+        Predicate::AlwaysTrue => RemapResult::exact(Predicate::AlwaysTrue),
+        Predicate::AlwaysFalse => RemapResult::exact(Predicate::AlwaysFalse),
     }
 }
 
@@ -133,4 +253,94 @@ fn normalize_field_mapping(mapping: Option<Vec<i32>>, num_fields: usize) -> Vec<
                 .collect()
         })
         .unwrap_or_else(|| identity_field_mapping(num_fields))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::{BigIntType, DataType, Datum, IntType, PredicateBuilder};
+
+    fn fields(value_type: DataType) -> Vec<DataField> {
+        vec![
+            DataField::new(1, "id".to_string(), DataType::Int(IntType::new())),
+            DataField::new(2, "value".to_string(), value_type),
+        ]
+    }
+
+    #[test]
+    fn test_type_evolved_leaf_is_not_passed_to_file_reader() {
+        let table_fields = fields(DataType::BigInt(BigIntType::new()));
+        let file_fields = fields(DataType::Int(IntType::new()));
+        let predicate = PredicateBuilder::new(&table_fields)
+            .equal("value", Datum::Long(7))
+            .unwrap();
+
+        let remapped = remap_predicates_to_file(&[predicate], &table_fields, &file_fields);
+        assert!(remapped.predicates.is_empty());
+        assert!(remapped.requires_current_schema_residual);
+    }
+
+    #[test]
+    fn test_and_keeps_safe_conjunct_but_or_fails_open() {
+        let table_fields = fields(DataType::BigInt(BigIntType::new()));
+        let file_fields = fields(DataType::Int(IntType::new()));
+        let builder = PredicateBuilder::new(&table_fields);
+        let stable = builder.equal("id", Datum::Int(1)).unwrap();
+        let evolved = builder.equal("value", Datum::Long(7)).unwrap();
+
+        let remapped = remap_predicates_to_file(
+            &[Predicate::and(vec![stable.clone(), evolved.clone()])],
+            &table_fields,
+            &file_fields,
+        );
+        assert_eq!(remapped.predicates.len(), 1);
+        assert!(matches!(
+            remapped.predicates[0],
+            Predicate::Leaf { index: 0, .. }
+        ));
+        assert!(remapped.requires_current_schema_residual);
+
+        let remapped = remap_predicates_to_file(
+            &[Predicate::or(vec![stable, evolved])],
+            &table_fields,
+            &file_fields,
+        );
+        assert!(remapped.predicates.is_empty());
+        assert!(remapped.requires_current_schema_residual);
+    }
+
+    #[test]
+    fn test_not_fails_open_when_descendant_cannot_be_remapped() {
+        let table_fields = fields(DataType::BigInt(BigIntType::new()));
+        let file_fields = fields(DataType::Int(IntType::new()));
+        let builder = PredicateBuilder::new(&table_fields);
+        let stable = builder.equal("id", Datum::Int(1)).unwrap();
+        let evolved = builder.equal("value", Datum::Long(7)).unwrap();
+        let predicate = Predicate::negate(Predicate::and(vec![stable, evolved]));
+
+        let remapped = remap_predicates_to_file(&[predicate], &table_fields, &file_fields);
+
+        assert!(remapped.predicates.is_empty());
+        assert!(remapped.requires_current_schema_residual);
+    }
+
+    #[test]
+    fn test_not_preserves_exact_true_from_missing_columns() {
+        let table_fields = vec![
+            DataField::new(1, "id".to_string(), DataType::Int(IntType::new())),
+            DataField::new(2, "new1".to_string(), DataType::Int(IntType::new())),
+            DataField::new(3, "new2".to_string(), DataType::Int(IntType::new())),
+        ];
+        let file_fields = vec![table_fields[0].clone()];
+        let builder = PredicateBuilder::new(&table_fields);
+        let predicate = Predicate::negate(Predicate::and(vec![
+            builder.is_null("new1").unwrap(),
+            builder.is_null("new2").unwrap(),
+        ]));
+
+        let remapped = remap_predicates_to_file(&[predicate], &table_fields, &file_fields);
+
+        assert_eq!(remapped.predicates, vec![Predicate::AlwaysFalse]);
+        assert!(!remapped.requires_current_schema_residual);
+    }
 }

--- a/crates/paimon/src/arrow/schema_evolution.rs
+++ b/crates/paimon/src/arrow/schema_evolution.rs
@@ -19,11 +19,372 @@
 //!
 //! Reference: [org.apache.paimon.schema.SchemaEvolutionUtil](https://github.com/apache/paimon/blob/release-1.3/paimon-core/src/main/java/org/apache/paimon/schema/SchemaEvolutionUtil.java)
 
-use crate::spec::DataField;
+use crate::arrow::paimon_type_to_arrow;
+use crate::spec::{DataField, DataType};
+use arrow_array::builder::{BinaryBuilder, StringBuilder};
+use arrow_array::types::{
+    ArrowPrimitiveType, Date32Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type,
+    Int8Type, TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType,
+};
+use arrow_array::{Array, ArrayRef, BinaryArray, PrimitiveArray, StringArray};
+use arrow_cast::cast;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// Sentinel value indicating a field does not exist in the data schema.
 pub const NULL_FIELD_INDEX: i32 = -1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchemaEvolutionCast {
+    Identity,
+    NumericPrimitive,
+    Decimal,
+    DateToTimestamp,
+    TimestampToDate,
+    CharacterString,
+    BinaryString,
+}
+
+/// Return whether a schema-evolution cast has a real executor.
+///
+/// This is deliberately narrower than SQL explicit casting. Schema admission
+/// uses this function in addition to the logical Paimon cast rules, so every
+/// accepted type change can be executed while reading old files.
+pub(crate) fn schema_evolution_cast_implemented(source: &DataType, target: &DataType) -> bool {
+    resolve_schema_evolution_cast(source, target).is_some()
+}
+
+fn resolve_schema_evolution_cast(
+    source: &DataType,
+    target: &DataType,
+) -> Option<SchemaEvolutionCast> {
+    if same_type_ignoring_nullability(source, target) {
+        return is_top_level_scalar(source).then_some(SchemaEvolutionCast::Identity);
+    }
+
+    match (source, target) {
+        (DataType::Char(_) | DataType::VarChar(_), DataType::Char(_) | DataType::VarChar(_)) => {
+            Some(SchemaEvolutionCast::CharacterString)
+        }
+        (
+            DataType::Binary(_) | DataType::VarBinary(_),
+            DataType::Binary(_) | DataType::VarBinary(_),
+        ) => Some(SchemaEvolutionCast::BinaryString),
+        (source, target) if is_numeric_primitive(source) && is_numeric_primitive(target) => {
+            Some(SchemaEvolutionCast::NumericPrimitive)
+        }
+        (source, DataType::Decimal(_))
+            if is_integer_numeric(source) || matches!(source, DataType::Decimal(_)) =>
+        {
+            Some(SchemaEvolutionCast::Decimal)
+        }
+        (DataType::Date(_), DataType::Timestamp(timestamp)) if timestamp.precision() <= 3 => {
+            Some(SchemaEvolutionCast::DateToTimestamp)
+        }
+        (DataType::Timestamp(_), DataType::Date(_)) => Some(SchemaEvolutionCast::TimestampToDate),
+        _ => None,
+    }
+}
+
+fn is_top_level_scalar(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Boolean(_)
+            | DataType::TinyInt(_)
+            | DataType::SmallInt(_)
+            | DataType::Int(_)
+            | DataType::BigInt(_)
+            | DataType::Decimal(_)
+            | DataType::Double(_)
+            | DataType::Float(_)
+            | DataType::Binary(_)
+            | DataType::VarBinary(_)
+            | DataType::Char(_)
+            | DataType::VarChar(_)
+            | DataType::Date(_)
+            | DataType::LocalZonedTimestamp(_)
+            | DataType::Time(_)
+            | DataType::Timestamp(_)
+    )
+}
+
+fn is_integer_numeric(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::TinyInt(_) | DataType::SmallInt(_) | DataType::Int(_) | DataType::BigInt(_)
+    )
+}
+
+fn is_numeric_primitive(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::TinyInt(_)
+            | DataType::SmallInt(_)
+            | DataType::Int(_)
+            | DataType::BigInt(_)
+            | DataType::Double(_)
+            | DataType::Float(_)
+    )
+}
+
+pub(crate) fn same_type_ignoring_nullability(source: &DataType, target: &DataType) -> bool {
+    match (
+        source.copy_with_nullable(true),
+        target.copy_with_nullable(true),
+    ) {
+        (Ok(source), Ok(target)) => source == target,
+        _ => false,
+    }
+}
+
+/// Cast one physical Arrow column according to Paimon schema-evolution
+/// semantics. Arrow is used only after the Paimon source/target pair has been
+/// resolved to a supported executor.
+pub(crate) fn cast_array_for_schema_evolution(
+    array: &ArrayRef,
+    source: &DataType,
+    target: &DataType,
+) -> crate::Result<ArrayRef> {
+    // Unchanged complex fields can still appear in an old file selected by a
+    // different table schema version. They need no ALTER TYPE executor, but
+    // nested Arrow fields may still carry file metadata which must be removed
+    // before constructing a batch with the current logical schema.
+    if same_type_ignoring_nullability(source, target) {
+        let target_arrow_type = paimon_type_to_arrow(target)?;
+        if array.data_type() == &target_arrow_type {
+            return Ok(array.clone());
+        }
+        return cast(array.as_ref(), &target_arrow_type).map_err(|error| {
+            crate::Error::UnexpectedError {
+                message: format!(
+                    "Failed schema evolution Arrow normalization from {source:?} to {target:?}: {error}"
+                ),
+                source: Some(Box::new(error)),
+            }
+        });
+    }
+    let executor =
+        resolve_schema_evolution_cast(source, target).ok_or_else(|| crate::Error::Unsupported {
+            message: format!(
+                "Schema evolution cast from {source:?} to {target:?} is not implemented"
+            ),
+        })?;
+
+    match executor {
+        SchemaEvolutionCast::Identity => Ok(array.clone()),
+        SchemaEvolutionCast::NumericPrimitive => cast_numeric_primitive(array, source, target),
+        SchemaEvolutionCast::Decimal => {
+            let target_arrow_type = paimon_type_to_arrow(target)?;
+            cast(array.as_ref(), &target_arrow_type).map_err(|error| {
+                crate::Error::UnexpectedError {
+                    message: format!(
+                        "Failed schema evolution cast from {source:?} to {target:?}: {error}"
+                    ),
+                    source: Some(Box::new(error)),
+                }
+            })
+        }
+        SchemaEvolutionCast::DateToTimestamp => cast_date_to_timestamp(array, target),
+        SchemaEvolutionCast::TimestampToDate => cast_timestamp_to_date(array, source),
+        SchemaEvolutionCast::CharacterString => cast_character_string(array, target),
+        SchemaEvolutionCast::BinaryString => cast_binary_string(array, target),
+    }
+}
+
+fn downcast_primitive<'a, T: ArrowPrimitiveType>(
+    array: &'a ArrayRef,
+    semantic_type: &str,
+) -> crate::Result<&'a PrimitiveArray<T>> {
+    array
+        .as_any()
+        .downcast_ref::<PrimitiveArray<T>>()
+        .ok_or_else(|| crate::Error::DataInvalid {
+            message: format!(
+                "Expected {semantic_type} array with physical type {:?}, found {:?}",
+                T::DATA_TYPE,
+                array.data_type()
+            ),
+            source: None,
+        })
+}
+
+macro_rules! cast_numeric_primitive_array {
+    ($array:expr, $source:ty, $target:expr) => {{
+        let values = downcast_primitive::<$source>($array, "numeric")?;
+        let result: ArrayRef = match $target {
+            DataType::TinyInt(_) => {
+                Arc::new(values.unary::<_, Int8Type>(|value| value as i32 as i8))
+            }
+            DataType::SmallInt(_) => {
+                Arc::new(values.unary::<_, Int16Type>(|value| value as i32 as i16))
+            }
+            DataType::Int(_) => Arc::new(values.unary::<_, Int32Type>(|value| value as i32)),
+            DataType::BigInt(_) => Arc::new(values.unary::<_, Int64Type>(|value| value as i64)),
+            DataType::Float(_) => Arc::new(values.unary::<_, Float32Type>(|value| value as f32)),
+            DataType::Double(_) => Arc::new(values.unary::<_, Float64Type>(|value| value as f64)),
+            _ => unreachable!("numeric primitive executor requires a primitive numeric target"),
+        };
+        Ok(result)
+    }};
+}
+
+fn cast_numeric_primitive(
+    array: &ArrayRef,
+    source: &DataType,
+    target: &DataType,
+) -> crate::Result<ArrayRef> {
+    // Java Number converts floating-point values to byte/short through int,
+    // combining saturating float-to-int conversion with wrapping integer
+    // narrowing. The macro uses that two-stage conversion for those targets.
+    match source {
+        DataType::TinyInt(_) => cast_numeric_primitive_array!(array, Int8Type, target),
+        DataType::SmallInt(_) => cast_numeric_primitive_array!(array, Int16Type, target),
+        DataType::Int(_) => cast_numeric_primitive_array!(array, Int32Type, target),
+        DataType::BigInt(_) => cast_numeric_primitive_array!(array, Int64Type, target),
+        DataType::Float(_) => cast_numeric_primitive_array!(array, Float32Type, target),
+        DataType::Double(_) => cast_numeric_primitive_array!(array, Float64Type, target),
+        _ => unreachable!("numeric primitive executor requires a primitive numeric source"),
+    }
+}
+
+fn cast_date_to_timestamp(array: &ArrayRef, target: &DataType) -> crate::Result<ArrayRef> {
+    let values = downcast_primitive::<Date32Type>(array, "DATE")?;
+    let DataType::Timestamp(timestamp) = target else {
+        unreachable!("date executor requires a TIMESTAMP target")
+    };
+    let result: ArrayRef = match timestamp.precision() {
+        0..=3 => Arc::new(
+            values.unary::<_, TimestampMillisecondType>(|value| i64::from(value) * 86_400_000),
+        ),
+        _ => unreachable!("DATE to TIMESTAMP precision above 3 is not admitted"),
+    };
+    Ok(result)
+}
+
+fn cast_timestamp_to_date(array: &ArrayRef, source: &DataType) -> crate::Result<ArrayRef> {
+    let DataType::Timestamp(timestamp) = source else {
+        unreachable!("timestamp executor requires a TIMESTAMP source")
+    };
+    let result: ArrayRef = match timestamp.precision() {
+        0..=3 => Arc::new(
+            downcast_primitive::<TimestampMillisecondType>(array, "TIMESTAMP")?
+                .unary::<_, Date32Type>(|value| (value / 86_400_000) as i32),
+        ),
+        4..=6 => Arc::new(
+            downcast_primitive::<TimestampMicrosecondType>(array, "TIMESTAMP")?
+                .unary::<_, Date32Type>(|value| (value / 86_400_000_000) as i32),
+        ),
+        7..=9 => Arc::new(
+            downcast_primitive::<TimestampNanosecondType>(array, "TIMESTAMP")?
+                .unary::<_, Date32Type>(|value| (value / 86_400_000_000_000) as i32),
+        ),
+        _ => unreachable!("TIMESTAMP precision is validated by its data type"),
+    };
+    Ok(result)
+}
+
+/// Normalize values before storage only for logical types whose constraints are
+/// not represented by their Arrow type. Callers decide which evolved field IDs
+/// require this normalization.
+pub(crate) fn normalize_array_for_schema_evolution_storage(
+    array: &ArrayRef,
+    target: &DataType,
+) -> crate::Result<ArrayRef> {
+    match target {
+        DataType::Char(_) | DataType::VarChar(_) => cast_character_string(array, target),
+        DataType::Binary(_) | DataType::VarBinary(_) => cast_binary_string(array, target),
+        _ => Ok(array.clone()),
+    }
+}
+
+pub(crate) fn requires_schema_evolution_storage_normalization(target: &DataType) -> bool {
+    match target {
+        DataType::Char(_) | DataType::Binary(_) => true,
+        DataType::VarChar(data_type) => data_type.length() < crate::spec::VarCharType::MAX_LENGTH,
+        DataType::VarBinary(data_type) => {
+            data_type.length() < crate::spec::VarBinaryType::MAX_LENGTH
+        }
+        _ => false,
+    }
+}
+
+fn cast_character_string(array: &ArrayRef, target: &DataType) -> crate::Result<ArrayRef> {
+    let values = array
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| crate::Error::DataInvalid {
+            message: format!(
+                "Expected Utf8 array for schema evolution cast, found {:?}",
+                array.data_type()
+            ),
+            source: None,
+        })?;
+    let (length, fixed) = match target {
+        DataType::Char(data_type) => (data_type.length(), true),
+        DataType::VarChar(data_type) => (data_type.length() as usize, false),
+        _ => unreachable!("character executor requires a character target"),
+    };
+
+    let mut builder = StringBuilder::new();
+    for index in 0..values.len() {
+        if values.is_null(index) {
+            builder.append_null();
+            continue;
+        }
+        let value = values.value(index);
+        let char_count = value.chars().count();
+        if char_count > length {
+            let truncated = value.chars().take(length).collect::<String>();
+            builder.append_value(truncated);
+        } else if fixed && char_count < length {
+            let mut padded = String::with_capacity(value.len() + length - char_count);
+            padded.push_str(value);
+            padded.extend(std::iter::repeat_n(' ', length - char_count));
+            builder.append_value(padded);
+        } else {
+            builder.append_value(value);
+        }
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+fn cast_binary_string(array: &ArrayRef, target: &DataType) -> crate::Result<ArrayRef> {
+    let values = array
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .ok_or_else(|| crate::Error::DataInvalid {
+            message: format!(
+                "Expected Binary array for schema evolution cast, found {:?}",
+                array.data_type()
+            ),
+            source: None,
+        })?;
+    let (length, fixed) = match target {
+        DataType::Binary(data_type) => (data_type.length(), true),
+        DataType::VarBinary(data_type) => (data_type.length() as usize, false),
+        _ => unreachable!("binary executor requires a binary target"),
+    };
+
+    let mut builder = BinaryBuilder::new();
+    for index in 0..values.len() {
+        if values.is_null(index) {
+            builder.append_null();
+            continue;
+        }
+        let value = values.value(index);
+        if value.len() > length {
+            builder.append_value(&value[..length]);
+        } else if fixed && value.len() < length {
+            let mut padded = Vec::with_capacity(length);
+            padded.extend_from_slice(value);
+            padded.resize(length, 0);
+            builder.append_value(padded);
+        } else {
+            builder.append_value(value);
+        }
+    }
+    Ok(Arc::new(builder.finish()))
+}
 
 /// Create index mapping from table fields to underlying data fields using field IDs.
 ///
@@ -74,7 +435,16 @@ pub fn create_index_mapping(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::spec::{DataType, IntType, VarCharType};
+    use crate::spec::{
+        ArrayType, BigIntType, BinaryType, CharType, DataType, DateType, DecimalType, DoubleType,
+        FloatType, IntType, SmallIntType, TimestampType, TinyIntType, VarBinaryType, VarCharType,
+    };
+    use arrow_array::{
+        ArrayRef, Date32Array, Decimal128Array, Float32Array, Float64Array, Int16Array, Int32Array,
+        Int64Array, Int8Array, ListArray, TimestampMillisecondArray,
+    };
+    use arrow_buffer::{OffsetBuffer, ScalarBuffer};
+    use arrow_schema::{DataType as ArrowDataType, Field};
 
     fn field(id: i32, name: &str) -> DataField {
         DataField::new(id, name.to_string(), DataType::Int(IntType::new()))
@@ -147,5 +517,394 @@ mod tests {
             ),
         ];
         assert_eq!(create_index_mapping(&table_fields, &data_fields), None);
+    }
+
+    #[test]
+    fn test_unchanged_nested_type_removes_file_field_metadata() {
+        let element_field = Arc::new(
+            Field::new("element", ArrowDataType::Int32, true).with_metadata(HashMap::from([(
+                "PARQUET:field_id".to_string(),
+                "1".to_string(),
+            )])),
+        );
+        let array: ArrayRef = Arc::new(ListArray::new(
+            element_field,
+            OffsetBuffer::new(ScalarBuffer::from(vec![0, 2])),
+            Arc::new(Int32Array::from(vec![1, 2])),
+            None,
+        ));
+        let data_type = DataType::Array(ArrayType::new(DataType::Int(IntType::new())));
+
+        let normalized = cast_array_for_schema_evolution(&array, &data_type, &data_type).unwrap();
+
+        assert_eq!(
+            normalized.data_type(),
+            &paimon_type_to_arrow(&data_type).unwrap()
+        );
+        assert_eq!(
+            normalized
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .unwrap()
+                .values()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .values(),
+            &[1, 2]
+        );
+    }
+
+    #[test]
+    fn test_schema_evolution_cast_matrix() {
+        let cases = [
+            (
+                DataType::Int(IntType::new()),
+                DataType::BigInt(BigIntType::new()),
+                true,
+            ),
+            (
+                DataType::Double(DoubleType::new()),
+                DataType::Decimal(DecimalType::new(12, 2).unwrap()),
+                false,
+            ),
+            (
+                DataType::Int(IntType::new()),
+                DataType::Decimal(DecimalType::new(12, 2).unwrap()),
+                true,
+            ),
+            (
+                DataType::Decimal(DecimalType::new(12, 4).unwrap()),
+                DataType::Decimal(DecimalType::new(10, 2).unwrap()),
+                true,
+            ),
+            (
+                DataType::Char(CharType::new(8).unwrap()),
+                DataType::VarChar(VarCharType::new(4).unwrap()),
+                true,
+            ),
+            (
+                DataType::Binary(BinaryType::new(8).unwrap()),
+                DataType::VarBinary(VarBinaryType::new(4).unwrap()),
+                true,
+            ),
+            (
+                DataType::Timestamp(TimestampType::new(3).unwrap()),
+                DataType::Date(DateType::new()),
+                true,
+            ),
+            (
+                DataType::Date(DateType::new()),
+                DataType::Timestamp(TimestampType::new(3).unwrap()),
+                true,
+            ),
+            (
+                DataType::Date(DateType::new()),
+                DataType::Timestamp(TimestampType::new(6).unwrap()),
+                false,
+            ),
+            (
+                DataType::Timestamp(TimestampType::new(3).unwrap()),
+                DataType::Timestamp(TimestampType::new(6).unwrap()),
+                false,
+            ),
+            (
+                DataType::Int(IntType::new()),
+                DataType::VarChar(VarCharType::new(10).unwrap()),
+                false,
+            ),
+            (
+                DataType::Array(ArrayType::new(DataType::Int(IntType::new()))),
+                DataType::Array(ArrayType::new(DataType::BigInt(BigIntType::new()))),
+                false,
+            ),
+        ];
+
+        for (source, target, expected) in cases {
+            assert_eq!(
+                schema_evolution_cast_implemented(&source, &target),
+                expected,
+                "unexpected executor availability for {source:?} -> {target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_character_schema_evolution_casts() {
+        let source: ArrayRef = Arc::new(StringArray::from(vec![
+            Some("abcdef"),
+            Some("é猫"),
+            Some("x"),
+            None,
+        ]));
+        let cases = [
+            (
+                DataType::Char(CharType::new(3).unwrap()),
+                vec![Some("abc"), Some("é猫 "), Some("x  "), None],
+            ),
+            (
+                DataType::VarChar(VarCharType::new(3).unwrap()),
+                vec![Some("abc"), Some("é猫"), Some("x"), None],
+            ),
+        ];
+
+        for (target, expected) in cases {
+            let casted = cast_array_for_schema_evolution(
+                &source,
+                &DataType::VarChar(VarCharType::new(20).unwrap()),
+                &target,
+            )
+            .unwrap();
+            let casted = casted.as_any().downcast_ref::<StringArray>().unwrap();
+            let actual = (0..casted.len())
+                .map(|index| (!casted.is_null(index)).then(|| casted.value(index)))
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn test_storage_normalization_is_required_only_for_bounded_targets() {
+        let cases = [
+            (DataType::Char(CharType::new(5).unwrap()), true),
+            (DataType::VarChar(VarCharType::new(5).unwrap()), true),
+            (DataType::VarChar(VarCharType::string_type()), false),
+            (DataType::Binary(BinaryType::new(5).unwrap()), true),
+            (DataType::VarBinary(VarBinaryType::new(5).unwrap()), true),
+            (
+                DataType::VarBinary(VarBinaryType::new(VarBinaryType::MAX_LENGTH).unwrap()),
+                false,
+            ),
+            (DataType::Int(IntType::new()), false),
+        ];
+
+        for (target, expected) in cases {
+            assert_eq!(
+                requires_schema_evolution_storage_normalization(&target),
+                expected,
+                "unexpected storage normalization requirement for {target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_binary_schema_evolution_casts() {
+        let source: ArrayRef = Arc::new(BinaryArray::from(vec![
+            Some(&b"abcd"[..]),
+            Some(&b"x"[..]),
+            None,
+        ]));
+        let cases = [
+            (
+                DataType::Binary(BinaryType::new(3).unwrap()),
+                vec![Some(&b"abc"[..]), Some(&b"x\0\0"[..]), None],
+            ),
+            (
+                DataType::VarBinary(VarBinaryType::new(3).unwrap()),
+                vec![Some(&b"abc"[..]), Some(&b"x"[..]), None],
+            ),
+        ];
+
+        for (target, expected) in cases {
+            let casted = cast_array_for_schema_evolution(
+                &source,
+                &DataType::VarBinary(VarBinaryType::new(20).unwrap()),
+                &target,
+            )
+            .unwrap();
+            let casted = casted.as_any().downcast_ref::<BinaryArray>().unwrap();
+            let actual = (0..casted.len())
+                .map(|index| (!casted.is_null(index)).then(|| casted.value(index)))
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn test_numeric_primitive_cast_uses_paimon_semantics() {
+        let numeric_source: ArrayRef = Arc::new(Int32Array::from(vec![Some(7), None, Some(-4)]));
+        let numeric = cast_array_for_schema_evolution(
+            &numeric_source,
+            &DataType::Int(IntType::new()),
+            &DataType::BigInt(BigIntType::new()),
+        )
+        .unwrap();
+        assert_eq!(
+            numeric.as_any().downcast_ref::<Int64Array>().unwrap(),
+            &Int64Array::from(vec![Some(7), None, Some(-4)])
+        );
+
+        let narrowing_source: ArrayRef =
+            Arc::new(Int64Array::from(vec![Some(i64::from(i32::MAX) + 1), None]));
+        let narrowing = cast_array_for_schema_evolution(
+            &narrowing_source,
+            &DataType::BigInt(BigIntType::new()),
+            &DataType::Int(IntType::new()),
+        )
+        .unwrap();
+        assert_eq!(
+            narrowing.as_any().downcast_ref::<Int32Array>().unwrap(),
+            &Int32Array::from(vec![Some(i32::MIN), None])
+        );
+
+        let floating_source: ArrayRef = Arc::new(Float64Array::from(vec![
+            Some(f64::NAN),
+            Some(f64::INFINITY),
+            Some(f64::NEG_INFINITY),
+            Some(3.9),
+            Some(-3.9),
+        ]));
+        let floating = cast_array_for_schema_evolution(
+            &floating_source,
+            &DataType::Double(DoubleType::new()),
+            &DataType::Int(IntType::new()),
+        )
+        .unwrap();
+        assert_eq!(
+            floating.as_any().downcast_ref::<Int32Array>().unwrap(),
+            &Int32Array::from(vec![
+                Some(0),
+                Some(i32::MAX),
+                Some(i32::MIN),
+                Some(3),
+                Some(-3)
+            ])
+        );
+
+        let float_narrowing_cases = [
+            (
+                Arc::new(Float32Array::from(vec![
+                    1000.0,
+                    -1000.0,
+                    f32::NAN,
+                    f32::INFINITY,
+                    f32::NEG_INFINITY,
+                    f32::MAX,
+                    -f32::MAX,
+                    127.0,
+                    128.0,
+                    32_767.0,
+                    32_768.0,
+                ])) as ArrayRef,
+                DataType::Float(FloatType::new()),
+            ),
+            (
+                Arc::new(Float64Array::from(vec![
+                    1000.0,
+                    -1000.0,
+                    f64::NAN,
+                    f64::INFINITY,
+                    f64::NEG_INFINITY,
+                    f64::MAX,
+                    -f64::MAX,
+                    127.0,
+                    128.0,
+                    32_767.0,
+                    32_768.0,
+                ])) as ArrayRef,
+                DataType::Double(DoubleType::new()),
+            ),
+        ];
+        for (source, source_type) in float_narrowing_cases {
+            let tinyint = cast_array_for_schema_evolution(
+                &source,
+                &source_type,
+                &DataType::TinyInt(TinyIntType::new()),
+            )
+            .unwrap();
+            assert_eq!(
+                tinyint.as_any().downcast_ref::<Int8Array>().unwrap(),
+                &Int8Array::from(vec![-24, 24, 0, -1, 0, -1, 0, 127, -128, -1, 0]),
+                "unexpected {source_type:?} to TINYINT result"
+            );
+
+            let smallint = cast_array_for_schema_evolution(
+                &source,
+                &source_type,
+                &DataType::SmallInt(SmallIntType::new()),
+            )
+            .unwrap();
+            assert_eq!(
+                smallint.as_any().downcast_ref::<Int16Array>().unwrap(),
+                &Int16Array::from(vec![
+                    1000, -1000, 0, -1, 0, -1, 0, 127, 128, 32_767, -32_768,
+                ]),
+                "unexpected {source_type:?} to SMALLINT result"
+            );
+        }
+    }
+
+    #[test]
+    fn test_decimal_cast_uses_paimon_rounding_and_overflow_semantics() {
+        let decimal_source: ArrayRef = Arc::new(
+            Decimal128Array::from(vec![Some(1_235), Some(-1_235), Some(99_999), None])
+                .with_precision_and_scale(5, 3)
+                .unwrap(),
+        );
+        let decimal = cast_array_for_schema_evolution(
+            &decimal_source,
+            &DataType::Decimal(DecimalType::new(5, 3).unwrap()),
+            &DataType::Decimal(DecimalType::new(4, 2).unwrap()),
+        )
+        .unwrap();
+        assert_eq!(
+            decimal.as_any().downcast_ref::<Decimal128Array>().unwrap(),
+            &Decimal128Array::from(vec![Some(124), Some(-124), None, None])
+                .with_precision_and_scale(4, 2)
+                .unwrap()
+        );
+
+        let integer_source: ArrayRef = Arc::new(Int32Array::from(vec![Some(1), Some(12), None]));
+        let decimal = cast_array_for_schema_evolution(
+            &integer_source,
+            &DataType::Int(IntType::new()),
+            &DataType::Decimal(DecimalType::new(3, 2).unwrap()),
+        )
+        .unwrap();
+        assert_eq!(
+            decimal.as_any().downcast_ref::<Decimal128Array>().unwrap(),
+            &Decimal128Array::from(vec![Some(100), None, None])
+                .with_precision_and_scale(3, 2)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_date_timestamp_cast_uses_paimon_epoch_semantics() {
+        let date_source: ArrayRef = Arc::new(Date32Array::from(vec![Some(1), None]));
+        let timestamp_source: ArrayRef = Arc::new(TimestampMillisecondArray::from(vec![
+            Some(-1),
+            Some(-86_400_000),
+            Some(-86_400_001),
+            None,
+        ]));
+        for precision in [0, 3] {
+            let timestamp = cast_array_for_schema_evolution(
+                &date_source,
+                &DataType::Date(DateType::new()),
+                &DataType::Timestamp(TimestampType::new(precision).unwrap()),
+            )
+            .unwrap();
+            assert_eq!(
+                timestamp
+                    .as_any()
+                    .downcast_ref::<TimestampMillisecondArray>()
+                    .unwrap(),
+                &TimestampMillisecondArray::from(vec![Some(86_400_000), None]),
+                "unexpected DATE to TIMESTAMP({precision}) result"
+            );
+
+            let date = cast_array_for_schema_evolution(
+                &timestamp_source,
+                &DataType::Timestamp(TimestampType::new(precision).unwrap()),
+                &DataType::Date(DateType::new()),
+            )
+            .unwrap();
+            assert_eq!(
+                date.as_any().downcast_ref::<Date32Array>().unwrap(),
+                &Date32Array::from(vec![Some(0), Some(-1), Some(-1), None]),
+                "unexpected TIMESTAMP({precision}) to DATE result"
+            );
+        }
     }
 }

--- a/crates/paimon/src/catalog/filesystem.rs
+++ b/crates/paimon/src/catalog/filesystem.rs
@@ -21,6 +21,7 @@
 
 use std::collections::HashMap;
 
+use crate::catalog::schema_evolution::{apply_schema_changes, validate_type_evolution_precommit};
 use crate::catalog::{Catalog, Database, Identifier, DB_LOCATION_PROP, DB_SUFFIX};
 use crate::common::{CatalogOptions, Options};
 use crate::error::{ConfigInvalidSnafu, Error, Result};
@@ -458,26 +459,10 @@ impl Catalog for FileSystemCatalog {
                 full_name: identifier.full_name(),
             })?;
 
-        let new_schema = current
-            .apply_changes(changes)
-            .map_err(|e| fill_table_name(e, identifier))?;
+        let new_schema = apply_schema_changes(&current, &changes, identifier)?;
+        validate_type_evolution_precommit(&self.file_io, &table_path, &current, &new_schema)
+            .await?;
         self.save_table_schema(&table_path, &new_schema).await
-    }
-}
-
-/// `TableSchema::apply_changes` returns column errors without a table name;
-/// fill in the identifier's full name so the message identifies the table.
-fn fill_table_name(err: Error, identifier: &Identifier) -> Error {
-    match err {
-        Error::ColumnNotExist { column, .. } => Error::ColumnNotExist {
-            full_name: identifier.full_name(),
-            column,
-        },
-        Error::ColumnAlreadyExist { column, .. } => Error::ColumnAlreadyExist {
-            full_name: identifier.full_name(),
-            column,
-        },
-        other => other,
     }
 }
 

--- a/crates/paimon/src/catalog/mod.rs
+++ b/crates/paimon/src/catalog/mod.rs
@@ -26,6 +26,7 @@ mod filesystem;
 mod function;
 mod partition_listing;
 mod rest;
+mod schema_evolution;
 mod view;
 
 use std::collections::HashMap;

--- a/crates/paimon/src/catalog/rest/rest_catalog.rs
+++ b/crates/paimon/src/catalog/rest/rest_catalog.rs
@@ -28,6 +28,7 @@ use async_trait::async_trait;
 use crate::api::rest_api::RESTApi;
 use crate::api::rest_error::RestError;
 use crate::api::PagedList;
+use crate::catalog::schema_evolution::{apply_schema_changes, validate_type_evolution_precommit};
 use crate::catalog::{
     list_partitions_from_file_system, Catalog, Database, Identifier, DB_LOCATION_PROP,
 };
@@ -278,6 +279,25 @@ impl Catalog for RESTCatalog {
         changes: Vec<SchemaChange>,
         ignore_if_not_exists: bool,
     ) -> Result<()> {
+        if changes
+            .iter()
+            .any(|change| matches!(change, SchemaChange::UpdateColumnType { .. }))
+        {
+            let table = match self.get_table(identifier).await {
+                Ok(table) => table,
+                Err(Error::TableNotExist { .. }) if ignore_if_not_exists => return Ok(()),
+                Err(error) => return Err(error),
+            };
+            let new_schema = apply_schema_changes(table.schema(), &changes, identifier)?;
+            validate_type_evolution_precommit(
+                table.file_io(),
+                table.location(),
+                table.schema(),
+                &new_schema,
+            )
+            .await?;
+        }
+
         let result = self
             .api
             .alter_table(identifier, changes)

--- a/crates/paimon/src/catalog/schema_evolution.rs
+++ b/crates/paimon/src/catalog/schema_evolution.rs
@@ -1,0 +1,175 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashSet;
+
+use crate::catalog::Identifier;
+use crate::io::FileIO;
+use crate::spec::{FileKind, IndexManifest, SchemaChange, TableSchema};
+use crate::table::{SchemaManager, SnapshotManager};
+use crate::{Error, Result};
+
+pub(crate) fn apply_schema_changes(
+    current_schema: &TableSchema,
+    changes: &[SchemaChange],
+    identifier: &Identifier,
+) -> Result<TableSchema> {
+    current_schema
+        .apply_changes(changes.to_vec())
+        .map_err(|error| fill_table_name(error, identifier))
+}
+
+pub(crate) async fn validate_type_evolution_precommit(
+    file_io: &FileIO,
+    table_path: &str,
+    current_schema: &TableSchema,
+    new_schema: &TableSchema,
+) -> Result<()> {
+    let changed_field_ids = type_changed_field_ids(current_schema, new_schema);
+    if changed_field_ids.is_empty() {
+        return Ok(());
+    }
+
+    assert_historical_schema_evolution_casts(file_io, table_path, new_schema, &changed_field_ids)
+        .await?;
+    assert_no_persisted_index_type_dependencies(
+        file_io,
+        table_path,
+        current_schema,
+        &changed_field_ids,
+    )
+    .await
+}
+
+async fn assert_historical_schema_evolution_casts(
+    file_io: &FileIO,
+    table_path: &str,
+    new_schema: &TableSchema,
+    changed_field_ids: &HashSet<i32>,
+) -> Result<()> {
+    let schema_manager = SchemaManager::new(file_io.clone(), table_path.to_string());
+    for historical_schema in schema_manager.list_all().await? {
+        for target_field in new_schema
+            .fields()
+            .iter()
+            .filter(|field| changed_field_ids.contains(&field.id()))
+        {
+            let Some(source_field) = historical_schema
+                .fields()
+                .iter()
+                .find(|field| field.id() == target_field.id())
+            else {
+                continue;
+            };
+            if !crate::arrow::schema_evolution::schema_evolution_cast_implemented(
+                source_field.data_type(),
+                target_field.data_type(),
+            ) {
+                return Err(Error::Unsupported {
+                    message: format!(
+                        "Cannot update type of column '{}' because historical schema {} requires an unimplemented schema evolution cast from {:?} to {:?} for field id {}",
+                        target_field.name(),
+                        historical_schema.id(),
+                        source_field.data_type(),
+                        target_field.data_type(),
+                        target_field.id()
+                    ),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn assert_no_persisted_index_type_dependencies(
+    file_io: &FileIO,
+    table_path: &str,
+    current_schema: &TableSchema,
+    changed_field_ids: &HashSet<i32>,
+) -> Result<()> {
+    let snapshot_manager = SnapshotManager::new(file_io.clone(), table_path.to_string());
+    let Some(snapshot) = snapshot_manager.get_latest_snapshot().await? else {
+        return Ok(());
+    };
+    let Some(index_manifest_name) = snapshot.index_manifest() else {
+        return Ok(());
+    };
+    let entries = IndexManifest::read(
+        file_io,
+        &snapshot_manager.manifest_path(index_manifest_name),
+    )
+    .await?;
+    for entry in entries {
+        if entry.kind != FileKind::Add {
+            continue;
+        }
+        let Some(index_meta) = entry.index_file.global_index_meta.as_ref() else {
+            continue;
+        };
+        let dependent_field_id = std::iter::once(index_meta.index_field_id)
+            .chain(index_meta.extra_field_ids.iter().flatten().copied())
+            .find(|field_id| changed_field_ids.contains(field_id));
+        let Some(field_id) = dependent_field_id else {
+            continue;
+        };
+        let field_name = current_schema
+            .fields()
+            .iter()
+            .find(|field| field.id() == field_id)
+            .map(|field| field.name())
+            .unwrap_or("<unknown>");
+        return Err(Error::Unsupported {
+            message: format!(
+                "Cannot update type of column '{field_name}' because persisted global index '{}' depends on field id {field_id}",
+                entry.index_file.index_type
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn type_changed_field_ids(current_schema: &TableSchema, new_schema: &TableSchema) -> HashSet<i32> {
+    current_schema
+        .fields()
+        .iter()
+        .filter_map(|current_field| {
+            let new_field = new_schema
+                .fields()
+                .iter()
+                .find(|field| field.id() == current_field.id())?;
+            (!crate::arrow::schema_evolution::same_type_ignoring_nullability(
+                current_field.data_type(),
+                new_field.data_type(),
+            ))
+            .then_some(current_field.id())
+        })
+        .collect()
+}
+
+fn fill_table_name(error: Error, identifier: &Identifier) -> Error {
+    match error {
+        Error::ColumnNotExist { column, .. } => Error::ColumnNotExist {
+            full_name: identifier.full_name(),
+            column,
+        },
+        Error::ColumnAlreadyExist { column, .. } => Error::ColumnAlreadyExist {
+            full_name: identifier.full_name(),
+            column,
+        },
+        other => other,
+    }
+}

--- a/crates/paimon/src/spec/avro/index_manifest_entry_decode.rs
+++ b/crates/paimon/src/spec/avro/index_manifest_entry_decode.rs
@@ -212,6 +212,23 @@ fn decode_nullable_global_index(
         None
     };
 
+    // Rust extension used to guard index key semantics across ALTER TYPE.
+    // It is trailing and optional so Java and older Rust manifests remain
+    // readable in both directions.
+    let has_build_schema_id = extract_record_schema(schema)
+        .map(|s| s.fields.iter().any(|f| f.name == "_BUILD_SCHEMA_ID"))
+        .unwrap_or(false);
+    let build_schema_id = if has_build_schema_id {
+        let u_idx = cursor.read_union_index()?;
+        if u_idx == 0 {
+            None
+        } else {
+            Some(cursor.read_long()?)
+        }
+    } else {
+        None
+    };
+
     Ok(Some(GlobalIndexMeta {
         row_range_start,
         row_range_end,
@@ -219,5 +236,6 @@ fn decode_nullable_global_index(
         extra_field_ids,
         index_meta,
         source_meta,
+        build_schema_id,
     }))
 }

--- a/crates/paimon/src/spec/index_file_meta.rs
+++ b/crates/paimon/src/spec/index_file_meta.rs
@@ -49,6 +49,13 @@ pub struct GlobalIndexMeta {
 
     #[serde(default, rename = "_SOURCE_META", with = "serde_bytes")]
     pub source_meta: Option<Vec<u8>>,
+
+    /// Schema used to encode the indexed fields.
+    ///
+    /// Rust readers use this to reject an index whose key semantics no longer
+    /// match the current field types after schema evolution.
+    #[serde(default, rename = "_BUILD_SCHEMA_ID")]
+    pub build_schema_id: Option<i64>,
 }
 
 /// Metadata of index file.

--- a/crates/paimon/src/spec/index_manifest.rs
+++ b/crates/paimon/src/spec/index_manifest.rs
@@ -71,7 +71,8 @@ pub const INDEX_MANIFEST_ENTRY_SCHEMA: &str = r#"{
                     {"name": "_INDEX_FIELD_ID", "type": "int"},
                     {"name": "_EXTRA_FIELD_IDS", "type": ["null", {"type": "array", "items": "int"}], "default": null},
                     {"name": "_INDEX_META", "type": ["null", "bytes"], "default": null},
-                    {"name": "_SOURCE_META", "type": ["null", "bytes"], "default": null}
+                    {"name": "_SOURCE_META", "type": ["null", "bytes"], "default": null},
+                    {"name": "_BUILD_SCHEMA_ID", "type": ["null", "long"], "default": null}
                 ]
             }]
         }
@@ -277,7 +278,10 @@ mod tests {
         assert_eq!(sample, decoded);
     }
 
-    fn global_index_entry(source_meta: Option<Vec<u8>>) -> IndexManifestEntry {
+    fn global_index_entry(
+        source_meta: Option<Vec<u8>>,
+        build_schema_id: Option<i64>,
+    ) -> IndexManifestEntry {
         IndexManifestEntry {
             version: 1,
             kind: FileKind::Add,
@@ -296,6 +300,7 @@ mod tests {
                     extra_field_ids: Some(vec![4, 5]),
                     index_meta: Some(vec![9, 8, 7]),
                     source_meta,
+                    build_schema_id,
                 }),
             },
         }
@@ -304,7 +309,7 @@ mod tests {
     #[test]
     fn source_meta_round_trips_through_index_manifest() {
         // New-format writer schema carries _SOURCE_META; a Some(..) value must round-trip.
-        let entry = global_index_entry(Some(vec![1, 2, 3]));
+        let entry = global_index_entry(Some(vec![1, 2, 3]), Some(7));
         let bytes = crate::spec::to_avro_bytes_with_compression(
             INDEX_MANIFEST_ENTRY_SCHEMA,
             std::slice::from_ref(&entry),
@@ -322,9 +327,18 @@ mod tests {
                 .source_meta,
             Some(vec![1, 2, 3])
         );
+        assert_eq!(
+            decoded[0]
+                .index_file
+                .global_index_meta
+                .as_ref()
+                .unwrap()
+                .build_schema_id,
+            Some(7)
+        );
 
         // A None source_meta must also round-trip as None.
-        let entry_none = global_index_entry(None);
+        let entry_none = global_index_entry(None, None);
         let bytes_none = crate::spec::to_avro_bytes_with_compression(
             INDEX_MANIFEST_ENTRY_SCHEMA,
             std::slice::from_ref(&entry_none),
@@ -340,6 +354,33 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .source_meta,
+            None
+        );
+    }
+
+    #[test]
+    fn java_six_field_global_index_decodes_without_build_schema_id() {
+        let java_schema = INDEX_MANIFEST_ENTRY_SCHEMA.replace(
+            ",\n                    {\"name\": \"_BUILD_SCHEMA_ID\", \"type\": [\"null\", \"long\"], \"default\": null}",
+            "",
+        );
+        let entry = global_index_entry(Some(vec![1, 2, 3]), None);
+        let bytes = crate::spec::to_avro_bytes_with_compression(
+            &java_schema,
+            std::slice::from_ref(&entry),
+            crate::spec::DEFAULT_AVRO_COMPRESSION,
+        )
+        .unwrap();
+
+        let decoded = IndexManifest::read_from_bytes(&bytes).unwrap();
+        assert_eq!(decoded, vec![entry]);
+        assert_eq!(
+            decoded[0]
+                .index_file
+                .global_index_meta
+                .as_ref()
+                .unwrap()
+                .build_schema_id,
             None
         );
     }
@@ -422,14 +463,14 @@ mod tests {
 }"#;
 
         // Written by a pre-#8549 writer (5-field record, source_meta absent).
-        let entry = global_index_entry(None);
+        let entry = global_index_entry(None, None);
         let bytes = crate::spec::to_avro_bytes_with_compression(
             LEGACY_SCHEMA,
             std::slice::from_ref(&entry),
             crate::spec::DEFAULT_AVRO_COMPRESSION,
         )
         .unwrap();
-        // Decoding with the current 6-field reader must not misalign the stream.
+        // Decoding with the current 7-field reader must not misalign the stream.
         let decoded = IndexManifest::read_from_bytes(&bytes).unwrap();
         assert_eq!(decoded[0], entry);
         assert_eq!(
@@ -439,6 +480,15 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .source_meta,
+            None
+        );
+        assert_eq!(
+            decoded[0]
+                .index_file
+                .global_index_meta
+                .as_ref()
+                .unwrap()
+                .build_schema_id,
             None
         );
     }

--- a/crates/paimon/src/spec/pk_index_source.rs
+++ b/crates/paimon/src/spec/pk_index_source.rs
@@ -458,6 +458,7 @@ mod tests {
             extra_field_ids: None,
             index_meta: None,
             source_meta: None,
+            build_schema_id: None,
         };
         assert!(PrimaryKeyIndexSourceMeta::from_global_index_meta(&meta).is_err());
     }
@@ -471,6 +472,7 @@ mod tests {
             extra_field_ids: None,
             index_meta: None,
             source_meta: Some(frame(1, &[("f0", 3)])),
+            build_schema_id: None,
         };
         let parsed = PrimaryKeyIndexSourceMeta::from_global_index_meta(&meta).unwrap();
         assert_eq!(parsed.data_level(), 1);

--- a/crates/paimon/src/spec/schema.rs
+++ b/crates/paimon/src/spec/schema.rs
@@ -269,10 +269,10 @@ impl TableSchema {
             .get(crate::spec::DISABLE_EXPLICIT_TYPE_CASTING_OPTION)
             .map(|v| v != "true")
             .unwrap_or(true);
-        // Capture stable IDs before applying changes so removing the option or
-        // renaming its column cannot bypass historical bucket-key protection.
-        let old_bucket_key_field_ids: HashSet<i32> = self
-            .core_options()
+        // Capture stable IDs before applying changes so renaming a role column
+        // cannot bypass dependency protection later in the same change batch.
+        let original_core_options = self.core_options();
+        let old_bucket_key_field_ids: HashSet<i32> = original_core_options
             .bucket_key()
             .into_iter()
             .flatten()
@@ -283,6 +283,22 @@ impl TableSchema {
                     .map(DataField::id)
             })
             .collect();
+        let old_sequence_field_ids: HashSet<i32> = original_core_options
+            .sequence_fields()
+            .into_iter()
+            .filter_map(|name| {
+                self.fields
+                    .iter()
+                    .find(|field| field.name() == name)
+                    .map(DataField::id)
+            })
+            .collect();
+        let old_rowkind_field_id = original_core_options.rowkind_field().and_then(|name| {
+            self.fields
+                .iter()
+                .find(|field| field.name() == name)
+                .map(DataField::id)
+        });
 
         let mut new_schema = self.clone();
         new_schema.id += 1;
@@ -471,6 +487,18 @@ impl TableSchema {
                             column: name.to_string(),
                         })?;
                     let old = &fields[idx];
+                    if old_sequence_field_ids.contains(&old.id()) {
+                        return Err(crate::Error::Unsupported {
+                            message: format!("Cannot update type of sequence field: [{name}]"),
+                        });
+                    }
+                    if old_rowkind_field_id == Some(old.id()) {
+                        return Err(crate::Error::Unsupported {
+                            message: format!(
+                                "Cannot update type of rowkind routing field: [{name}]"
+                            ),
+                        });
+                    }
                     assert_not_updating_bucket_key_column(
                         &old_bucket_key_field_ids,
                         old,
@@ -498,15 +526,15 @@ impl TableSchema {
                         )?;
                         new_data_type
                     };
-                    // Existing data files keep the old schema; the read path
-                    // casts old columns to the new type, so the change must be
-                    // both a supported Paimon cast and executable by arrow.
-                    let arrow_castable = arrow_cast::can_cast_types(
-                        &crate::arrow::paimon_type_to_arrow(old.data_type())?,
-                        &crate::arrow::paimon_type_to_arrow(&target)?,
-                    );
+                    // Existing files keep the old schema. Admission therefore
+                    // requires both a legal Paimon cast and a concrete schema
+                    // evolution executor. Arrow castability alone does not
+                    // define Paimon conversion semantics.
                     if !crate::spec::supports_cast(old.data_type(), &target, allow_explicit_cast)
-                        || !arrow_castable
+                        || !crate::arrow::schema_evolution::schema_evolution_cast_implemented(
+                            old.data_type(),
+                            &target,
+                        )
                     {
                         return Err(crate::Error::Unsupported {
                             message: format!(
@@ -3059,6 +3087,8 @@ mod tests {
         for new_type in [
             DataType::Array(ArrayType::new(DataType::Int(IntType::new()))),
             DataType::Boolean(crate::spec::BooleanType::new()),
+            DataType::Timestamp(crate::spec::TimestampType::new(6).unwrap()),
+            DataType::VarChar(crate::spec::VarCharType::new(20).unwrap()),
         ] {
             let err = table_schema
                 .apply_changes(vec![crate::spec::SchemaChange::update_column_type(
@@ -3072,6 +3102,25 @@ mod tests {
                 "expected cast rejection, got {err:?}"
             );
         }
+
+        let floating_schema = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("f", DataType::Double(crate::spec::DoubleType::new()))
+                .build()
+                .unwrap(),
+        );
+        let err = floating_schema
+            .apply_changes(vec![crate::spec::SchemaChange::update_column_type(
+                "f".to_string(),
+                DataType::Decimal(crate::spec::DecimalType::new(12, 2).unwrap()),
+            )])
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::Error::Unsupported { ref message }
+                if message.contains("cannot be converted") && message.contains('f')),
+            "expected unimplemented semantic cast rejection, got {err:?}"
+        );
     }
 
     #[test]
@@ -4977,6 +5026,80 @@ mod tests {
             matches!(err, crate::Error::Unsupported { ref message }
                 if message.contains("sequence.field") && message.contains("ts")),
             "drop of a sequence.field column should be rejected, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_update_type_rejects_sequence_and_rowkind_role_columns() {
+        let table_schema = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("seq", DataType::Int(IntType::new()))
+                .column("op", DataType::VarChar(VarCharType::string_type()))
+                .primary_key(["id"])
+                .option("sequence.field", "seq")
+                .option("rowkind.field", "op")
+                .build()
+                .unwrap(),
+        );
+
+        for (column, target, expected_message) in [
+            (
+                "seq",
+                DataType::BigInt(crate::spec::BigIntType::new()),
+                "sequence field",
+            ),
+            (
+                "op",
+                DataType::Char(crate::spec::CharType::new(10).unwrap()),
+                "rowkind routing field",
+            ),
+        ] {
+            let err = table_schema
+                .apply_changes(vec![crate::spec::SchemaChange::update_column_type(
+                    column.to_string(),
+                    target,
+                )])
+                .unwrap_err();
+            assert!(
+                matches!(err, crate::Error::Unsupported { ref message }
+                    if message.contains(expected_message) && message.contains(column)),
+                "expected role-column rejection, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_update_type_rejects_sequence_role_after_rename_in_same_batch() {
+        let table_schema = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("seq", DataType::Int(IntType::new()))
+                .primary_key(["id"])
+                .option("sequence.field", "seq")
+                .build()
+                .unwrap(),
+        );
+
+        let err = table_schema
+            .apply_changes(vec![
+                crate::spec::SchemaChange::rename_column(
+                    "seq".to_string(),
+                    "renamed_seq".to_string(),
+                ),
+                crate::spec::SchemaChange::update_column_type(
+                    "renamed_seq".to_string(),
+                    DataType::BigInt(crate::spec::BigIntType::new()),
+                ),
+            ])
+            .unwrap_err();
+
+        assert!(
+            matches!(err, crate::Error::Unsupported { ref message }
+                if message.contains("sequence field") && message.contains("renamed_seq")),
+            "expected stable role-column rejection, got {err:?}"
         );
     }
 

--- a/crates/paimon/src/table/btree_global_index_build_builder.rs
+++ b/crates/paimon/src/table/btree_global_index_build_builder.rs
@@ -303,6 +303,7 @@ impl<'a> BTreeGlobalIndexBuildBuilder<'a> {
                 extra_field_ids: None,
                 source_meta: None,
                 index_meta: Some(index_meta.serialize()),
+                build_schema_id: None,
             }),
         })
     }
@@ -2518,6 +2519,7 @@ mod tests {
                 extra_field_ids: None,
                 source_meta: None,
                 index_meta: None,
+                build_schema_id: None,
             }),
         };
         let mut message = CommitMessage::new(BinaryRow::new(0).to_serialized_bytes(), 0, vec![]);

--- a/crates/paimon/src/table/data_file_reader.rs
+++ b/crates/paimon/src/table/data_file_reader.rs
@@ -17,7 +17,9 @@
 
 use crate::arrow::build_target_arrow_schema;
 use crate::arrow::format::create_format_reader_with_budget;
-use crate::arrow::schema_evolution::{create_index_mapping, NULL_FIELD_INDEX};
+use crate::arrow::schema_evolution::{
+    cast_array_for_schema_evolution, create_index_mapping, NULL_FIELD_INDEX,
+};
 use crate::arrow::ParquetReadBudget;
 use crate::deletion_vector::{DeletionVector, DeletionVectorFactory};
 use crate::io::FileIO;
@@ -29,7 +31,6 @@ use crate::table::ArrowRecordBatchStream;
 use crate::table::RowRange;
 use crate::{DataSplit, Error};
 use arrow_array::{Array, Int64Array, RecordBatch};
-use arrow_cast::cast;
 
 use async_stream::try_stream;
 use futures::StreamExt;
@@ -271,7 +272,7 @@ impl DataFileReader {
         // they pass, so this guard does not affect them.
         Self::reject_row_id_with_predicates(&self.read_type, &self.predicates)?;
 
-        let read_type = self.read_type.clone();
+        let output_read_type = self.read_type.clone();
         let table_fields = self.table_fields.clone();
         let predicates = self.predicates.clone();
         // The first version of the engine hook is deliberately limited to a
@@ -292,9 +293,36 @@ impl DataFileReader {
         let batch_size = self.batch_size;
         let parquet_read_budget = self.parquet_read_budget.clone();
 
-        let target_schema = build_target_arrow_schema(&read_type)?;
         let file_fields = data_fields.clone().unwrap_or_else(|| table_fields.clone());
         let is_row_file = is_row_file(&file_meta);
+
+        // File-level predicates are only a pruning/filtering optimization. When
+        // a predicate references a type-evolved field, its current-schema
+        // literal cannot be passed to the old physical type. Keep the safe
+        // remapped subset for the format reader, then enforce the original
+        // predicate after converting the batch to current logical types.
+        let remapped = crate::arrow::filtering::remap_predicates_to_file(
+            &predicates,
+            &table_fields,
+            &file_fields,
+        );
+        let current_schema_residual = remapped.requires_current_schema_residual.then(|| {
+            crate::arrow::format::FilePredicates {
+                predicates: predicates.clone(),
+                row_filter_factory: None,
+                file_fields: table_fields.clone(),
+            }
+        });
+        let read_type = crate::arrow::residual::widen_scan_fields(
+            &output_read_type,
+            current_schema_residual.as_ref(),
+        );
+        let target_schema = build_target_arrow_schema(&read_type)?;
+        let output_schema = if current_schema_residual.is_some() {
+            Some(build_target_arrow_schema(&output_read_type)?)
+        } else {
+            None
+        };
 
         // Compute index mapping and determine which columns to read from the file.
         let (projected_read_fields, index_mapping) = if let Some(ref df) = data_fields {
@@ -319,16 +347,11 @@ impl DataFileReader {
 
         // Remap predicates from table-level to file-level indices.
         let file_predicates = {
-            let remapped = crate::arrow::filtering::remap_predicates_to_file(
-                &predicates,
-                &table_fields,
-                &file_fields,
-            );
-            if remapped.is_empty() && row_filter_factory.is_none() {
+            if remapped.predicates.is_empty() && row_filter_factory.is_none() {
                 None
             } else {
                 Some(crate::arrow::format::FilePredicates {
-                    predicates: remapped,
+                    predicates: remapped.predicates,
                     row_filter_factory,
                     file_fields: file_fields.clone(),
                 })
@@ -397,42 +420,45 @@ impl DataFileReader {
                             None
                         } else {
                             let data_field = &data_fields.as_ref().unwrap()[data_idx as usize];
-                            batch_schema
-                                .index_of(data_field.name())
-                                .ok()
-                                .map(|col_idx| batch.column(col_idx))
+                            match batch_schema.index_of(data_field.name()) {
+                                Ok(col_idx) => Some((
+                                    batch.column(col_idx),
+                                    decoded_data_type(data_field, &format_read_fields)?,
+                                )),
+                                Err(_) => None,
+                            }
                         }
                     } else if let Some(ref df) = data_fields {
-                        batch_schema
-                            .index_of(df[i].name())
-                            .ok()
-                            .map(|col_idx| batch.column(col_idx))
+                        let data_field = &df[i];
+                        match batch_schema.index_of(data_field.name()) {
+                            Ok(col_idx) => Some((
+                                batch.column(col_idx),
+                                decoded_data_type(data_field, &format_read_fields)?,
+                            )),
+                            Err(_) => None,
+                        }
                     } else {
                         batch_schema
                             .index_of(target_field.name())
                             .ok()
-                            .map(|col_idx| batch.column(col_idx))
+                            .map(|col_idx| (batch.column(col_idx), read_type[i].data_type()))
                     };
 
                     match source_col {
-                        Some(col) => {
-                            if col.data_type() == target_field.data_type() {
-                                columns.push(col.clone());
-                            } else {
-                                let casted = cast(col, target_field.data_type()).map_err(|e| {
-                                    Error::UnexpectedError {
-                                        message: format!(
-                                            "Failed to cast column '{}' from {:?} to {:?}: {e}",
-                                            target_field.name(),
-                                            col.data_type(),
-                                            target_field.data_type()
-                                        ),
-                                        source: Some(Box::new(e)),
-                                    }
-                                })?;
-                                columns.push(casted);
-                            }
-                        }
+                        Some((col, source_type)) => columns.push(
+                            cast_array_for_schema_evolution(
+                                col,
+                                source_type,
+                                read_type[i].data_type(),
+                            )
+                            .map_err(|error| Error::UnexpectedError {
+                                message: format!(
+                                    "Failed to evolve column '{}': {error}",
+                                    target_field.name()
+                                ),
+                                source: Some(Box::new(error)),
+                            })?,
+                        ),
                         None => {
                             let null_array = arrow_array::new_null_array(target_field.data_type(), num_rows);
                             columns.push(null_array);
@@ -455,6 +481,18 @@ impl DataFileReader {
                         source: Some(Box::new(e)),
                     }
                 })?;
+                let result = match &current_schema_residual {
+                    Some(residual) => crate::arrow::residual::filter_record_batch_by_predicates(
+                        result,
+                        residual,
+                        &read_type,
+                    )?,
+                    None => result,
+                };
+                let result = match &output_schema {
+                    Some(schema) => project_batch_prefix(result, schema)?,
+                    None => result,
+                };
                 yield result;
             }
         }
@@ -535,11 +573,11 @@ impl DataFileReader {
                 &table_fields,
                 &file_fields,
             );
-            if remapped.is_empty() {
+            if remapped.predicates.is_empty() {
                 None
             } else {
                 Some(crate::arrow::format::FilePredicates {
-                    predicates: remapped,
+                    predicates: remapped.predicates,
                     row_filter_factory: None,
                     file_fields: file_fields.clone(),
                 })
@@ -582,14 +620,76 @@ impl DataFileReader {
                 let result = project_file_batch(
                     &batch,
                     &target_schema,
+                    &read_type,
                     index_mapping.as_deref(),
                     data_fields.as_deref(),
+                    &format_read_fields,
                 )?;
                 yield result;
             }
         }
         .boxed())
     }
+}
+
+/// Project a batch whose leading columns follow the caller's read type back to
+/// that output schema. Predicate-only columns appended for a current-schema
+/// residual are removed after filtering.
+fn project_batch_prefix(
+    batch: RecordBatch,
+    output_schema: &Arc<arrow_schema::Schema>,
+) -> crate::Result<RecordBatch> {
+    let output_width = output_schema.fields().len();
+    if batch.num_columns() == output_width {
+        return Ok(batch);
+    }
+    if batch.num_columns() < output_width {
+        return Err(Error::DataInvalid {
+            message: format!(
+                "Cannot project {} batch columns to {output_width} output columns",
+                batch.num_columns()
+            ),
+            source: None,
+        });
+    }
+
+    let columns = batch.columns()[..output_width].to_vec();
+    let result = if columns.is_empty() {
+        RecordBatch::try_new_with_options(
+            output_schema.clone(),
+            columns,
+            &arrow_array::RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+        )
+    } else {
+        RecordBatch::try_new(output_schema.clone(), columns)
+    };
+    result.map_err(|error| Error::UnexpectedError {
+        message: format!("Failed to project RecordBatch to requested read type: {error}"),
+        source: Some(Box::new(error)),
+    })
+}
+
+/// Return the semantic type materialized by the format reader for `data_field`.
+///
+/// The decoded type can differ from the file schema type when nested projection
+/// rewrites a physical column, for example a VARIANT extraction materialized as
+/// a synthetic ROW. Field IDs remain stable across that rewrite.
+fn decoded_data_type<'a>(
+    data_field: &DataField,
+    decoded_fields: &'a [DataField],
+) -> crate::Result<&'a DataType> {
+    decoded_fields
+        .iter()
+        .find(|field| field.id() == data_field.id())
+        .map(DataField::data_type)
+        .ok_or_else(|| Error::DataInvalid {
+            message: format!(
+                "Decoded fields do not contain file field '{}' with id {}",
+                data_field.name(),
+                data_field.id()
+            ),
+            source: None,
+        })
 }
 
 /// Project one decoded file `batch` onto `target_schema`, resolving each target
@@ -601,8 +701,10 @@ impl DataFileReader {
 fn project_file_batch(
     batch: &RecordBatch,
     target_schema: &Arc<arrow_schema::Schema>,
+    read_type: &[DataField],
     index_mapping: Option<&[i32]>,
     data_fields: Option<&[DataField]>,
+    decoded_fields: &[DataField],
 ) -> crate::Result<RecordBatch> {
     let num_rows = batch.num_rows();
     let batch_schema = batch.schema();
@@ -614,42 +716,41 @@ fn project_file_batch(
                 None
             } else {
                 let data_field = &data_fields.unwrap()[data_idx as usize];
-                batch_schema
-                    .index_of(data_field.name())
-                    .ok()
-                    .map(|col_idx| batch.column(col_idx))
+                match batch_schema.index_of(data_field.name()) {
+                    Ok(col_idx) => Some((
+                        batch.column(col_idx),
+                        decoded_data_type(data_field, decoded_fields)?,
+                    )),
+                    Err(_) => None,
+                }
             }
         } else if let Some(df) = data_fields {
-            batch_schema
-                .index_of(df[i].name())
-                .ok()
-                .map(|col_idx| batch.column(col_idx))
+            let data_field = &df[i];
+            match batch_schema.index_of(data_field.name()) {
+                Ok(col_idx) => Some((
+                    batch.column(col_idx),
+                    decoded_data_type(data_field, decoded_fields)?,
+                )),
+                Err(_) => None,
+            }
         } else {
             batch_schema
                 .index_of(target_field.name())
                 .ok()
-                .map(|col_idx| batch.column(col_idx))
+                .map(|col_idx| (batch.column(col_idx), read_type[i].data_type()))
         };
 
         match source_col {
-            Some(col) => {
-                if col.data_type() == target_field.data_type() {
-                    columns.push(col.clone());
-                } else {
-                    let casted = cast(col, target_field.data_type()).map_err(|e| {
-                        Error::UnexpectedError {
-                            message: format!(
-                                "Failed to cast column '{}' from {:?} to {:?}: {e}",
-                                target_field.name(),
-                                col.data_type(),
-                                target_field.data_type()
-                            ),
-                            source: Some(Box::new(e)),
-                        }
-                    })?;
-                    columns.push(casted);
-                }
-            }
+            Some((col, source_type)) => columns.push(
+                cast_array_for_schema_evolution(col, source_type, read_type[i].data_type())
+                    .map_err(|error| Error::UnexpectedError {
+                        message: format!(
+                            "Failed to evolve column '{}': {error}",
+                            target_field.name()
+                        ),
+                        source: Some(Box::new(error)),
+                    })?,
+            ),
             None => {
                 columns.push(arrow_array::new_null_array(
                     target_field.data_type(),
@@ -990,6 +1091,7 @@ mod row_tests {
     use crate::spec::{
         is_variant_extraction_row_type, variant_extraction_row, BigIntType, BinaryRow,
         DataFileMeta, DataType, Datum, IntType, Predicate, PredicateBuilder, RowType, VarCharType,
+        VariantType,
     };
     use crate::table::source::DataSplitBuilder;
     use crate::variant::variant_shredding_type;
@@ -1061,6 +1163,35 @@ mod row_tests {
 
         assert_eq!(read_fields.len(), 1);
         assert_eq!(read_fields[0].data_type(), &DataType::Int(IntType::new()));
+    }
+
+    #[test]
+    fn project_file_batch_uses_decoded_variant_extraction_type() {
+        let extraction_type = DataType::Row(variant_extraction_row(
+            true,
+            vec![(
+                DataType::Int(IntType::new()),
+                "$.age".to_string(),
+                true,
+                "UTC".to_string(),
+            )],
+        ));
+        let read_type = vec![field(1, "v", extraction_type)];
+        let target_schema = build_target_arrow_schema(&read_type).unwrap();
+        let batch = RecordBatch::new_empty(target_schema.clone());
+        let data_fields = vec![field(1, "v", DataType::Variant(VariantType::new()))];
+
+        let projected = project_file_batch(
+            &batch,
+            &target_schema,
+            &read_type,
+            Some(&[0]),
+            Some(&data_fields),
+            &read_type,
+        )
+        .unwrap();
+
+        assert_eq!(projected.schema(), target_schema);
     }
 
     #[tokio::test]

--- a/crates/paimon/src/table/full_text_search_builder.rs
+++ b/crates/paimon/src/table/full_text_search_builder.rs
@@ -168,7 +168,12 @@ impl<'a> FullTextSearchBuilder<'a> {
         let index_entries = match snapshot.index_manifest() {
             Some(index_manifest_name) => {
                 let manifest_path = snapshot_manager.manifest_path(index_manifest_name);
-                IndexManifest::read(self.table.file_io(), &manifest_path).await?
+                super::global_index_build_common::retain_schema_compatible_entries(
+                    self.table,
+                    IndexManifest::read(self.table.file_io(), &manifest_path).await?,
+                    |entry| entry.index_file.index_type == FULL_TEXT_INDEX_TYPE,
+                )
+                .await?
             }
             None => Vec::new(),
         };
@@ -1018,6 +1023,7 @@ mod tests {
                     extra_field_ids: None,
                     index_meta: None,
                     source_meta: None,
+                    build_schema_id: None,
                 }),
             },
             version: 1,
@@ -1099,6 +1105,7 @@ mod tests {
                     extra_field_ids: None,
                     index_meta: None,
                     source_meta: None,
+                    build_schema_id: None,
                 }),
             },
             version: 1,
@@ -1276,6 +1283,7 @@ mod tests {
                     extra_field_ids: None,
                     index_meta: None,
                     source_meta: None,
+                    build_schema_id: None,
                 }),
             },
             version: 1,

--- a/crates/paimon/src/table/global_index_build_common.rs
+++ b/crates/paimon/src/table/global_index_build_common.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Shared helpers for the global-index build builders (btree, lumina, vindex).
+//! Shared helpers for global-index metadata and build planning.
 //!
 //! Mirrors Java `GlobalIndexBuilderUtils`, which exposes a single
 //! `indexedRowRanges` used by both the sorted and vector index builders. The
@@ -24,7 +24,7 @@
 //! `index_type` string, so it lives here once rather than being copied into
 //! each builder.
 
-use crate::spec::{FileKind, IndexManifest};
+use crate::spec::{FileKind, IndexManifest, IndexManifestEntry};
 use crate::table::{merge_row_ranges, RowRange, Table};
 use crate::{Error, Result};
 
@@ -38,6 +38,39 @@ pub(crate) fn same_extra_field_ids(a: Option<&[i32]>, b: Option<&[i32]>) -> bool
 /// Inclusive `[start, end]` range overlap.
 fn ranges_overlap(a_start: i64, a_end: i64, b_start: i64, b_end: i64) -> bool {
     a_start <= b_end && b_start <= a_end
+}
+
+/// Remove relevant global-index entries whose persisted build schema is
+/// incompatible with the current indexed field types. Unrelated entries are
+/// preserved for their own consumers.
+///
+/// Known-incompatible entries are omitted so index evaluators fall back to data
+/// files rather than pruning rows with mismatched key semantics.
+pub(crate) async fn retain_schema_compatible_entries(
+    table: &Table,
+    entries: Vec<IndexManifestEntry>,
+    is_relevant: impl Fn(&IndexManifestEntry) -> bool,
+) -> Result<Vec<IndexManifestEntry>> {
+    let mut retained = Vec::with_capacity(entries.len());
+    for entry in entries {
+        if !is_relevant(&entry) {
+            retained.push(entry);
+            continue;
+        }
+        let compatible = match entry.index_file.global_index_meta.as_ref() {
+            Some(global_index) => {
+                table
+                    .schema_manager()
+                    .global_index_schema_compatible(table.schema(), global_index)
+                    .await?
+            }
+            None => true,
+        };
+        if compatible {
+            retained.push(entry);
+        }
+    }
+    Ok(retained)
 }
 
 /// Row ranges already covered by `index_type` global-index files for
@@ -58,7 +91,25 @@ pub(crate) async fn indexed_row_ranges(
         table.location().trim_end_matches('/'),
         index_manifest_name
     );
-    let entries = IndexManifest::read(table.file_io(), &path).await?;
+    let entries = retain_schema_compatible_entries(
+        table,
+        IndexManifest::read(table.file_io(), &path).await?,
+        |entry| {
+            entry.index_file.index_type == index_type
+                && entry
+                    .index_file
+                    .global_index_meta
+                    .as_ref()
+                    .is_some_and(|meta| {
+                        meta.index_field_id == index_field_id
+                            && same_extra_field_ids(
+                                meta.extra_field_ids.as_deref(),
+                                extra_field_ids,
+                            )
+                    })
+        },
+    )
+    .await?;
     let mut ranges = Vec::new();
     for entry in entries {
         if entry.kind != FileKind::Add || entry.index_file.index_type != index_type {
@@ -99,7 +150,25 @@ pub(crate) async fn validate_existing_index_overlap(
         table.location().trim_end_matches('/'),
         index_manifest_name
     );
-    let entries = IndexManifest::read(table.file_io(), &path).await?;
+    let entries = retain_schema_compatible_entries(
+        table,
+        IndexManifest::read(table.file_io(), &path).await?,
+        |entry| {
+            entry.index_file.index_type == index_type
+                && entry
+                    .index_file
+                    .global_index_meta
+                    .as_ref()
+                    .is_some_and(|meta| {
+                        meta.index_field_id == index_field_id
+                            && same_extra_field_ids(
+                                meta.extra_field_ids.as_deref(),
+                                extra_field_ids,
+                            )
+                    })
+        },
+    )
+    .await?;
     for entry in entries {
         if entry.kind != FileKind::Add || entry.index_file.index_type != index_type {
             continue;
@@ -126,4 +195,109 @@ pub(crate) async fn validate_existing_index_overlap(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::Identifier;
+    use crate::io::{FileIO, FileIOBuilder};
+    use crate::spec::{
+        BigIntType, DataType, GlobalIndexMeta, IndexFileMeta, IntType, Schema, SchemaChange,
+        TableSchema,
+    };
+    use bytes::Bytes;
+
+    async fn write_schema(file_io: &FileIO, table_path: &str, schema: &TableSchema) {
+        let schema_dir = format!("{table_path}/schema");
+        file_io.mkdirs(&schema_dir).await.unwrap();
+        let output = file_io
+            .new_output(&format!("{schema_dir}/schema-{}", schema.id()))
+            .unwrap();
+        output
+            .write(Bytes::from(serde_json::to_vec(schema).unwrap()))
+            .await
+            .unwrap();
+    }
+
+    fn index_entry(field_id: i32, build_schema_id: Option<i64>) -> IndexManifestEntry {
+        IndexManifestEntry {
+            version: 1,
+            kind: FileKind::Add,
+            partition: Vec::new(),
+            bucket: 0,
+            index_file: IndexFileMeta {
+                index_type: "BTREE".to_string(),
+                file_name: "stale.index".to_string(),
+                file_size: 1,
+                row_count: 1,
+                deletion_vectors_ranges: None,
+                global_index_meta: Some(GlobalIndexMeta {
+                    row_range_start: 0,
+                    row_range_end: 0,
+                    index_field_id: field_id,
+                    extra_field_ids: None,
+                    index_meta: None,
+                    source_meta: None,
+                    build_schema_id,
+                }),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn incompatible_build_schema_entry_is_removed_before_index_evaluation() {
+        let file_io = FileIOBuilder::new("memory").build().unwrap();
+        let table_path = "memory:/global_index_schema_filter";
+        let initial = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .build()
+                .unwrap(),
+        );
+        let current = initial
+            .apply_changes(vec![SchemaChange::update_column_type(
+                "id".to_string(),
+                DataType::BigInt(BigIntType::new()),
+            )])
+            .unwrap();
+        write_schema(&file_io, table_path, &initial).await;
+        write_schema(&file_io, table_path, &current).await;
+        let table = Table::new(
+            file_io,
+            Identifier::new("default", "t"),
+            table_path.to_string(),
+            current,
+            None,
+        );
+        let field_id = table.schema().fields()[0].id();
+
+        let retained = retain_schema_compatible_entries(
+            &table,
+            vec![index_entry(field_id, Some(initial.id()))],
+            |_| true,
+        )
+        .await
+        .unwrap();
+        assert!(retained.is_empty());
+
+        let retained = retain_schema_compatible_entries(
+            &table,
+            vec![index_entry(field_id, Some(table.schema().id()))],
+            |_| true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(retained.len(), 1);
+
+        let retained = retain_schema_compatible_entries(
+            &table,
+            vec![index_entry(field_id, Some(initial.id()))],
+            |_| false,
+        )
+        .await
+        .unwrap();
+        assert_eq!(retained.len(), 1);
+    }
 }

--- a/crates/paimon/src/table/global_index_drop_builder.rs
+++ b/crates/paimon/src/table/global_index_drop_builder.rs
@@ -218,6 +218,7 @@ mod tests {
                 extra_field_ids: None,
                 source_meta: None,
                 index_meta: None,
+                build_schema_id: None,
             }),
         }
     }

--- a/crates/paimon/src/table/global_index_scanner.rs
+++ b/crates/paimon/src/table/global_index_scanner.rs
@@ -1872,6 +1872,7 @@ mod tests {
                     extra_field_ids: None,
                     source_meta: None,
                     index_meta: Some(meta.serialize()),
+                    build_schema_id: None,
                 }),
             },
         }

--- a/crates/paimon/src/table/hybrid_search_builder.rs
+++ b/crates/paimon/src/table/hybrid_search_builder.rs
@@ -1397,6 +1397,7 @@ mod pk_hybrid_tests {
                     &[(&data_file_name, row_count)],
                 )),
                 index_meta: None,
+                build_schema_id: None,
             }),
         };
 
@@ -1427,6 +1428,7 @@ mod pk_hybrid_tests {
                 extra_field_ids: None,
                 source_meta: Some(source_meta_bytes(1, &[(&data_file_name, row_count)])),
                 index_meta: None,
+                build_schema_id: None,
             }),
         };
 

--- a/crates/paimon/src/table/lumina_index_build_builder.rs
+++ b/crates/paimon/src/table/lumina_index_build_builder.rs
@@ -243,6 +243,7 @@ impl<'a> LuminaIndexBuildBuilder<'a> {
                 extra_field_ids: None,
                 source_meta: None,
                 index_meta: Some(index_meta),
+                build_schema_id: None,
             }),
         })
     }
@@ -1706,6 +1707,7 @@ mod tests {
                 extra_field_ids: None,
                 source_meta: None,
                 index_meta: None,
+                build_schema_id: None,
             }),
         };
         let mut message = CommitMessage::new(BinaryRow::new(0).to_serialized_bytes(), 0, vec![]);

--- a/crates/paimon/src/table/pk_full_text_bucket_search.rs
+++ b/crates/paimon/src/table/pk_full_text_bucket_search.rs
@@ -360,6 +360,7 @@ mod tests {
             extra_field_ids: None,
             index_meta: None,
             source_meta: Some(source_meta),
+            build_schema_id: None,
         }
     }
 

--- a/crates/paimon/src/table/pk_full_text_bucket_state.rs
+++ b/crates/paimon/src/table/pk_full_text_bucket_state.rs
@@ -318,6 +318,7 @@ mod tests {
             extra_field_ids: None,
             index_meta: None,
             source_meta,
+            build_schema_id: None,
         }
     }
 

--- a/crates/paimon/src/table/pk_full_text_read.rs
+++ b/crates/paimon/src/table/pk_full_text_read.rs
@@ -693,6 +693,7 @@ mod read_tests {
                 extra_field_ids: None,
                 index_meta: None,
                 source_meta: Some(frame(1, files)),
+                build_schema_id: None,
             }),
         }
     }

--- a/crates/paimon/src/table/pk_full_text_scan.rs
+++ b/crates/paimon/src/table/pk_full_text_scan.rs
@@ -312,7 +312,20 @@ impl<'a> PrimaryKeyFullTextScan<'a> {
         let mut entries: Vec<(BinaryRow, i32, IndexFileMeta)> = Vec::new();
         if let Some(name) = snapshot.index_manifest() {
             let path = snapshot_manager.manifest_path(name);
-            for entry in IndexManifest::read(self.table.file_io(), &path).await? {
+            let index_entries = super::global_index_build_common::retain_schema_compatible_entries(
+                self.table,
+                IndexManifest::read(self.table.file_io(), &path).await?,
+                |entry| {
+                    entry.index_file.index_type == PK_FULL_TEXT_INDEX_TYPE
+                        && entry
+                            .index_file
+                            .global_index_meta
+                            .as_ref()
+                            .is_some_and(|meta| meta.index_field_id == self.text_field_id)
+                },
+            )
+            .await?;
+            for entry in index_entries {
                 // The on-disk index manifest is combined to live ADD entries only.
                 if entry.kind != FileKind::Add {
                     return Err(data_invalid(format!(
@@ -501,6 +514,7 @@ mod tests {
             extra_field_ids: None,
             index_meta: None,
             source_meta,
+            build_schema_id: None,
         }
     }
 

--- a/crates/paimon/src/table/pk_vector_scan.rs
+++ b/crates/paimon/src/table/pk_vector_scan.rs
@@ -271,7 +271,20 @@ impl<'a> PkVectorScan<'a> {
         let mut entries = Vec::new();
         if let Some(name) = snapshot.index_manifest() {
             let path = snapshot_manager.manifest_path(name);
-            for entry in IndexManifest::read(self.table.file_io(), &path).await? {
+            let index_entries = super::global_index_build_common::retain_schema_compatible_entries(
+                self.table,
+                IndexManifest::read(self.table.file_io(), &path).await?,
+                |entry| {
+                    entry.index_file.index_type == self.index_type
+                        && entry
+                            .index_file
+                            .global_index_meta
+                            .as_ref()
+                            .is_some_and(|meta| meta.index_field_id == self.vector_field_id)
+                },
+            )
+            .await?;
+            for entry in index_entries {
                 // The on-disk index manifest is combined to live ADD entries only.
                 // A non-ADD entry means a malformed manifest; fail loud rather than
                 // silently drop it (mirrors Java `checkArgument(kind == ADD)`).
@@ -469,6 +482,7 @@ mod tests {
             extra_field_ids: None,
             index_meta: Some(vec![1, 2, 3]),
             source_meta: Some(source_meta_bytes(data_level, source_files)),
+            build_schema_id: None,
         }
     }
 

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -699,16 +699,18 @@ mod tests {
     use crate::deletion_vector::DeletionVector;
     use crate::io::FileIOBuilder;
     use crate::spec::{
-        BinaryRow, DataField, DataType, IntType, Predicate, PredicateBuilder, Schema, TableSchema,
-        VarCharType,
+        BinaryRow, CharType, DataField, DataFileMeta, DataType, Datum, IntType, Predicate,
+        PredicateBuilder, Schema, TableSchema, VarCharType,
     };
     use crate::table::{query_auth_table, DataSplitBuilder, DeletionFile, Table};
-    use arrow_array::{Int32Array, RecordBatch};
+    use arrow_array::{Int32Array, RecordBatch, StringArray};
     use bytes::Bytes;
     use futures::TryStreamExt;
+    use parquet::arrow::ArrowWriter;
     use roaring::RoaringBitmap;
     use std::collections::{HashMap, HashSet};
-    use std::fs;
+    use std::fs::{self, File};
+    use std::path::Path;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -733,6 +735,123 @@ mod tests {
                     .collect::<Vec<_>>()
             })
             .collect()
+    }
+
+    fn char_evolution_schema(id: i64, length: usize) -> TableSchema {
+        TableSchema::new(
+            id,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("name", DataType::Char(CharType::new(length).unwrap()))
+                .build()
+                .unwrap(),
+        )
+    }
+
+    fn write_id_name_parquet_file(
+        path: &Path,
+        fields: &[DataField],
+        ids: Vec<i32>,
+        names: Vec<&str>,
+    ) {
+        let schema = crate::arrow::build_target_arrow_schema(fields).unwrap();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(StringArray::from(names)),
+            ],
+        )
+        .unwrap();
+        let mut writer = ArrowWriter::try_new(File::create(path).unwrap(), schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+    }
+
+    async fn write_schema_file(table: &Table, schema: &TableSchema) {
+        let path = table.schema_manager().schema_path(schema.id());
+        let dir = path.rsplit_once('/').map(|(dir, _)| dir).unwrap();
+        table.file_io().mkdirs(dir).await.unwrap();
+        table
+            .file_io()
+            .new_output(&path)
+            .unwrap()
+            .write(Bytes::from(serde_json::to_vec(schema).unwrap()))
+            .await
+            .unwrap();
+    }
+
+    async fn read_type_evolved_char_rows(
+        include_current_file: bool,
+        predicate: impl FnOnce(&[DataField]) -> Predicate,
+    ) -> Vec<i32> {
+        let tempdir = tempdir().unwrap();
+        let table_path = local_file_path(tempdir.path());
+        let bucket_dir = tempdir.path().join("bucket-0");
+        fs::create_dir_all(&bucket_dir).unwrap();
+
+        let old_schema = char_evolution_schema(0, 10);
+        let current_schema = char_evolution_schema(1, 5);
+        let old_path = bucket_dir.join("old.parquet");
+        write_id_name_parquet_file(
+            &old_path,
+            old_schema.fields(),
+            vec![1, 2],
+            vec!["abcde-oldx", "other-oldx"],
+        );
+
+        let file_io = FileIOBuilder::new("file").build().unwrap();
+        let table = Table::new(
+            file_io,
+            Identifier::new("default", "type_evolved_filter"),
+            table_path,
+            current_schema.clone(),
+            None,
+        );
+        write_schema_file(&table, &old_schema).await;
+
+        let old_size = fs::metadata(&old_path).unwrap().len() as i64;
+        let mut files = vec![test_data_file::<DataFileMeta>("old.parquet", 2, old_size)];
+        if include_current_file {
+            let current_path = bucket_dir.join("current.parquet");
+            write_id_name_parquet_file(
+                &current_path,
+                current_schema.fields(),
+                vec![3, 4],
+                vec!["abcde", "other"],
+            );
+            let current_size = fs::metadata(&current_path).unwrap().len() as i64;
+            let mut current_file =
+                test_data_file::<DataFileMeta>("current.parquet", 2, current_size);
+            current_file.schema_id = current_schema.id();
+            files.push(current_file);
+        }
+
+        let split = DataSplitBuilder::new()
+            .with_snapshot(1)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(0)
+            .with_bucket_path(local_file_path(&bucket_dir))
+            .with_total_buckets(1)
+            .with_data_files(files)
+            .build()
+            .unwrap();
+        let predicate = predicate(table.schema().fields());
+        let mut builder = table.new_read_builder();
+        builder
+            .with_projection(&["id"])
+            .unwrap()
+            .with_filter(predicate);
+        let read = builder.new_read().unwrap();
+        let batches = read
+            .to_arrow(&[split])
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert!(batches.iter().all(|batch| batch.num_columns() == 1));
+        collect_int_column(&batches, "id")
     }
 
     async fn write_test_deletion_file(
@@ -1264,6 +1383,114 @@ mod tests {
             .unwrap();
 
         assert_eq!(collect_int_column(&batches, "id"), vec![3, 4]);
+    }
+
+    #[tokio::test]
+    async fn test_new_read_applies_type_evolved_filter_to_old_file() {
+        let rows = read_type_evolved_char_rows(false, |fields| {
+            PredicateBuilder::new(fields)
+                .equal("name", Datum::String("abcde".to_string()))
+                .unwrap()
+        })
+        .await;
+        assert_eq!(rows, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn test_new_read_applies_type_evolved_filter_to_old_and_current_files() {
+        let rows = read_type_evolved_char_rows(true, |fields| {
+            PredicateBuilder::new(fields)
+                .equal("name", Datum::String("abcde".to_string()))
+                .unwrap()
+        })
+        .await;
+        assert_eq!(rows, vec![1, 3]);
+    }
+
+    #[tokio::test]
+    async fn test_new_read_not_over_type_evolved_and_keeps_old_rows() {
+        let rows = read_type_evolved_char_rows(false, |fields| {
+            let builder = PredicateBuilder::new(fields);
+            Predicate::negate(Predicate::and(vec![
+                builder.equal("id", Datum::Int(1)).unwrap(),
+                builder
+                    .equal("name", Datum::String("other".to_string()))
+                    .unwrap(),
+            ]))
+        })
+        .await;
+        assert_eq!(rows, vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn test_new_read_not_is_null_on_added_columns_filters_old_rows() {
+        let tempdir = tempdir().unwrap();
+        let table_path = local_file_path(tempdir.path());
+        let bucket_dir = tempdir.path().join("bucket-0");
+        fs::create_dir_all(&bucket_dir).unwrap();
+
+        let old_schema = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .build()
+                .unwrap(),
+        );
+        let current_schema = TableSchema::new(
+            1,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("new1", DataType::Int(IntType::new()))
+                .column("new2", DataType::Int(IntType::new()))
+                .build()
+                .unwrap(),
+        );
+        let old_path = bucket_dir.join("old.parquet");
+        write_int_parquet_file(&old_path, vec![("id", vec![1, 2])], None);
+
+        let table = Table::new(
+            FileIOBuilder::new("file").build().unwrap(),
+            Identifier::new("default", "added_column_filter"),
+            table_path,
+            current_schema,
+            None,
+        );
+        write_schema_file(&table, &old_schema).await;
+
+        let file_size = fs::metadata(&old_path).unwrap().len() as i64;
+        let split = DataSplitBuilder::new()
+            .with_snapshot(1)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(0)
+            .with_bucket_path(local_file_path(&bucket_dir))
+            .with_total_buckets(1)
+            .with_data_files(vec![test_data_file::<DataFileMeta>(
+                "old.parquet",
+                2,
+                file_size,
+            )])
+            .build()
+            .unwrap();
+        let builder = PredicateBuilder::new(table.schema().fields());
+        let predicate = Predicate::negate(Predicate::and(vec![
+            builder.is_null("new1").unwrap(),
+            builder.is_null("new2").unwrap(),
+        ]));
+        let mut read_builder = table.new_read_builder();
+        read_builder
+            .with_projection(&["id"])
+            .unwrap()
+            .with_filter(predicate);
+        let batches = read_builder
+            .new_read()
+            .unwrap()
+            .to_arrow(&[split])
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert!(collect_int_column(&batches, "id").is_empty());
     }
 
     #[tokio::test]

--- a/crates/paimon/src/table/schema_manager.rs
+++ b/crates/paimon/src/table/schema_manager.rs
@@ -19,15 +19,29 @@
 //!
 //! Reference: [org.apache.paimon.schema.SchemaManager](https://github.com/apache/paimon/blob/release-1.3/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java)
 
+use crate::arrow::schema_evolution::{
+    requires_schema_evolution_storage_normalization, same_type_ignoring_nullability,
+    schema_evolution_cast_implemented,
+};
 use crate::io::FileIO;
-use crate::spec::TableSchema;
+use crate::spec::{GlobalIndexMeta, TableSchema};
 use futures::future::try_join_all;
 use opendal::raw::get_basename;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
+use tokio::sync::OnceCell;
 
 const SCHEMA_DIR: &str = "schema";
 const SCHEMA_PREFIX: &str = "schema-";
+
+#[derive(Debug)]
+struct SchemaEvolutionInfo {
+    history_complete: bool,
+    type_evolved_field_ids: Arc<HashSet<i32>>,
+    storage_normalization_field_ids: Arc<HashSet<i32>>,
+}
+
+type SchemaEvolutionCell = Arc<OnceCell<Arc<SchemaEvolutionInfo>>>;
 
 /// Manager for versioned table schema files.
 ///
@@ -46,6 +60,9 @@ pub struct SchemaManager {
     table_path: String,
     /// Shared cache of loaded schemas by ID.
     cache: Arc<Mutex<HashMap<i64, Arc<TableSchema>>>>,
+    /// Shared history analysis by current schema ID. A `OnceCell` prevents
+    /// concurrent writers/readers from repeating the same remote schema LIST.
+    evolution_cache: Arc<Mutex<HashMap<i64, SchemaEvolutionCell>>>,
 }
 
 impl SchemaManager {
@@ -54,6 +71,7 @@ impl SchemaManager {
             file_io,
             table_path,
             cache: Arc::new(Mutex::new(HashMap::new())),
+            evolution_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -154,13 +172,177 @@ impl SchemaManager {
 
         Ok(schema)
     }
+
+    /// Return type-evolved field IDs for `current_schema`, or `None` when its
+    /// preceding schema history is incomplete. Results are cached by current
+    /// schema ID and shared across `SchemaManager` clones.
+    pub async fn type_evolved_field_ids(
+        &self,
+        current_schema: &TableSchema,
+    ) -> crate::Result<Option<Arc<HashSet<i32>>>> {
+        let info = self.schema_evolution_info(current_schema).await?;
+        Ok(info
+            .history_complete
+            .then(|| Arc::clone(&info.type_evolved_field_ids)))
+    }
+
+    /// Return whether a global index was encoded with field types compatible
+    /// with `current_schema`.
+    ///
+    /// New index entries carry their build schema ID. Legacy entries remain
+    /// usable only when complete history proves that none of their dependent
+    /// fields has changed type.
+    pub(crate) async fn global_index_schema_compatible(
+        &self,
+        current_schema: &TableSchema,
+        global_index: &GlobalIndexMeta,
+    ) -> crate::Result<bool> {
+        let field_ids = std::iter::once(global_index.index_field_id)
+            .chain(global_index.extra_field_ids.iter().flatten().copied())
+            .collect::<Vec<_>>();
+
+        if field_ids.iter().any(|field_id| {
+            current_schema
+                .fields()
+                .iter()
+                .all(|field| field.id() != *field_id)
+        }) {
+            return Ok(false);
+        }
+
+        let Some(build_schema_id) = global_index.build_schema_id else {
+            let Some(evolved_field_ids) = self.type_evolved_field_ids(current_schema).await? else {
+                return Ok(false);
+            };
+            return Ok(field_ids
+                .iter()
+                .all(|field_id| !evolved_field_ids.contains(field_id)));
+        };
+
+        if build_schema_id == current_schema.id() {
+            return Ok(true);
+        }
+        let build_schema = self.schema(build_schema_id).await?;
+        Ok(field_ids.iter().all(|field_id| {
+            let build_field = build_schema
+                .fields()
+                .iter()
+                .find(|field| field.id() == *field_id);
+            let current_field = current_schema
+                .fields()
+                .iter()
+                .find(|field| field.id() == *field_id);
+            matches!(
+                (build_field, current_field),
+                (Some(build), Some(current))
+                    if same_type_ignoring_nullability(
+                        build.data_type(),
+                        current.data_type()
+                    )
+            )
+        }))
+    }
+
+    /// Return fields that need target storage normalization after a supported
+    /// type evolution. Unlike predicate planning, writer behavior does not
+    /// require a complete history and preserves the previous best-effort scan.
+    pub(crate) async fn storage_normalization_field_ids(
+        &self,
+        current_schema: &TableSchema,
+    ) -> crate::Result<Arc<HashSet<i32>>> {
+        let info = self.schema_evolution_info(current_schema).await?;
+        Ok(Arc::clone(&info.storage_normalization_field_ids))
+    }
+
+    async fn schema_evolution_info(
+        &self,
+        current_schema: &TableSchema,
+    ) -> crate::Result<Arc<SchemaEvolutionInfo>> {
+        let cell = {
+            let mut cache = self.evolution_cache.lock().unwrap();
+            Arc::clone(
+                cache
+                    .entry(current_schema.id())
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        };
+        let info = cell
+            .get_or_try_init(|| self.load_schema_evolution_info(current_schema))
+            .await?;
+        Ok(Arc::clone(info))
+    }
+
+    async fn load_schema_evolution_info(
+        &self,
+        current_schema: &TableSchema,
+    ) -> crate::Result<Arc<SchemaEvolutionInfo>> {
+        if current_schema.id() == 0 {
+            return Ok(Arc::new(SchemaEvolutionInfo {
+                history_complete: true,
+                type_evolved_field_ids: Arc::new(HashSet::new()),
+                storage_normalization_field_ids: Arc::new(HashSet::new()),
+            }));
+        }
+
+        let schemas = self.list_all().await?;
+        let historical = schemas
+            .iter()
+            .filter(|schema| schema.id() < current_schema.id())
+            .collect::<Vec<_>>();
+        let history_complete = usize::try_from(current_schema.id())
+            .ok()
+            .is_some_and(|count| {
+                historical.len() == count
+                    && historical
+                        .iter()
+                        .enumerate()
+                        .all(|(id, schema)| schema.id() == id as i64)
+            });
+
+        let mut type_evolved_field_ids = HashSet::new();
+        let mut storage_normalization_field_ids = HashSet::new();
+        for current_field in current_schema.fields() {
+            for historical_schema in &historical {
+                let Some(historical_field) = historical_schema
+                    .fields()
+                    .iter()
+                    .find(|field| field.id() == current_field.id())
+                else {
+                    continue;
+                };
+                if same_type_ignoring_nullability(
+                    historical_field.data_type(),
+                    current_field.data_type(),
+                ) {
+                    continue;
+                }
+                type_evolved_field_ids.insert(current_field.id());
+                if requires_schema_evolution_storage_normalization(current_field.data_type())
+                    && schema_evolution_cast_implemented(
+                        historical_field.data_type(),
+                        current_field.data_type(),
+                    )
+                {
+                    storage_normalization_field_ids.insert(current_field.id());
+                }
+            }
+        }
+
+        Ok(Arc::new(SchemaEvolutionInfo {
+            history_complete,
+            type_evolved_field_ids: Arc::new(type_evolved_field_ids),
+            storage_normalization_field_ids: Arc::new(storage_normalization_field_ids),
+        }))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::io::FileIOBuilder;
-    use crate::spec::Schema;
+    use crate::spec::{
+        BigIntType, CharType, DataType, GlobalIndexMeta, IntType, Schema, SchemaChange,
+    };
     use bytes::Bytes;
 
     fn memory_file_io() -> FileIO {
@@ -170,8 +352,12 @@ mod tests {
     async fn write_schema_file(file_io: &FileIO, dir: &str, id: i64) {
         let schema = Schema::builder().build().unwrap();
         let table_schema = TableSchema::new(id, &schema);
+        write_table_schema_file(file_io, dir, &table_schema).await;
+    }
+
+    async fn write_table_schema_file(file_io: &FileIO, dir: &str, table_schema: &TableSchema) {
         let json = serde_json::to_vec(&table_schema).unwrap();
-        let path = format!("{dir}/{SCHEMA_PREFIX}{id}");
+        let path = format!("{dir}/{SCHEMA_PREFIX}{}", table_schema.id());
         let out = file_io.new_output(&path).unwrap();
         out.write(Bytes::from(json)).await.unwrap();
     }
@@ -264,5 +450,146 @@ mod tests {
         let sm = SchemaManager::new(file_io, table_path.to_string());
         let latest = sm.latest().await.unwrap().expect("latest");
         assert_eq!(latest.id(), 5);
+    }
+
+    #[tokio::test]
+    async fn schema_evolution_info_is_cached_by_current_schema_id() {
+        let file_io = memory_file_io();
+        let table_path = "memory:/schema_evolution_info";
+        let dir = format!("{table_path}/{SCHEMA_DIR}");
+        file_io.mkdirs(&dir).await.unwrap();
+
+        let initial = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("name", DataType::Char(CharType::new(10).unwrap()))
+                .build()
+                .unwrap(),
+        );
+        let renamed = initial
+            .apply_changes(vec![SchemaChange::rename_column(
+                "name".to_string(),
+                "renamed_name".to_string(),
+            )])
+            .unwrap();
+        let evolved = renamed
+            .apply_changes(vec![
+                SchemaChange::update_column_type(
+                    "id".to_string(),
+                    DataType::BigInt(BigIntType::new()),
+                ),
+                SchemaChange::update_column_type(
+                    "renamed_name".to_string(),
+                    DataType::Char(CharType::new(5).unwrap()),
+                ),
+            ])
+            .unwrap();
+        for schema in [&initial, &renamed, &evolved] {
+            write_table_schema_file(&file_io, &dir, schema).await;
+        }
+
+        let manager = SchemaManager::new(file_io, table_path.to_string());
+        let rename_info = manager.schema_evolution_info(&renamed).await.unwrap();
+        assert!(rename_info.history_complete);
+        assert!(rename_info.type_evolved_field_ids.is_empty());
+        assert!(rename_info.storage_normalization_field_ids.is_empty());
+
+        let manager_clone = manager.clone();
+        let (first, second) = tokio::join!(
+            manager.schema_evolution_info(&evolved),
+            manager_clone.schema_evolution_info(&evolved)
+        );
+        let first = first.unwrap();
+        let second = second.unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(first.history_complete);
+        assert_eq!(
+            first.type_evolved_field_ids.as_ref(),
+            &HashSet::from([evolved.fields()[0].id(), evolved.fields()[1].id()])
+        );
+        assert_eq!(
+            first.storage_normalization_field_ids.as_ref(),
+            &HashSet::from([evolved.fields()[1].id()])
+        );
+
+        let public_ids = manager
+            .type_evolved_field_ids(&evolved)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(Arc::ptr_eq(&public_ids, &first.type_evolved_field_ids));
+    }
+
+    #[tokio::test]
+    async fn global_index_compatibility_uses_build_schema_field_types() {
+        let file_io = memory_file_io();
+        let table_path = "memory:/global_index_schema_compatibility";
+        let dir = format!("{table_path}/{SCHEMA_DIR}");
+        file_io.mkdirs(&dir).await.unwrap();
+
+        let initial = TableSchema::new(
+            0,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("name", DataType::Char(CharType::new(10).unwrap()))
+                .build()
+                .unwrap(),
+        );
+        let current = initial
+            .apply_changes(vec![
+                SchemaChange::update_column_type(
+                    "id".to_string(),
+                    DataType::BigInt(BigIntType::new()),
+                ),
+                SchemaChange::add_column("unrelated".to_string(), DataType::Int(IntType::new())),
+            ])
+            .unwrap();
+        for schema in [&initial, &current] {
+            write_table_schema_file(&file_io, &dir, schema).await;
+        }
+
+        let manager = SchemaManager::new(file_io, table_path.to_string());
+        let id_field_id = initial.fields()[0].id();
+        let name_field_id = initial.fields()[1].id();
+        let meta = |index_field_id, extra_field_ids, build_schema_id| GlobalIndexMeta {
+            row_range_start: 0,
+            row_range_end: 9,
+            index_field_id,
+            extra_field_ids,
+            index_meta: None,
+            source_meta: None,
+            build_schema_id,
+        };
+
+        assert!(!manager
+            .global_index_schema_compatible(&current, &meta(id_field_id, None, Some(initial.id())),)
+            .await
+            .unwrap());
+        assert!(manager
+            .global_index_schema_compatible(
+                &current,
+                &meta(name_field_id, None, Some(initial.id())),
+            )
+            .await
+            .unwrap());
+        assert!(!manager
+            .global_index_schema_compatible(
+                &current,
+                &meta(name_field_id, Some(vec![id_field_id]), Some(initial.id())),
+            )
+            .await
+            .unwrap());
+
+        // Legacy entries have no build schema ID. Complete history still lets
+        // unchanged fields use them, while evolved dependencies are rejected.
+        assert!(!manager
+            .global_index_schema_compatible(&current, &meta(id_field_id, None, None))
+            .await
+            .unwrap());
+        assert!(manager
+            .global_index_schema_compatible(&current, &meta(name_field_id, None, None))
+            .await
+            .unwrap());
     }
 }

--- a/crates/paimon/src/table/stats_filter.rs
+++ b/crates/paimon/src/table/stats_filter.rs
@@ -18,7 +18,7 @@
 //! Data-level stats predicate filtering for manifest entries and data evolution groups.
 
 use super::Table;
-use crate::arrow::schema_evolution::create_index_mapping;
+use crate::arrow::filtering::remap_predicates_to_file;
 use crate::predicate_stats::{
     data_leaf_may_match, data_leaf_must_match, missing_field_may_match, missing_field_must_match,
     predicates_may_match_with_schema, StatsAccessor,
@@ -145,22 +145,10 @@ impl StatsAccessor for FileStatsRows {
 #[derive(Debug)]
 pub(super) struct ResolvedStatsSchema {
     file_fields: Vec<DataField>,
-    field_mapping: Vec<Option<usize>>,
 }
 
 fn identity_field_mapping(num_fields: usize) -> Vec<Option<usize>> {
     (0..num_fields).map(Some).collect()
-}
-
-fn normalize_field_mapping(mapping: Option<Vec<i32>>, num_fields: usize) -> Vec<Option<usize>> {
-    mapping
-        .map(|field_mapping| {
-            field_mapping
-                .into_iter()
-                .map(|index| usize::try_from(index).ok())
-                .collect()
-        })
-        .unwrap_or_else(|| identity_field_mapping(num_fields))
 }
 
 /// Check whether a data file *may* contain rows matching all `predicates`.
@@ -214,18 +202,11 @@ async fn resolve_stats_schema(
     let resolved = if file_schema_id == table_schema.id() {
         Some(Arc::new(ResolvedStatsSchema {
             file_fields: current_fields.to_vec(),
-            field_mapping: identity_field_mapping(current_fields.len()),
         }))
     } else {
         let file_schema = table.schema_manager().schema(file_schema_id).await.ok()?;
         let file_fields = file_schema.fields().to_vec();
-        Some(Arc::new(ResolvedStatsSchema {
-            field_mapping: normalize_field_mapping(
-                create_index_mapping(current_fields, &file_fields),
-                current_fields.len(),
-            ),
-            file_fields,
-        }))
+        Some(Arc::new(ResolvedStatsSchema { file_fields }))
     };
 
     schema_cache.insert(file_schema_id, resolved.clone());
@@ -255,11 +236,17 @@ pub(super) async fn data_file_matches_predicates_for_table(
         return true;
     };
 
+    let file_predicates =
+        remap_predicates_to_file(predicates, table.schema().fields(), &resolved.file_fields);
+    if file_predicates.predicates.is_empty() {
+        return true;
+    }
     let stats = FileStatsRows::from_data_file(file, &resolved.file_fields);
+    let field_mapping = identity_field_mapping(resolved.file_fields.len());
     predicates_may_match_with_schema(
-        predicates,
+        &file_predicates.predicates,
         &stats,
-        &resolved.field_mapping,
+        &field_mapping,
         &resolved.file_fields,
     )
 }

--- a/crates/paimon/src/table/table_commit.rs
+++ b/crates/paimon/src/table/table_commit.rs
@@ -2646,16 +2646,19 @@ impl TableCommit {
         messages
             .iter()
             .flat_map(|msg| {
-                let adds = msg
-                    .new_index_files
-                    .iter()
-                    .map(move |index_file| IndexManifestEntry {
+                let adds = msg.new_index_files.iter().map(move |index_file| {
+                    let mut index_file = index_file.clone();
+                    if let Some(global_meta) = index_file.global_index_meta.as_mut() {
+                        global_meta.build_schema_id = Some(self.table.schema().id());
+                    }
+                    IndexManifestEntry {
                         kind: FileKind::Add,
                         partition: msg.partition.clone(),
                         bucket: msg.bucket,
-                        index_file: index_file.clone(),
+                        index_file,
                         version: 1,
-                    });
+                    }
+                });
                 let deletes =
                     msg.deleted_index_files
                         .iter()
@@ -3014,6 +3017,7 @@ mod tests {
                 extra_field_ids: None,
                 source_meta: None,
                 index_meta: None,
+                build_schema_id: None,
             }),
         }
     }
@@ -3572,6 +3576,15 @@ mod tests {
                 .unwrap();
         assert_eq!(index_entries.len(), 1);
         assert_eq!(index_entries[0].index_file.file_name, "lumina-0.index");
+        assert_eq!(
+            index_entries[0]
+                .index_file
+                .global_index_meta
+                .as_ref()
+                .unwrap()
+                .build_schema_id,
+            Some(0)
+        );
     }
 
     #[tokio::test]

--- a/crates/paimon/src/table/table_scan.rs
+++ b/crates/paimon/src/table/table_scan.rs
@@ -1208,13 +1208,17 @@ impl<'a> PaimonTableScan<'a> {
         };
         let table_path = self.table.location().trim_end_matches('/');
         let path = format!("{table_path}/{MANIFEST_DIR}/{index_manifest_name}");
-        let entries = IndexManifest::read(self.table.file_io(), &path)
-            .await?
-            .into_iter()
-            .filter(|entry| {
-                retain_index_manifest_entry(entry, global_index_needed, deletion_vectors_needed)
-            })
-            .collect();
+        let entries = super::global_index_build_common::retain_schema_compatible_entries(
+            self.table,
+            IndexManifest::read(self.table.file_io(), &path).await?,
+            |entry| normalize_sorted_global_index_type(&entry.index_file.index_type).is_some(),
+        )
+        .await?
+        .into_iter()
+        .filter(|entry| {
+            retain_index_manifest_entry(entry, global_index_needed, deletion_vectors_needed)
+        })
+        .collect();
         Ok(Some(entries))
     }
 
@@ -1841,11 +1845,16 @@ impl<'a> PaimonTableScan<'a> {
                     let groups = row_id_groups
                         .into_iter()
                         .filter(|group| {
-                            data_evolution_group_matches_predicates(
-                                group,
-                                &self.data_predicates,
-                                self.table.schema().fields(),
-                            )
+                            // Group stats are encoded with each file's schema.
+                            // Until type-evolved stats can be converted safely,
+                            // retain every cross-schema group and let the row
+                            // reader plus residual filter decide.
+                            group.iter().any(|file| file.schema_id != table_schema_id)
+                                || data_evolution_group_matches_predicates(
+                                    group,
+                                    &self.data_predicates,
+                                    self.table.schema().fields(),
+                                )
                         })
                         .collect::<Vec<_>>();
                     if let Some(trace) = trace.as_deref_mut() {

--- a/crates/paimon/src/table/table_write.rs
+++ b/crates/paimon/src/table/table_write.rs
@@ -21,6 +21,9 @@
 //! and [pypaimon FileStoreWrite](https://github.com/apache/paimon/blob/master/paimon-python/pypaimon/write/file_store_write.py)
 
 use crate::arrow::build_target_arrow_schema;
+use crate::arrow::schema_evolution::{
+    normalize_array_for_schema_evolution_storage, requires_schema_evolution_storage_normalization,
+};
 use crate::spec::PartitionComputer;
 use crate::spec::{
     first_row_supports_changelog_producer, BinaryRow, ChangelogProducer, CoreOptions, DataField,
@@ -126,6 +129,9 @@ pub struct TableWrite {
     has_dedicated_vector_fields: bool,
     row_kind_generator: Option<RowKindGenerator>,
     row_kind_filter: Option<RowKindFilter>,
+    /// Field IDs with a supported type change to a bounded character or binary
+    /// target. Only these fields receive target storage normalization.
+    evolved_storage_field_ids: Option<Arc<HashSet<i32>>>,
 }
 
 impl TableWrite {
@@ -343,6 +349,12 @@ impl TableWrite {
                 .fields()
                 .iter()
                 .any(|f| matches!(f.data_type(), DataType::Vector(_)));
+        let evolved_storage_field_ids = (schema.id() == 0
+            || !schema
+                .fields()
+                .iter()
+                .any(|field| requires_schema_evolution_storage_normalization(field.data_type())))
+        .then(|| Arc::new(HashSet::new()));
 
         Ok(Self {
             table: table.clone(),
@@ -377,6 +389,7 @@ impl TableWrite {
             has_dedicated_vector_fields,
             row_kind_generator,
             row_kind_filter,
+            evolved_storage_field_ids,
         })
     }
 
@@ -443,7 +456,8 @@ impl TableWrite {
             return Ok(());
         }
 
-        let batch = self.enrich_rowkind_batch(batch)?;
+        let batch = self.normalize_evolved_storage_fields(batch).await?;
+        let batch = self.enrich_rowkind_batch(&batch)?;
         if batch.num_rows() == 0 {
             return Ok(());
         }
@@ -454,6 +468,44 @@ impl TableWrite {
                 .await?;
         }
         Ok(())
+    }
+
+    async fn normalize_evolved_storage_fields(
+        &mut self,
+        batch: &RecordBatch,
+    ) -> Result<RecordBatch> {
+        if self.evolved_storage_field_ids.is_none() {
+            self.evolved_storage_field_ids = Some(
+                self.table
+                    .schema_manager()
+                    .storage_normalization_field_ids(self.table.schema())
+                    .await?,
+            );
+        }
+        let evolved_field_ids = self.evolved_storage_field_ids.as_ref().unwrap();
+        if evolved_field_ids.is_empty() {
+            return Ok(batch.clone());
+        }
+
+        let fields = self.table.schema().fields();
+        let mut columns = batch.columns().to_vec();
+        for (index, field) in fields.iter().enumerate() {
+            if evolved_field_ids.contains(&field.id()) {
+                columns[index] = normalize_array_for_schema_evolution_storage(
+                    &columns[index],
+                    field.data_type(),
+                )?;
+            }
+        }
+
+        RecordBatch::try_new(batch.schema(), columns).map_err(|error| {
+            crate::Error::UnexpectedError {
+                message: format!(
+                    "Failed to build storage-normalized schema evolution batch: {error}"
+                ),
+                source: Some(Box::new(error)),
+            }
+        })
     }
 
     fn validate_write_batch_schema(&self, batch: &RecordBatch) -> Result<()> {
@@ -1032,6 +1084,31 @@ mod tests {
             test_schema(),
             None,
         )
+    }
+
+    #[test]
+    fn test_writer_skips_history_lookup_without_bounded_storage_targets() {
+        let schema = TableSchema::new(
+            1,
+            &Schema::builder()
+                .column("id", DataType::Int(IntType::new()))
+                .column("name", DataType::VarChar(VarCharType::string_type()))
+                .build()
+                .unwrap(),
+        );
+        let table = Table::new(
+            test_file_io(),
+            Identifier::new("default", "no_storage_normalization"),
+            "memory:/no_storage_normalization".to_string(),
+            schema,
+            None,
+        );
+
+        let writer = TableWrite::new(&table, "test-user".to_string()).unwrap();
+        assert!(writer
+            .evolved_storage_field_ids
+            .as_ref()
+            .is_some_and(|field_ids| field_ids.is_empty()));
     }
 
     fn test_partitioned_table(file_io: &FileIO, table_path: &str) -> Table {

--- a/crates/paimon/src/table/vector_search_builder.rs
+++ b/crates/paimon/src/table/vector_search_builder.rs
@@ -1236,7 +1236,14 @@ impl<'a> BatchVectorSearchBuilder<'a> {
         let index_entries = match snapshot.index_manifest() {
             Some(index_manifest_name) => {
                 let manifest_path = snapshot_manager.manifest_path(index_manifest_name);
-                IndexManifest::read(self.table.file_io(), &manifest_path).await?
+                super::global_index_build_common::retain_schema_compatible_entries(
+                    self.table,
+                    IndexManifest::read(self.table.file_io(), &manifest_path).await?,
+                    |entry| {
+                        VectorIndexBackend::from_index_type(&entry.index_file.index_type).is_some()
+                    },
+                )
+                .await?
             }
             None => Vec::new(),
         };
@@ -4833,6 +4840,7 @@ mod tests {
                 extra_field_ids: None,
                 source_meta: Some(pk_source_meta_bytes(1, &[(&data_file_name, row_count)])),
                 index_meta: None,
+                build_schema_id: None,
             }),
         };
 
@@ -5345,6 +5353,7 @@ mod tests {
                     extra_field_ids: None,
                     source_meta: None,
                     index_meta: None,
+                    build_schema_id: None,
                 }),
             },
             version: 1,

--- a/crates/paimon/src/table/vindex_index_build_builder.rs
+++ b/crates/paimon/src/table/vindex_index_build_builder.rs
@@ -268,6 +268,7 @@ impl<'a> VindexIndexBuildBuilder<'a> {
                 extra_field_ids: None,
                 source_meta: None,
                 index_meta: Some(index_meta),
+                build_schema_id: None,
             }),
         })
     }
@@ -1101,6 +1102,7 @@ mod tests {
                 extra_field_ids: None,
                 source_meta: None,
                 index_meta: None,
+                build_schema_id: None,
             }),
         };
         let mut message = CommitMessage::new(BinaryRow::new(0).to_serialized_bytes(), 0, vec![]);
@@ -1344,6 +1346,7 @@ mod tests {
                 extra_field_ids: None,
                 source_meta: None,
                 index_meta: None,
+                build_schema_id: None,
             }),
         };
         let mut message = CommitMessage::new(BinaryRow::new(0).to_serialized_bytes(), 0, vec![]);

--- a/crates/paimon/tests/mock_server.rs
+++ b/crates/paimon/tests/mock_server.rs
@@ -941,6 +941,18 @@ impl RESTServer {
         schema: paimon::spec::Schema,
         path: &str,
     ) {
+        self.add_table_with_schema_id(database, table, schema, path, 0);
+    }
+
+    /// Add a table with an explicit schema ID to the server state.
+    pub fn add_table_with_schema_id(
+        &self,
+        database: &str,
+        table: &str,
+        schema: paimon::spec::Schema,
+        path: &str,
+        schema_id: i64,
+    ) {
         let mut s = self.inner.lock().unwrap();
         s.databases.entry(database.to_string()).or_insert_with(|| {
             GetDatabaseResponse::new(
@@ -960,7 +972,7 @@ impl RESTServer {
                 Some(table.to_string()),
                 Some(path.to_string()),
                 Some(true),
-                Some(0),
+                Some(schema_id),
                 Some(schema),
                 AuditRESTResponse::new(None, None, None, None, None),
             ),

--- a/crates/paimon/tests/pk_vector_baseline_test.rs
+++ b/crates/paimon/tests/pk_vector_baseline_test.rs
@@ -436,6 +436,7 @@ async fn build_table_with_first_row_id(
                 &[(&data_file_name, row_count)],
             )),
             index_meta: None,
+            build_schema_id: None,
         }),
     };
 
@@ -1283,6 +1284,7 @@ async fn pk_vector_refine_factor_matches_exact_ground_truth() {
                 &[(&data_file_name, row_count)],
             )),
             index_meta: None,
+            build_schema_id: None,
         }),
     };
     let mut message = CommitMessage::new(partition, bucket, vec![indexed_meta]);

--- a/crates/paimon/tests/pk_vector_batch_test.rs
+++ b/crates/paimon/tests/pk_vector_batch_test.rs
@@ -297,6 +297,7 @@ async fn build_table(vectors: &[[f32; DIM]]) -> (tempfile::TempDir, Table) {
                 &[(&data_file_name, row_count)],
             )),
             index_meta: None,
+            build_schema_id: None,
         }),
     };
 

--- a/crates/paimon/tests/rest_catalog_test.rs
+++ b/crates/paimon/tests/rest_catalog_test.rs
@@ -31,8 +31,8 @@ use paimon::api::ConfigResponse;
 use paimon::catalog::{Catalog, Function, FunctionDefinition, Identifier, RESTCatalog, ViewSchema};
 use paimon::common::Options;
 use paimon::spec::{
-    BigIntType, BlobType, BlobViewStruct, DataField, DataType, Datum, IntType, PredicateBuilder,
-    Schema, SchemaChange, VarCharType,
+    BigIntType, BlobType, BlobViewStruct, DataField, DataType, Datum, DecimalType, FloatType,
+    IntType, PredicateBuilder, Schema, SchemaChange, VarCharType,
 };
 use paimon::{CatalogOptions, FileSystemCatalog, Table};
 
@@ -975,6 +975,112 @@ async fn test_catalog_alter_table() {
         .alter_table(&missing, vec![], true)
         .await
         .unwrap();
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_catalog_alter_type_runs_rust_preflight_before_post() {
+    let tmp = tempfile::tempdir().unwrap();
+    let warehouse = format!("file://{}", tmp.path().display());
+    let mut fs_options = Options::new();
+    fs_options.set(CatalogOptions::WAREHOUSE, &warehouse);
+    let fs_catalog = FileSystemCatalog::new(fs_options).unwrap();
+    fs_catalog
+        .create_database("default", false, HashMap::new())
+        .await
+        .unwrap();
+
+    let identifier = Identifier::new("default", "rest_type_evolution");
+    let initial_schema = Schema::builder()
+        .column("id", DataType::Int(IntType::new()))
+        .column("value", DataType::Float(FloatType::new()))
+        .build()
+        .unwrap();
+    fs_catalog
+        .create_table(&identifier, initial_schema, false)
+        .await
+        .unwrap();
+    let ctx = setup_catalog(vec!["default"]).await;
+    let rest_schema = |table: &Table| -> Schema {
+        serde_json::from_value(
+            serde_json::to_value(table.schema()).expect("serialize table schema"),
+        )
+        .expect("deserialize REST schema")
+    };
+
+    let initial_table = fs_catalog.get_table(&identifier).await.unwrap();
+    ctx.server.add_table_with_schema_id(
+        identifier.database(),
+        identifier.object(),
+        rest_schema(&initial_table),
+        initial_table.location(),
+        initial_table.schema().id(),
+    );
+    let error = ctx
+        .catalog
+        .alter_table(
+            &identifier,
+            vec![SchemaChange::update_column_type(
+                "value".to_string(),
+                DataType::Decimal(DecimalType::new(10, 2).unwrap()),
+            )],
+            false,
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, paimon::Error::Unsupported { ref message }
+            if message.contains("cannot be converted")),
+        "unexpected error: {error:?}"
+    );
+
+    fs_catalog
+        .alter_table(
+            &identifier,
+            vec![SchemaChange::update_column_type(
+                "value".to_string(),
+                DataType::Int(IntType::new()),
+            )],
+            false,
+        )
+        .await
+        .unwrap();
+    let stored_table = fs_catalog.get_table(&identifier).await.unwrap();
+    ctx.server.add_table_with_schema_id(
+        identifier.database(),
+        identifier.object(),
+        rest_schema(&stored_table),
+        stored_table.location(),
+        stored_table.schema().id(),
+    );
+
+    let error = ctx
+        .catalog
+        .alter_table(
+            &identifier,
+            vec![SchemaChange::update_column_type(
+                "value".to_string(),
+                DataType::Decimal(DecimalType::new(10, 2).unwrap()),
+            )],
+            false,
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, paimon::Error::Unsupported { ref message }
+            if message.contains("historical schema 0")
+                && message.contains("unimplemented schema evolution cast")),
+        "unexpected error: {error:?}"
+    );
+    assert_eq!(
+        stored_table
+            .schema_manager()
+            .list_all()
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
 }
 
 // ==================== Multiple Databases Tests ====================

--- a/docs/src/sql.md
+++ b/docs/src/sql.md
@@ -721,6 +721,9 @@ ALTER TABLE paimon.my_db.users RENAME COLUMN name TO username;
 -- Rename a table
 ALTER TABLE paimon.my_db.users RENAME TO members;
 
+-- Change a regular scalar column type
+ALTER TABLE paimon.my_db.users ALTER COLUMN age TYPE BIGINT;
+
 -- Set table properties
 ALTER TABLE paimon.my_db.users SET TBLPROPERTIES('data-evolution.enabled' = 'true');
 ```
@@ -730,6 +733,71 @@ ALTER TABLE paimon.my_db.users SET TBLPROPERTIES('data-evolution.enabled' = 'tru
 ```sql
 ALTER TABLE IF EXISTS paimon.my_db.users ADD COLUMN age INT;
 ```
+
+#### ALTER COLUMN TYPE
+
+Type evolution is limited to top-level scalar columns with no key, partition,
+bucket, sequence, row-kind routing, persisted global-index, or search-payload
+dependency. Nested and constructed types are rejected before schema metadata is
+written. Existing configured primary-key vector/full-text index columns and
+persisted global-index primary or extra payload fields are also rejected; this
+operation does not invalidate or rebuild indexes.
+
+Rust-written global-index entries persist their build schema ID. Readers ignore
+an entry when any indexed field has a different logical type in the current
+schema, so an index commit racing with `ALTER COLUMN TYPE` cannot be used for
+pruning under incompatible key semantics. Legacy entries without a build schema
+ID remain eligible only when complete schema history proves that none of their
+indexed fields has changed type.
+
+This is a compatibility tightening from earlier Rust releases, which admitted
+some Arrow-castable pairs without guaranteeing matching Paimon reader
+semantics. Such pairs are now rejected before schema metadata is written. The
+Rust matrix is also currently narrower than Java Paimon's complete executor
+set; expanding it requires adding and testing the corresponding Rust semantic
+executor first.
+
+The executable conversion matrix is intentionally narrower than general SQL
+`CAST`:
+
+| Source | Target | Execution semantics |
+|---|---|---|
+| `TINYINT`, `SMALLINT`, `INT`, `BIGINT`, `FLOAT`, `DOUBLE` | Any listed primitive numeric type allowed by the table's implicit/explicit-cast option | Paimon primitive conversion, including Java-compatible narrowing, overflow, `NaN`, and infinity behavior |
+| `TINYINT`, `SMALLINT`, `INT`, `BIGINT` | `DECIMAL(p, s)` | Scale to the target decimal; values exceeding target precision become null |
+| `DECIMAL(p, s)` | `DECIMAL(p2, s2)` | Half-up rescaling; values exceeding target precision become null |
+| `CHAR(n)`, `VARCHAR(n)` | `CHAR(m)`, `VARCHAR(m)` | Unicode character truncation; `CHAR` is space-padded to its target length |
+| `BINARY(n)`, `VARBINARY(n)` | `BINARY(m)`, `VARBINARY(m)` | Byte truncation; `BINARY` is zero-padded to its target length |
+| `DATE` | `TIMESTAMP(p)`, where `p` is 0–3 | Epoch-day conversion to the millisecond physical representation |
+| `TIMESTAMP(p)` | `DATE` | Paimon epoch-millisecond division, truncated toward zero |
+
+Changing timestamp precision, converting to or from local-zoned timestamps,
+floating-point-to-decimal conversions, decimal-to-primitive conversions, and
+cross-family conversions such as numeric-to-string are not admitted by schema
+evolution even if an ordinary SQL `CAST` could express them. Nullability changes
+continue to follow the existing table options.
+
+For repeated type changes, the final target must have an executable direct cast
+from every historical type of the same stable field ID. A non-executable chain
+is rejected before the new schema metadata is written.
+
+Readers resolve old columns by stable Paimon field ID and present them using the
+current logical type. Writers normalize target `CHAR`/`VARCHAR` and
+`BINARY`/`VARBINARY` constraints only for field IDs that have a supported type
+change in schema history; this does not retroactively change write behavior for
+unrelated existing columns.
+
+Predicate pushdown fails open across type evolution. A predicate that cannot be
+safely converted to an old file's schema is not passed to that file reader or
+its statistics pruning path, so the full candidate set is retained and the
+DataFusion residual filter produces the final result. DataFusion resolves type
+evolution by stable field ID and retains the additional residual only when a
+pushed predicate references an evolved field. Unrelated additions, renames,
+comments, or option changes do not cause a table-wide pushdown downgrade.
+
+Type narrowing and other downgrades are not guaranteed to be lossless. Values
+may be truncated, rounded, rejected on overflow, or otherwise follow the target
+executor's conversion semantics. This feature does not provide downgrade
+recovery or restore the original value representation.
 
 ## DML
 


### PR DESCRIPTION
### Purpose

`ALTER COLUMN TYPE` previously accepted Arrow-castable type pairs without guaranteeing Paimon-compatible conversion of historical files. Predicates, statistics, and global indexes could therefore use incompatible physical-type semantics.

### Brief change log

- Add explicit Paimon-compatible type-evolution executors and historical-schema preflight validation.
- Cast old files to the current logical schema and fail open for unsafe predicate or statistics pruning.
- Normalize bounded character and binary writes after type evolution.
- Record global-index build schema IDs and ignore schema-incompatible index entries.
- Apply the validation consistently to filesystem, REST catalog, and DataFusion paths.

### Tests

- Workspace format, build, and clippy checks
- Paimon and REST server all-target tests
- DataFusion integration tests with Spark fixtures
- Vortex end-to-end test

### API and Format

Adds an optional `build_schema_id` to global-index metadata. Legacy index entries remain readable.

### Documentation

Documents the supported type-evolution matrix and safety restrictions.