### PR TITLE
perf(parquet): scope exact metadata reads by storage capability

### DIFF
--- a/crates/paimon/src/arrow/format/parquet.rs
+++ b/crates/paimon/src/arrow/format/parquet.rs
@@ -3323,6 +3323,21 @@ mod tests {
         );
     }
 
+    fn expected_offset_index_range(data: &Bytes) -> std::ops::Range<u64> {
+        let metadata = load_metadata_with_page_index(data, false);
+        metadata
+            .row_groups()
+            .iter()
+            .flat_map(|row_group| row_group.columns())
+            .filter_map(|column| {
+                let start = u64::try_from(column.offset_index_offset()?).ok()?;
+                let length = u64::try_from(column.offset_index_length()?).ok()?;
+                Some(start..start + length)
+            })
+            .reduce(|left, right| left.start.min(right.start)..left.end.max(right.end))
+            .expect("test parquet file should contain offset indexes")
+    }
+
     #[tokio::test]
     async fn test_metadata_reads_exact_footer_without_fixed_prefetch() {
         let data = Bytes::from(write_multi_page_parquet(10, 80).await);
@@ -3371,6 +3386,33 @@ mod tests {
         assert_eq!(rows, 0);
         let ranges = tracker.ranges();
         assert_exact_metadata_reads(&data, &ranges);
+    }
+
+    #[tokio::test]
+    async fn test_non_empty_row_selection_reads_exact_offset_index_range() {
+        let data = Bytes::from(write_multi_page_parquet(10, 80).await);
+        let file_size = data.len() as u64;
+        let file_read = TrackingFileRead::new(data.clone());
+        let tracker = file_read.clone();
+        let fields = vec![int_field("id"), int_field("value")];
+
+        let stream = ParquetFormatReader::default()
+            .read_batch_stream(
+                Box::new(file_read),
+                file_size,
+                &fields,
+                None,
+                None,
+                Some(vec![RowRange::new(0, 0)]),
+            )
+            .await
+            .unwrap();
+        drop(stream);
+
+        let ranges = tracker.ranges();
+        assert_eq!(ranges.len(), 3);
+        assert_exact_metadata_reads(&data, &ranges[..2]);
+        assert_eq!(ranges[2..], [expected_offset_index_range(&data)]);
     }
 
     async fn write_nested_multi_page_parquet() -> Vec<u8> {

--- a/crates/paimon/src/arrow/format/parquet.rs
+++ b/crates/paimon/src/arrow/format/parquet.rs
@@ -336,7 +336,11 @@ impl FormatFileReader for ParquetFormatReader {
         if !preds.is_empty() {
             arrow_options = arrow_options.with_column_index_policy(PageIndexPolicy::Optional);
         }
-        if !preds.is_empty() || row_selection.is_some() {
+        if !preds.is_empty()
+            || row_selection
+                .as_ref()
+                .is_some_and(|ranges| !ranges.is_empty())
+        {
             arrow_options = arrow_options.with_offset_index_policy(PageIndexPolicy::Optional);
         }
         let mut batch_stream_builder =
@@ -1879,9 +1883,10 @@ fn build_row_ranges_selection(
 /// # TODO
 ///
 /// [ParquetObjectReader](https://docs.rs/parquet/latest/src/parquet/arrow/async_reader/store.rs.html#64)
-/// contains the following hints to speed up metadata loading, similar to iceberg, we can consider adding them to this struct:
+/// supports optional metadata prefetch hints. Keep the hint unset so metadata
+/// loading first reads the 8-byte footer and then requests the exact metadata
+/// and page-index ranges, matching parquet-hadoop's seek-based read path.
 ///
-/// - `metadata_size_hint`: Provide a hint as to the size of the parquet file's footer.
 /// - `preload_column_index`: Load the Column Index  as part of [`Self::get_metadata`].
 /// - `preload_offset_index`: Load the Offset Index as part of [`Self::get_metadata`].
 struct ArrowFileReader {
@@ -1893,8 +1898,6 @@ struct ArrowFileReader {
 const RANGE_COALESCE_BYTES: u64 = 1024 * 1024;
 /// concurrent range fetches.
 const RANGE_FETCH_CONCURRENCY: usize = 10;
-/// metadata prefetch hint: 512 KiB.
-const METADATA_SIZE_HINT: usize = 512 * 1024;
 /// Minimum range size for splitting: 4 MiB.
 /// The block size used for split alignment and as the minimum split
 /// granularity.  Ranges smaller than this will not be split further to
@@ -2049,12 +2052,9 @@ impl AsyncFileReader for ArrowFileReader {
         // no page index would ever be loaded.
         let column_index_policy = options.map(|o| o.column_index_policy());
         let offset_index_policy = options.map(|o| o.offset_index_policy());
-        let prefetch_hint = Some(METADATA_SIZE_HINT);
         Box::pin(async move {
             let file_size = self.file_size;
-            let mut reader = ParquetMetaDataReader::new()
-                .with_prefetch_hint(prefetch_hint)
-                .with_metadata_options(metadata_opts);
+            let mut reader = ParquetMetaDataReader::new().with_metadata_options(metadata_opts);
             if let Some(policy) = column_index_policy {
                 reader = reader.with_column_index_policy(policy);
             }
@@ -3291,6 +3291,10 @@ mod tests {
                 .sum()
         }
 
+        fn ranges(&self) -> Vec<std::ops::Range<u64>> {
+            self.ranges.lock().unwrap().clone()
+        }
+
         fn reset(&self) {
             self.ranges.lock().unwrap().clear();
         }
@@ -3302,6 +3306,71 @@ mod tests {
             self.ranges.lock().unwrap().push(range.clone());
             Ok(self.data.slice(range.start as usize..range.end as usize))
         }
+    }
+
+    fn assert_exact_metadata_reads(data: &Bytes, ranges: &[std::ops::Range<u64>]) {
+        let file_size = data.len() as u64;
+        let footer_start = data.len() - 8;
+        let metadata_len =
+            u32::from_le_bytes(data[footer_start..footer_start + 4].try_into().unwrap()) as u64;
+
+        assert_eq!(
+            ranges,
+            &[
+                file_size - 8..file_size,
+                file_size - 8 - metadata_len..file_size - 8,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_metadata_reads_exact_footer_without_fixed_prefetch() {
+        let data = Bytes::from(write_multi_page_parquet(10, 80).await);
+        let file_size = data.len() as u64;
+        let file_read = TrackingFileRead::new(data.clone());
+        let tracker = file_read.clone();
+        let fields = vec![int_field("id"), int_field("value")];
+
+        let stream = ParquetFormatReader::default()
+            .read_batch_stream(Box::new(file_read), file_size, &fields, None, None, None)
+            .await
+            .unwrap();
+        drop(stream);
+
+        let ranges = tracker.ranges();
+        assert_exact_metadata_reads(&data, &ranges);
+    }
+
+    #[tokio::test]
+    async fn test_empty_row_selection_keeps_footer_only_metadata_path() {
+        let data = Bytes::from(write_multi_page_parquet(10, 80).await);
+        let file_size = data.len() as u64;
+        let file_read = TrackingFileRead::new(data.clone());
+        let tracker = file_read.clone();
+        let fields = vec![int_field("id"), int_field("value")];
+
+        let stream = ParquetFormatReader::default()
+            .read_batch_stream(
+                Box::new(file_read),
+                file_size,
+                &fields,
+                None,
+                None,
+                Some(Vec::new()),
+            )
+            .await
+            .unwrap();
+        let rows = stream
+            .try_fold(
+                0usize,
+                |rows, batch| async move { Ok(rows + batch.num_rows()) },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(rows, 0);
+        let ranges = tracker.ranges();
+        assert_exact_metadata_reads(&data, &ranges);
     }
 
     async fn write_nested_multi_page_parquet() -> Vec<u8> {

--- a/crates/paimon/src/arrow/format/parquet.rs
+++ b/crates/paimon/src/arrow/format/parquet.rs
@@ -54,6 +54,9 @@ use std::ops::Range;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
+/// Metadata prefetch hint used when range reads have non-trivial request cost.
+const METADATA_SIZE_HINT: usize = 512 * 1024;
+
 #[derive(Default)]
 pub(crate) struct ParquetFormatReader {
     read_budget: Option<Arc<ParquetReadBudget>>,
@@ -330,8 +333,9 @@ impl FormatFileReader for ParquetFormatReader {
         };
         let row_filter_factory = predicates.and_then(|fp| fp.row_filter_factory.as_deref());
 
-        // Predicates need both indexes for page-stat pruning. Row selection only
-        // needs OffsetIndex so arrow-rs can avoid fetching unselected pages.
+        // Predicates need both indexes for page-stat pruning. A non-empty row
+        // selection only needs OffsetIndex so arrow-rs can avoid fetching
+        // unselected pages.
         let mut arrow_options = ArrowReaderOptions::new();
         if !preds.is_empty() {
             arrow_options = arrow_options.with_column_index_policy(PageIndexPolicy::Optional);
@@ -1880,18 +1884,13 @@ fn build_row_ranges_selection(
 
 /// ArrowFileReader is a wrapper around a FileRead that impls parquets AsyncFileReader.
 ///
-/// # TODO
-///
-/// [ParquetObjectReader](https://docs.rs/parquet/latest/src/parquet/arrow/async_reader/store.rs.html#64)
-/// supports optional metadata prefetch hints. Keep the hint unset so metadata
-/// loading first reads the 8-byte footer and then requests the exact metadata
-/// and page-index ranges, matching parquet-hadoop's seek-based read path.
-///
-/// - `preload_column_index`: Load the Column Index  as part of [`Self::get_metadata`].
-/// - `preload_offset_index`: Load the Offset Index as part of [`Self::get_metadata`].
+/// The metadata prefetch policy follows [`FileRead::supports_cheap_range_reads`].
+/// Filesystem, memory, and HDFS readers use exact positioned reads; object-store
+/// readers retain the fixed suffix prefetch to avoid extra network round trips.
 struct ArrowFileReader {
     file_size: u64,
     r: Arc<dyn FileRead>,
+    metadata_prefetch_hint: Option<usize>,
 }
 
 /// coalesce threshold: 1 MiB.
@@ -1906,7 +1905,13 @@ const IO_BLOCK_SIZE: u64 = 4 * 1024 * 1024;
 
 impl ArrowFileReader {
     fn new(file_size: u64, r: Arc<dyn FileRead>) -> Self {
-        Self { file_size, r }
+        let metadata_prefetch_hint =
+            (!r.supports_cheap_range_reads()).then_some(METADATA_SIZE_HINT);
+        Self {
+            file_size,
+            r,
+            metadata_prefetch_hint,
+        }
     }
 
     fn read_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, parquet::errors::Result<Bytes>> {
@@ -2052,9 +2057,12 @@ impl AsyncFileReader for ArrowFileReader {
         // no page index would ever be loaded.
         let column_index_policy = options.map(|o| o.column_index_policy());
         let offset_index_policy = options.map(|o| o.offset_index_policy());
+        let prefetch_hint = self.metadata_prefetch_hint;
         Box::pin(async move {
             let file_size = self.file_size;
-            let mut reader = ParquetMetaDataReader::new().with_metadata_options(metadata_opts);
+            let mut reader = ParquetMetaDataReader::new()
+                .with_prefetch_hint(prefetch_hint)
+                .with_metadata_options(metadata_opts);
             if let Some(policy) = column_index_policy {
                 reader = reader.with_column_index_policy(policy);
             }
@@ -3272,6 +3280,7 @@ mod tests {
     struct TrackingFileRead {
         data: Bytes,
         ranges: Arc<std::sync::Mutex<Vec<std::ops::Range<u64>>>>,
+        supports_cheap_range_reads: bool,
     }
 
     impl TrackingFileRead {
@@ -3279,6 +3288,14 @@ mod tests {
             Self {
                 data,
                 ranges: Arc::new(std::sync::Mutex::new(Vec::new())),
+                supports_cheap_range_reads: false,
+            }
+        }
+
+        fn with_cheap_range_reads(data: Bytes) -> Self {
+            Self {
+                supports_cheap_range_reads: true,
+                ..Self::new(data)
             }
         }
 
@@ -3306,9 +3323,13 @@ mod tests {
             self.ranges.lock().unwrap().push(range.clone());
             Ok(self.data.slice(range.start as usize..range.end as usize))
         }
+
+        fn supports_cheap_range_reads(&self) -> bool {
+            self.supports_cheap_range_reads
+        }
     }
 
-    fn assert_exact_metadata_reads(data: &Bytes, ranges: &[std::ops::Range<u64>]) {
+    fn assert_footer_then_exact_metadata_reads(data: &Bytes, ranges: &[std::ops::Range<u64>]) {
         let file_size = data.len() as u64;
         let footer_start = data.len() - 8;
         let metadata_len =
@@ -3339,10 +3360,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_metadata_reads_exact_footer_without_fixed_prefetch() {
+    async fn test_hdfs_metadata_reads_exact_footer_without_fixed_prefetch() {
         let data = Bytes::from(write_multi_page_parquet(10, 80).await);
         let file_size = data.len() as u64;
-        let file_read = TrackingFileRead::new(data.clone());
+        let file_read = TrackingFileRead::with_cheap_range_reads(data.clone());
         let tracker = file_read.clone();
         let fields = vec![int_field("id"), int_field("value")];
 
@@ -3353,14 +3374,39 @@ mod tests {
         drop(stream);
 
         let ranges = tracker.ranges();
-        assert_exact_metadata_reads(&data, &ranges);
+        assert_footer_then_exact_metadata_reads(&data, &ranges);
     }
 
     #[tokio::test]
-    async fn test_empty_row_selection_keeps_footer_only_metadata_path() {
+    async fn test_small_object_store_row_selection_uses_single_prefetch_request() {
         let data = Bytes::from(write_multi_page_parquet(10, 80).await);
         let file_size = data.len() as u64;
-        let file_read = TrackingFileRead::new(data.clone());
+        assert!(file_size <= super::METADATA_SIZE_HINT as u64);
+        let file_read = TrackingFileRead::new(data);
+        let tracker = file_read.clone();
+        let fields = vec![int_field("id"), int_field("value")];
+
+        let stream = ParquetFormatReader::default()
+            .read_batch_stream(
+                Box::new(file_read),
+                file_size,
+                &fields,
+                None,
+                None,
+                Some(vec![RowRange::new(0, 0)]),
+            )
+            .await
+            .unwrap();
+        drop(stream);
+
+        assert_eq!(tracker.ranges(), vec![0..file_size]);
+    }
+
+    #[tokio::test]
+    async fn test_hdfs_empty_row_selection_keeps_footer_only_metadata_path() {
+        let data = Bytes::from(write_multi_page_parquet(10, 80).await);
+        let file_size = data.len() as u64;
+        let file_read = TrackingFileRead::with_cheap_range_reads(data.clone());
         let tracker = file_read.clone();
         let fields = vec![int_field("id"), int_field("value")];
 
@@ -3385,14 +3431,14 @@ mod tests {
 
         assert_eq!(rows, 0);
         let ranges = tracker.ranges();
-        assert_exact_metadata_reads(&data, &ranges);
+        assert_footer_then_exact_metadata_reads(&data, &ranges);
     }
 
     #[tokio::test]
-    async fn test_non_empty_row_selection_reads_exact_offset_index_range() {
+    async fn test_hdfs_non_empty_row_selection_reads_exact_offset_index_range() {
         let data = Bytes::from(write_multi_page_parquet(10, 80).await);
         let file_size = data.len() as u64;
-        let file_read = TrackingFileRead::new(data.clone());
+        let file_read = TrackingFileRead::with_cheap_range_reads(data.clone());
         let tracker = file_read.clone();
         let fields = vec![int_field("id"), int_field("value")];
 
@@ -3411,7 +3457,7 @@ mod tests {
 
         let ranges = tracker.ranges();
         assert_eq!(ranges.len(), 3);
-        assert_exact_metadata_reads(&data, &ranges[..2]);
+        assert_footer_then_exact_metadata_reads(&data, &ranges[..2]);
         assert_eq!(ranges[2..], [expected_offset_index_range(&data)]);
     }
 

--- a/crates/paimon/src/arrow/format/parquet.rs
+++ b/crates/paimon/src/arrow/format/parquet.rs
@@ -1885,8 +1885,8 @@ fn build_row_ranges_selection(
 /// ArrowFileReader is a wrapper around a FileRead that impls parquets AsyncFileReader.
 ///
 /// The metadata prefetch policy follows [`FileRead::supports_cheap_range_reads`].
-/// Filesystem, memory, and HDFS readers use exact positioned reads; object-store
-/// readers retain the fixed suffix prefetch to avoid extra network round trips.
+/// Local filesystem, memory, and HDFS readers use exact positioned reads;
+/// other readers retain the fixed suffix prefetch unless they explicitly opt in.
 struct ArrowFileReader {
     file_size: u64,
     r: Arc<dyn FileRead>,
@@ -3360,7 +3360,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_hdfs_metadata_reads_exact_footer_without_fixed_prefetch() {
+    async fn test_cheap_range_reads_use_exact_footer_without_fixed_prefetch() {
         let data = Bytes::from(write_multi_page_parquet(10, 80).await);
         let file_size = data.len() as u64;
         let file_read = TrackingFileRead::with_cheap_range_reads(data.clone());
@@ -3403,7 +3403,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_hdfs_empty_row_selection_keeps_footer_only_metadata_path() {
+    async fn test_empty_row_selection_with_cheap_range_reads_keeps_exact_metadata_path() {
         let data = Bytes::from(write_multi_page_parquet(10, 80).await);
         let file_size = data.len() as u64;
         let file_read = TrackingFileRead::with_cheap_range_reads(data.clone());
@@ -3435,7 +3435,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_hdfs_non_empty_row_selection_reads_exact_offset_index_range() {
+    async fn test_non_empty_row_selection_with_cheap_range_reads_reads_exact_offset_index() {
         let data = Bytes::from(write_multi_page_parquet(10, 80).await);
         let file_size = data.len() as u64;
         let file_read = TrackingFileRead::with_cheap_range_reads(data.clone());

--- a/crates/paimon/src/io/file_io.rs
+++ b/crates/paimon/src/io/file_io.rs
@@ -442,6 +442,11 @@ impl FileIOBuilder {
 pub trait FileRead: Send + Sync + Unpin + 'static {
     async fn read(&self, range: Range<u64>) -> crate::Result<Bytes>;
 
+    /// Returns whether small positioned range reads are cheap enough to prefer
+    /// exact metadata reads over fixed-size prefetching.
+    ///
+    /// The conservative default keeps prefetching for custom readers unless
+    /// they explicitly opt in.
     fn supports_cheap_range_reads(&self) -> bool {
         false
     }
@@ -1165,6 +1170,15 @@ mod input_output_test {
         FileIOBuilder::new("file").build().unwrap()
     }
 
+    #[cfg(feature = "storage-memory")]
+    fn setup_custom_fs_file_io() -> FileIO {
+        let operator = Operator::from_config(opendal::services::MemoryConfig::default()).unwrap();
+        FileIOBuilder::new("")
+            .with_fs_operator(operator)
+            .build()
+            .unwrap()
+    }
+
     fn setup_cached_fs_file_io(cache_directory: &std::path::Path) -> FileIO {
         let mut options = Options::new();
         options.set(CatalogOptions::LOCAL_CACHE_ENABLED, "true");
@@ -1233,6 +1247,34 @@ mod input_output_test {
         let partial_content = reader.read(0..5).await.unwrap(); // read "hello"
 
         assert_eq!(&partial_content[..], b"hello");
+
+        file_io.delete_file(path).await.unwrap();
+    }
+
+    #[cfg(feature = "storage-memory")]
+    #[tokio::test]
+    async fn test_memory_reader_reports_cheap_range_reads() {
+        let file_io = setup_memory_file_io();
+        let path = "memory:/test_memory_reader_range_capability";
+        let output = file_io.new_output(path).unwrap();
+        output.write(Bytes::from_static(b"test")).await.unwrap();
+
+        let reader = output.to_input_file().reader().await.unwrap();
+        assert!(reader.supports_cheap_range_reads());
+
+        file_io.delete_file(path).await.unwrap();
+    }
+
+    #[cfg(feature = "storage-memory")]
+    #[tokio::test]
+    async fn test_custom_fs_reader_keeps_conservative_range_capability() {
+        let file_io = setup_custom_fs_file_io();
+        let path = "/test_custom_fs_reader_range_capability";
+        let output = file_io.new_output(path).unwrap();
+        output.write(Bytes::from_static(b"test")).await.unwrap();
+
+        let reader = output.to_input_file().reader().await.unwrap();
+        assert!(!reader.supports_cheap_range_reads());
 
         file_io.delete_file(path).await.unwrap();
     }

--- a/crates/paimon/src/io/file_io.rs
+++ b/crates/paimon/src/io/file_io.rs
@@ -88,6 +88,7 @@ impl FileIO {
     ///
     /// Reference: <https://github.com/apache/paimon/blob/release-0.8.2/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java#L76>
     pub fn new_input(&self, path: &str) -> crate::Result<InputFile> {
+        let supports_cheap_range_reads = self.storage.supports_cheap_range_reads();
         let (op, relative_path) = self.storage.create(path)?;
         let cache_path = cache_object_path(&op, relative_path.as_ref());
         Ok(InputFile {
@@ -100,6 +101,7 @@ impl FileIO {
                 .as_ref()
                 .filter(|cache| cache.is_cacheable(path))
                 .cloned(),
+            supports_cheap_range_reads,
         })
     }
 
@@ -107,6 +109,7 @@ impl FileIO {
     ///
     /// Reference: <https://github.com/apache/paimon/blob/release-0.8.2/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java#L87>
     pub fn new_output(&self, path: &str) -> Result<OutputFile> {
+        let supports_cheap_range_reads = self.storage.supports_cheap_range_reads();
         let (op, relative_path) = self.storage.create(path)?;
         let cache_path = cache_object_path(&op, relative_path.as_ref());
         Ok(OutputFile {
@@ -119,6 +122,7 @@ impl FileIO {
                 .as_ref()
                 .filter(|cache| cache.is_cacheable(path))
                 .cloned(),
+            supports_cheap_range_reads,
         })
     }
 
@@ -437,6 +441,10 @@ impl FileIOBuilder {
 #[async_trait::async_trait]
 pub trait FileRead: Send + Sync + Unpin + 'static {
     async fn read(&self, range: Range<u64>) -> crate::Result<Bytes>;
+
+    fn supports_cheap_range_reads(&self) -> bool {
+        false
+    }
 }
 
 #[async_trait::async_trait]
@@ -446,18 +454,27 @@ impl FileRead for opendal::Reader {
     }
 }
 
-enum InputFileReader {
+enum InputFileReaderInner {
     Direct(opendal::Reader),
     Cached(CachedFileReader),
+}
+
+struct InputFileReader {
+    inner: InputFileReaderInner,
+    supports_cheap_range_reads: bool,
 }
 
 #[async_trait::async_trait]
 impl FileRead for InputFileReader {
     async fn read(&self, range: Range<u64>) -> crate::Result<Bytes> {
-        match self {
-            Self::Direct(reader) => FileRead::read(reader, range).await,
-            Self::Cached(reader) => FileRead::read(reader, range).await,
+        match &self.inner {
+            InputFileReaderInner::Direct(reader) => FileRead::read(reader, range).await,
+            InputFileReaderInner::Cached(reader) => FileRead::read(reader, range).await,
         }
+    }
+
+    fn supports_cheap_range_reads(&self) -> bool {
+        self.supports_cheap_range_reads
     }
 }
 
@@ -573,6 +590,7 @@ pub struct InputFile {
     relative_path: String,
     cache_path: String,
     cache: Option<Arc<LocalCache>>,
+    supports_cheap_range_reads: bool,
 }
 
 impl InputFile {
@@ -625,26 +643,31 @@ impl InputFile {
 
     pub async fn reader(&self) -> crate::Result<impl FileRead> {
         let reader = self.op.reader(&self.relative_path).await?;
-        let Some(cache) = &self.cache else {
-            return Ok(InputFileReader::Direct(reader));
-        };
-        let read_token = cache.read_token(&self.cache_path);
-        let size = if let Some(size) = cache.file_size(&self.cache_path, &read_token).await {
-            size
+        let inner = if let Some(cache) = &self.cache {
+            let read_token = cache.read_token(&self.cache_path);
+            let size = if let Some(size) = cache.file_size(&self.cache_path, &read_token).await {
+                size
+            } else {
+                let size = self.op.stat(&self.relative_path).await?.content_length();
+                cache
+                    .put_file_size(&self.cache_path, size, &read_token)
+                    .await;
+                size
+            };
+            InputFileReaderInner::Cached(CachedFileReader::new_with_token(
+                Arc::new(reader),
+                &self.cache_path,
+                size,
+                cache.clone(),
+                read_token,
+            ))
         } else {
-            let size = self.op.stat(&self.relative_path).await?.content_length();
-            cache
-                .put_file_size(&self.cache_path, size, &read_token)
-                .await;
-            size
+            InputFileReaderInner::Direct(reader)
         };
-        Ok(InputFileReader::Cached(CachedFileReader::new_with_token(
-            Arc::new(reader),
-            &self.cache_path,
-            size,
-            cache.clone(),
-            read_token,
-        )))
+        Ok(InputFileReader {
+            inner,
+            supports_cheap_range_reads: self.supports_cheap_range_reads,
+        })
     }
 }
 
@@ -657,6 +680,7 @@ pub struct OutputFile {
     relative_path: String,
     cache_path: String,
     cache: Option<Arc<LocalCache>>,
+    supports_cheap_range_reads: bool,
 }
 
 impl OutputFile {
@@ -676,6 +700,7 @@ impl OutputFile {
             relative_path: self.relative_path,
             cache_path: self.cache_path,
             cache,
+            supports_cheap_range_reads: self.supports_cheap_range_reads,
         }
     }
 

--- a/crates/paimon/src/io/storage.rs
+++ b/crates/paimon/src/io/storage.rs
@@ -190,6 +190,30 @@ impl Storage {
         }
     }
 
+    pub(crate) fn supports_cheap_range_reads(&self) -> bool {
+        match self {
+            Self::CustomFs { .. } => true,
+            #[cfg(feature = "storage-memory")]
+            Self::Memory { .. } => true,
+            #[cfg(feature = "storage-fs")]
+            Self::LocalFs { .. } => true,
+            #[cfg(feature = "storage-hdfs")]
+            Self::Hdfs { .. } => true,
+            #[cfg(feature = "storage-oss")]
+            Self::Oss { .. } => false,
+            #[cfg(feature = "storage-s3")]
+            Self::S3 { .. } => false,
+            #[cfg(feature = "storage-cos")]
+            Self::Cos { .. } => false,
+            #[cfg(feature = "storage-azdls")]
+            Self::Azdls { .. } => false,
+            #[cfg(feature = "storage-obs")]
+            Self::Obs { .. } => false,
+            #[cfg(feature = "storage-gcs")]
+            Self::Gcs { .. } => false,
+        }
+    }
+
     pub(crate) fn create<'a>(&self, path: &'a str) -> crate::Result<(Operator, Cow<'a, str>)> {
         match self {
             Storage::CustomFs { op } => {
@@ -448,7 +472,9 @@ mod scheme_tests {
     #[test]
     fn memory_scheme_is_case_insensitive() {
         for scheme in ["memory", "MEMORY"] {
-            assert!(matches!(build(scheme), Storage::Memory { .. }), "{scheme}");
+            let storage = build(scheme);
+            assert!(matches!(&storage, Storage::Memory { .. }), "{scheme}");
+            assert!(storage.supports_cheap_range_reads(), "{scheme}");
         }
     }
 
@@ -456,7 +482,9 @@ mod scheme_tests {
     #[test]
     fn local_fs_scheme_aliases_are_compatible() {
         for scheme in ["", "file", "FILE", "fs", "FS"] {
-            assert!(matches!(build(scheme), Storage::LocalFs { .. }), "{scheme}");
+            let storage = build(scheme);
+            assert!(matches!(&storage, Storage::LocalFs { .. }), "{scheme}");
+            assert!(storage.supports_cheap_range_reads(), "{scheme}");
         }
     }
 
@@ -470,7 +498,8 @@ mod scheme_tests {
                 ("fs.oss.accessKeySecret", "test-sk"),
             ]))
             .unwrap();
-            assert!(matches!(storage, Storage::Oss { .. }), "{scheme}");
+            assert!(matches!(&storage, Storage::Oss { .. }), "{scheme}");
+            assert!(!storage.supports_cheap_range_reads(), "{scheme}");
         }
     }
 
@@ -478,7 +507,9 @@ mod scheme_tests {
     #[test]
     fn s3_scheme_aliases_are_compatible() {
         for scheme in ["s3", "S3", "s3a", "S3A"] {
-            assert!(matches!(build(scheme), Storage::S3 { .. }), "{scheme}");
+            let storage = build(scheme);
+            assert!(matches!(&storage, Storage::S3 { .. }), "{scheme}");
+            assert!(!storage.supports_cheap_range_reads(), "{scheme}");
         }
     }
 
@@ -528,7 +559,9 @@ mod scheme_tests {
             "hdfs_native",
             "HDFS_NATIVE",
         ] {
-            assert!(matches!(build(scheme), Storage::Hdfs { .. }), "{scheme}");
+            let storage = build(scheme);
+            assert!(matches!(&storage, Storage::Hdfs { .. }), "{scheme}");
+            assert!(storage.supports_cheap_range_reads(), "{scheme}");
         }
     }
 

--- a/crates/paimon/src/io/storage.rs
+++ b/crates/paimon/src/io/storage.rs
@@ -192,7 +192,7 @@ impl Storage {
 
     pub(crate) fn supports_cheap_range_reads(&self) -> bool {
         match self {
-            Self::CustomFs { .. } => true,
+            Self::CustomFs { .. } => false,
             #[cfg(feature = "storage-memory")]
             Self::Memory { .. } => true,
             #[cfg(feature = "storage-fs")]
@@ -517,7 +517,9 @@ mod scheme_tests {
     #[test]
     fn cos_scheme_aliases_are_compatible() {
         for scheme in ["cos", "COS", "cosn", "COSN"] {
-            assert!(matches!(build(scheme), Storage::Cos { .. }), "{scheme}");
+            let storage = build(scheme);
+            assert!(matches!(&storage, Storage::Cos { .. }), "{scheme}");
+            assert!(!storage.supports_cheap_range_reads(), "{scheme}");
         }
     }
 
@@ -528,7 +530,9 @@ mod scheme_tests {
             "azdls", "AZDLS", "azdfs", "AZDFS", "abfs", "ABFS", "abfss", "ABFSS", "az", "AZ",
             "azure", "AZURE",
         ] {
-            assert!(matches!(build(scheme), Storage::Azdls { .. }), "{scheme}");
+            let storage = build(scheme);
+            assert!(matches!(&storage, Storage::Azdls { .. }), "{scheme}");
+            assert!(!storage.supports_cheap_range_reads(), "{scheme}");
         }
     }
 
@@ -536,7 +540,9 @@ mod scheme_tests {
     #[test]
     fn obs_scheme_is_case_insensitive() {
         for scheme in ["obs", "OBS"] {
-            assert!(matches!(build(scheme), Storage::Obs { .. }), "{scheme}");
+            let storage = build(scheme);
+            assert!(matches!(&storage, Storage::Obs { .. }), "{scheme}");
+            assert!(!storage.supports_cheap_range_reads(), "{scheme}");
         }
     }
 
@@ -544,7 +550,9 @@ mod scheme_tests {
     #[test]
     fn gcs_scheme_aliases_are_compatible() {
         for scheme in ["gcs", "GCS", "gs", "GS"] {
-            assert!(matches!(build(scheme), Storage::Gcs { .. }), "{scheme}");
+            let storage = build(scheme);
+            assert!(matches!(&storage, Storage::Gcs { .. }), "{scheme}");
+            assert!(!storage.supports_cheap_range_reads(), "{scheme}");
         }
     }
 
@@ -631,6 +639,14 @@ mod tests {
         assert_eq!(relative, "warehouse/db/table");
         let (_, relative) = storage.create("file:/warehouse/db/table").unwrap();
         assert_eq!(relative, "warehouse/db/table");
+    }
+
+    #[test]
+    fn custom_fs_operator_does_not_assume_cheap_range_reads() {
+        let storage = Storage::CustomFs {
+            op: memory_operator(),
+        };
+        assert!(!storage.supports_cheap_range_reads());
     }
 
     /// A scheme'd path would be silently mangled by the filesystem rules


### PR DESCRIPTION
### Purpose

Linked issue: close #687

Use an explicit range-read capability to choose the Parquet metadata loading strategy:

- Built-in HDFS, local filesystem, and memory readers use the seek-based path: read the 8-byte footer first, then fetch the exact footer metadata and requested page-index ranges.
- Object-store readers and caller-provided filesystem operators retain the 512 KiB suffix prefetch by default, avoiding additional serialized network round trips when their range-read cost is unknown.

OpenDAL's HDFS native service keeps a file-scoped positioned-read handle, so exact range reads reuse the same underlying HDFS file reader. The capability is determined in the IO/storage layer and propagated through `InputFileReader`; the Parquet layer does not infer the backend from URI strings. Custom `FileRead` implementations may explicitly opt in, while the default remains conservative.

### Performance validation

A local HDFS comparison showed better read performance with exact range reads than with the fixed 512 KiB prefetch. Object stores and caller-provided filesystem operators have not been benchmarked, so this change deliberately preserves their existing prefetch behavior rather than assuming the HDFS result transfers to them.

This PR remains Draft until the reproducible HDFS measurements are added. The benchmark record should include the same dataset/query for both variants, file count, representative footer-metadata sizes, repeated wall-clock results, and bytes-read or request counts when available; #687 tracks that evidence.

### Brief change log

- Add a defaulted `FileRead::supports_cheap_range_reads` capability with a conservative `false` default.
- Enable exact metadata/page-index reads for built-in HDFS, local filesystem, and memory backends.
- Keep the fixed 512 KiB metadata prefetch for OSS, S3, COS, AzDLS, OBS, GCS, caller-provided filesystem operators, and other readers that do not explicitly opt in.
- Avoid requesting `OffsetIndex` solely because an external row selection is present but empty.
- Add range-tracking tests for both exact-read and prefetch paths.
- Add storage classification and `FileRead` capability-propagation tests.

### Tests

- `cargo fmt --all -- --check`
- `cargo test --locked -p paimon --lib arrow::format::parquet::tests` (49 passed)
- `cargo test --locked -p paimon --lib scheme_tests --features storage-all` (10 passed)
- `cargo test --locked -p paimon --lib custom_fs_operator --features storage-all` (3 passed)
- Targeted memory and caller-provided filesystem capability-propagation tests passed.
- `cargo clippy --locked --all-targets --workspace --features fulltext,vortex -- -D warnings`
- `git diff --check`

### API and Format

Adds a defaulted `FileRead::supports_cheap_range_reads` method. Existing implementations do not need to implement the new method; they receive the conservative `false` behavior. No storage-format changes.

### Documentation

No user-facing documentation changes required. Benchmark evidence is tracked in #687 before the PR is marked ready.
