### PR TITLE
fix(arrow): enforce exact Mosaic predicate filtering

### DIFF
--- a/crates/integrations/datafusion/tests/mosaic_tables.rs
+++ b/crates/integrations/datafusion/tests/mosaic_tables.rs
@@ -24,6 +24,9 @@ use std::sync::Arc;
 
 use datafusion::arrow::array::{Int32Array, Int64Array};
 use datafusion::arrow::record_batch::RecordBatch;
+use futures::TryStreamExt;
+use paimon::catalog::Identifier;
+use paimon::spec::{Datum, PredicateBuilder};
 use paimon::{Catalog, CatalogOptions, FileSystemCatalog, Options};
 use paimon_datafusion::SQLContext;
 
@@ -182,4 +185,39 @@ async fn test_read_pypaimon_mosaic_fixture() {
         .await,
     );
     assert_eq!(filtered_rows, vec![(2, "Bob".to_string(), 20)]);
+}
+
+#[tokio::test]
+async fn test_direct_core_read_applies_mosaic_filter_exactly() {
+    let (_tmp, warehouse) = extract_test_warehouse();
+    let mut options = Options::new();
+    options.set(CatalogOptions::WAREHOUSE, warehouse);
+    let catalog = FileSystemCatalog::new(options).expect("Failed to create catalog");
+    let table = catalog
+        .get_table(&Identifier::new("default", FIXTURE_TABLE))
+        .await
+        .expect("Failed to load Mosaic fixture table");
+
+    let plan = table
+        .new_read_builder()
+        .new_scan()
+        .plan()
+        .await
+        .expect("Failed to plan Mosaic fixture scan");
+    let predicate = PredicateBuilder::new(table.schema().fields())
+        .equal("id", Datum::Int(2))
+        .expect("Failed to build id predicate");
+    let read = paimon::table::TableRead::new(&table, table.schema().fields().to_vec(), Vec::new())
+        .with_filter(predicate);
+    let batches = read
+        .to_arrow(plan.splits())
+        .expect("Failed to create direct core stream")
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("Failed to read Mosaic fixture directly");
+
+    assert_eq!(
+        collect_id_name_score(&batches),
+        vec![(2, "Bob".to_string(), 20)]
+    );
 }

