### PR TITLE
docs: fix Go predicate usage comments and document with_row_ranges

### DIFF
--- a/bindings/go/predicate.go
+++ b/bindings/go/predicate.go
@@ -105,22 +105,22 @@ func StringDatum(v string) Datum {
 }
 
 // Date represents a date value as epoch days since 1970-01-01.
-// Usage: table.PredicateEqual("dt", paimon.Date(19000))
+// Usage: pb.Eq("dt", paimon.Date(19000))
 type Date int32
 
 // Time represents a time-of-day value as milliseconds since midnight.
-// Usage: table.PredicateEqual("t", paimon.Time(3600000))
+// Usage: pb.Eq("t", paimon.Time(3600000))
 type Time int32
 
 // Timestamp represents a timestamp without timezone (millis + sub-millis nanos).
-// Usage: table.PredicateEqual("ts", paimon.Timestamp{Millis: 1700000000000, Nanos: 0})
+// Usage: pb.Eq("ts", paimon.Timestamp{Millis: 1700000000000, Nanos: 0})
 type Timestamp struct {
 	Millis int64
 	Nanos  int32
 }
 
 // LocalZonedTimestamp represents a timestamp with local timezone semantics.
-// Usage: table.PredicateEqual("lzts", paimon.LocalZonedTimestamp{Millis: 1700000000000, Nanos: 0})
+// Usage: pb.Eq("lzts", paimon.LocalZonedTimestamp{Millis: 1700000000000, Nanos: 0})
 type LocalZonedTimestamp struct {
 	Millis int64
 	Nanos  int32
@@ -155,7 +155,7 @@ func NewDecimal(unscaled int64, precision, scale uint32) Decimal {
 }
 
 // Bytes represents a binary value.
-// Usage: table.PredicateEqual("data", paimon.Bytes(someSlice))
+// Usage: pb.Eq("data", paimon.Bytes(someSlice))
 type Bytes []byte
 
 // toDatum converts a Go value to a Datum for predicate comparison.

--- a/docs/src/python-binding.md
+++ b/docs/src/python-binding.md
@@ -229,6 +229,18 @@ rb.with_limit(100)
 !!! warning
     `with_limit` is a scan-planning hint, not an exact row cap. When all rows fall within a single split, the entire split is returned regardless of the limit value. Callers should apply application-level limiting if an exact upper bound is required.
 
+## Row Ranges
+
+Use `with_row_ranges` to restrict a Data Evolution scan to inclusive row ID ranges. Each range is a `(from, to)` tuple; `from` must not exceed `to`.
+
+```python
+rb = table.new_read_builder()
+rb.with_row_ranges([(0, 99), (200, 299)])
+```
+
+!!! warning
+    An empty list selects **zero** rows, not all rows. Format tables are not supported and raise `NotImplementedError`.
+
 ## Case Sensitivity
 
 Use `with_case_sensitive` to control whether column-name matching in projections and predicates is case-sensitive. Defaults to `True` (exact match). Set to `False` for case-insensitive matching (ASCII case-folding).


### PR DESCRIPTION
Five Go doc comments in `predicate.go` show `table.PredicateEqual("dt", ...)` as the usage
example, but no such method exists — the API is `PredicateBuilder.Eq`. `ffiPredicateEqual`
is an internal FFI symbol name, not a public method, so anyone copying these lines gets a
compile error.

`ReadBuilder.with_row_ranges` has been exposed to Python since #674, with a stub entry and
tests, but never made it into `python-binding.md` — every sibling method (projection, limit,
case sensitivity, filter push-down) has its own section. The new section records the two
behaviors a caller cannot guess: an empty list selects **zero** rows rather than all, and
format tables are rejected.

Comments and docs only.
