### PR TITLE
fix(arrow): list every writable format in the write-format error

### DIFF
--- a/crates/paimon/src/arrow/format/mod.rs
+++ b/crates/paimon/src/arrow/format/mod.rs
@@ -230,6 +230,16 @@ fn supported_read_formats() -> Vec<&'static str> {
     ]
 }
 
+fn supported_write_formats() -> Vec<&'static str> {
+    vec![
+        ".parquet",
+        ".blob",
+        ".row",
+        #[cfg(feature = "vortex")]
+        ".vortex",
+    ]
+}
+
 /// Create a format writer that streams directly to storage.
 pub(crate) async fn create_format_writer(
     output: &OutputFile,
@@ -277,7 +287,39 @@ pub(crate) async fn create_format_writer(
             ));
         }
         Err(Error::Unsupported {
-            message: format!("unsupported write format: expected .parquet, .row, got: {path}"),
+            message: format!(
+                "unsupported write format: expected {}, got: {path}",
+                supported_write_formats().join(", ")
+            ),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::FileIOBuilder;
+
+    #[tokio::test]
+    async fn create_format_writer_error_lists_every_supported_format() {
+        let file_io = FileIOBuilder::new("memory").build().unwrap();
+        let output = file_io.new_output("memory:/unsupported/data.csv").unwrap();
+        let schema = Arc::new(arrow_schema::Schema::empty());
+
+        let err = match create_format_writer(&output, schema, "zstd", 1, None, None, None).await {
+            Ok(_) => panic!("csv is not a writable format"),
+            Err(err) => err,
+        };
+
+        let Error::Unsupported { message } = err else {
+            panic!("expected Unsupported, got {err:?}");
+        };
+        for format in supported_write_formats() {
+            assert!(
+                message.contains(format),
+                "{format} missing from write-format error: {message}"
+            );
+        }
+        assert!(message.contains("data.csv"), "message: {message}");
     }
 }


### PR DESCRIPTION
`create_format_writer` says `expected .parquet, .row` when it rejects a path, but the same
function also dispatches `.blob` and, under the `vortex` feature, `.vortex`. A caller
passing an unsupported extension is told two of the four accepted ones.

**Fix**: derive the message from a `supported_write_formats()` list, mirroring the read
side, which already builds its error from `supported_read_formats()`. The list carries the
same `#[cfg(feature = "vortex")]` gate as the dispatch arm, so the message stays accurate
in both builds.

The new test asserts every entry of that list appears in the message, so a future writer
arm cannot drift from it again. It fails on the old literal.