--- a/crates/paimon/src/arrow/format/mod.rs
+++ b/crates/paimon/src/arrow/format/mod.rs
@@ -68,12 +68,11 @@ pub(crate) trait FormatFileReader: Send + Sync {
     /// requested output by name, so extra columns are harmless.
     ///
     /// Predicate exactness is per-format, NOT a blanket guarantee:
-    /// - Parquet, ORC, Avro, Row, and Vortex apply the predicate **exactly** —
+    /// - Parquet, ORC, Avro, Row, Mosaic, and Vortex apply the predicate **exactly** —
     ///   each emitted batch contains only rows matching the pushed-down predicate
     ///   (native pushdown for pruning + a row-level residual pass for the rest).
-    /// - Blob does not evaluate predicates at all; Mosaic applies only
-    ///   stats-level (row-group) pruning. For those, non-matching rows may
-    ///   survive and the caller must not assume exactness.
+    /// - Blob does not evaluate predicates at all. Non-matching rows may survive,
+    ///   and the caller must not assume exactness.
     /// `row_selection` is a pre-merged list of 0-based inclusive row ranges
     /// (DV + row_ranges already combined by the caller).
     async fn read_batch_stream(

--- a/crates/paimon/src/arrow/format/mosaic.rs
+++ b/crates/paimon/src/arrow/format/mosaic.rs
@@ -17,7 +17,10 @@
 
 use super::{FilePredicates, FormatFileReader};
 use crate::arrow::build_target_arrow_schema;
-use crate::arrow::filtering::{predicates_may_match_with_schema, StatsAccessor};
+use crate::arrow::filtering::{
+    predicates_may_match_with_schema, remap_predicates_to_file, StatsAccessor,
+};
+use crate::arrow::residual::{filter_record_batch_by_predicates, widen_scan_fields};
 use crate::io::FileRead;
 use crate::spec::{DataField, DataType as PaimonDataType, Datum, Predicate};
 use crate::table::{ArrowRecordBatchStream, RowRange};
@@ -129,26 +132,36 @@ fn read_mosaic_batches_blocking(
         .iter()
         .map(|column| column.name.as_str())
         .collect::<HashSet<_>>();
-    let existing_read_fields = read_fields
+    // Residual filtering needs every predicate column, including columns that
+    // are not part of the requested projection. DataFileReader drops extras by
+    // name after this format reader returns.
+    let scan_fields = widen_scan_fields(&read_fields, predicates.as_ref());
+    let existing_scan_fields = scan_fields
         .iter()
         .filter(|field| file_column_names.contains(field.name()))
         .cloned()
         .collect::<Vec<_>>();
-    let read_schema = build_target_arrow_schema(&existing_read_fields)?;
+    // A Mosaic file may physically omit columns still declared by its logical
+    // schema. Remap against the columns actually scanned so missing predicate
+    // columns use the existing all-NULL semantics before stats and residuals.
+    let predicates = predicates.map(|predicates| FilePredicates {
+        predicates: remap_predicates_to_file(
+            &predicates.predicates,
+            &predicates.file_fields,
+            &existing_scan_fields,
+        ),
+        row_filter_factory: None,
+        file_fields: existing_scan_fields.clone(),
+    });
+    let read_schema = build_target_arrow_schema(&existing_scan_fields)?;
     validate_mosaic_schema(&read_schema)?;
-    let projected_names = existing_read_fields
+    let projected_names = existing_scan_fields
         .iter()
         .map(|field| field.name().to_string())
         .collect::<Vec<_>>();
-    let all_projected_columns_missing = !read_fields.is_empty() && projected_names.is_empty();
-    let predicate_state = predicates.map(|predicates| {
-        let file_column_indices =
-            build_file_column_indices(mosaic_reader.schema(), &predicates.file_fields);
-        (
-            predicates.predicates,
-            predicates.file_fields,
-            file_column_indices,
-        )
+    let all_scan_columns_missing = !scan_fields.is_empty() && projected_names.is_empty();
+    let predicate_column_indices = predicates.as_ref().map(|predicates| {
+        build_file_column_indices(mosaic_reader.schema(), &predicates.file_fields)
     });
 
     let mut row_group_start = 0usize;
@@ -175,7 +188,9 @@ fn read_mosaic_batches_blocking(
             }
         }
 
-        if let Some((predicates, file_fields, file_column_indices)) = &predicate_state {
+        if let (Some(predicates), Some(file_column_indices)) =
+            (predicates.as_ref(), predicate_column_indices.as_ref())
+        {
             let row_group_stats = mosaic_reader
                 .row_group_stats(row_group_index)
                 .map_err(mosaic_read_error)?;
@@ -183,14 +198,14 @@ fn read_mosaic_batches_blocking(
                 row_group_rows,
                 row_group_stats,
                 file_column_indices,
-                predicates,
-                file_fields,
+                &predicates.predicates,
+                &predicates.file_fields,
             )? {
                 continue;
             }
         }
 
-        let batch = if all_projected_columns_missing {
+        let batch = if all_scan_columns_missing {
             let row_count = selected_slices
                 .as_ref()
                 .map_or(row_group_rows, |slices| selected_row_count(slices));
@@ -206,6 +221,12 @@ fn read_mosaic_batches_blocking(
 
             let batch = row_group_reader.read_columns().map_err(mosaic_read_error)?;
             take_row_slices(batch, selected_slices.as_deref(), &read_schema)?
+        };
+        let batch = match predicates.as_ref() {
+            Some(predicates) => {
+                filter_record_batch_by_predicates(batch, predicates, &existing_scan_fields)?
+            }
+            None => batch,
         };
         for chunk in split_batch(batch, batch_size) {
             if !send_batch(chunk) {
@@ -1112,7 +1133,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_read_predicate_prunes_non_matching_row_groups() {
+    async fn test_read_predicate_prunes_and_filters_row_groups() {
         let fields = data_fields();
         let builder = PredicateBuilder::new(&fields);
         let predicates = predicate_file_predicates(
@@ -1124,7 +1145,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(collect_i32_column(&batches, 0), vec![10, 11]);
+        assert_eq!(collect_i32_column(&batches, 0), vec![10]);
     }
 
     #[tokio::test]
@@ -1144,7 +1165,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_read_predicate_missing_stats_fails_open() {
+    async fn test_read_predicate_missing_stats_still_filters_rows() {
         let fields = data_fields();
         let builder = PredicateBuilder::new(&fields);
         let predicates = predicate_file_predicates(
@@ -1156,7 +1177,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(collect_i32_column(&batches, 0), vec![1, 2, 10, 11, 20, 21]);
+        assert!(collect_i32_column(&batches, 0).is_empty());
     }
 
     #[tokio::test]
@@ -1194,7 +1215,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(collect_i32_column(&batches, 0), vec![30, 40]);
+        assert_eq!(collect_i32_column(&batches, 0), vec![30]);
     }
 
     #[tokio::test]
@@ -1244,13 +1265,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_read_predicate_missing_column_false_prunes_all_row_groups() {
-        let fields = data_fields();
-        let predicates = predicate_file_predicates(fields.clone(), vec![Predicate::AlwaysFalse]);
-        let projected = vec![
-            fields[0].clone(),
-            field(3, "new_score", DataType::Int(IntType::with_nullable(true))),
-        ];
+    async fn test_read_predicate_missing_column_comparison_prunes_all_row_groups() {
+        let mut fields = data_fields();
+        let missing_field = field(3, "new_score", DataType::Int(IntType::with_nullable(true)));
+        fields.push(missing_field.clone());
+        let predicate = PredicateBuilder::new(&fields)
+            .equal("new_score", Datum::Int(1))
+            .unwrap();
+        let predicates = predicate_file_predicates(fields.clone(), vec![predicate]);
+        let projected = vec![fields[0].clone(), missing_field];
         let data = multi_row_group_mosaic(vec!["id".to_string()]);
         let batches = read_batches_with_predicates(data, &projected, Some(&predicates), None)
             .await
@@ -1261,12 +1284,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_predicate_missing_column_is_null_keeps_row_groups() {
-        let fields = data_fields();
-        let predicates = predicate_file_predicates(fields.clone(), vec![Predicate::AlwaysTrue]);
-        let projected = vec![
-            fields[0].clone(),
-            field(3, "new_score", DataType::Int(IntType::with_nullable(true))),
-        ];
+        let mut fields = data_fields();
+        let missing_field = field(3, "new_score", DataType::Int(IntType::with_nullable(true)));
+        fields.push(missing_field.clone());
+        let predicate = PredicateBuilder::new(&fields).is_null("new_score").unwrap();
+        let predicates = predicate_file_predicates(fields.clone(), vec![predicate]);
+        let projected = vec![fields[0].clone(), missing_field];
         let data = multi_row_group_mosaic(vec!["id".to_string()]);
         let batches = read_batches_with_predicates(data, &projected, Some(&predicates), None)
             .await

--- a/crates/paimon/src/table/data_file_reader.rs
+++ b/crates/paimon/src/table/data_file_reader.rs
@@ -1804,8 +1804,8 @@ mod tests {
         assert_eq!(ids, vec![1, 2, 3, 4]);
     }
 
-    /// Row-group predicate pruning, deletion vectors and projection must compose correctly:
-    /// the predicate keeps one row group, the DV deletes one of its rows, projection keeps `id`.
+    /// Exact predicate filtering, deletion vectors and projection must compose correctly:
+    /// the predicate selects `id = 10`, the DV deletes that row, and no rows remain.
     #[tokio::test]
     async fn test_mosaic_predicate_dv_projection_combination() {
         let fields = pk_fields();
@@ -1869,7 +1869,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(batches.iter().map(|b| b.num_columns()).max(), Some(1));
-        assert_eq!(collect_ids(&batches), vec![11]);
+        assert!(collect_ids(&batches).is_empty());
     }
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Mosaic only used row-group statistics for predicate pushdown, so core reads could return non-matching rows. Residual evaluation could also panic or fail open when predicates referenced physically missing columns.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - Apply shared row-level residual filtering after Mosaic row-group pruning.
  - Include non-projected predicate columns in the scan.
  - Remap predicates against physical columns so missing columns follow NULL semantics.
  - Add regression coverage for missing columns, projection, deletion vectors, and direct core reads.

### Tests

<!-- List unit tests or integration cases to verify this change -->

  - `cargo fmt --all -- --check`
  - `cargo clippy --locked --all-targets --workspace --features fulltext,vortex -- -D warnings`
  - `cargo test --locked -p paimon --all-targets --features fulltext,vortex`
  - `cargo test --locked -p paimon-datafusion --test mosaic_tables`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
