### PR TITLE
fix(table): reject row ranges for format tables at read construction

### DIFF
--- a/crates/paimon/src/table/format_read_builder.rs
+++ b/crates/paimon/src/table/format_read_builder.rs
@@ -127,6 +127,13 @@ impl<'a> FormatReadBuilder<'a> {
     }
 
     pub(crate) fn new_read(&self) -> Result<TableRead<'a>> {
+        // Fail closed here as well as in `FormatTableScan::plan`, so a caller that
+        // goes straight to `new_read` cannot silently read unfiltered rows.
+        if self.row_ranges.is_some() {
+            return Err(crate::Error::Unsupported {
+                message: "Row ranges are not supported for format tables".to_string(),
+            });
+        }
         let core_options = self.table.schema().core_options();
         core_options.ensure_read_authorized()?;
         let read_type = match self.resolve_read_type()? {

--- a/crates/paimon/src/table/read_builder.rs
+++ b/crates/paimon/src/table/read_builder.rs
@@ -819,6 +819,15 @@ mod tests {
         assert!(
             matches!(error, crate::Error::Unsupported { ref message } if message.contains("format tables"))
         );
+
+        // `new_read` must reject too: a caller that skips planning would otherwise
+        // read every row instead of the requested ranges.
+        let mut builder = table.new_read_builder();
+        builder.with_row_ranges(Vec::new());
+        let error = builder.new_read().unwrap_err();
+        assert!(
+            matches!(error, crate::Error::Unsupported { ref message } if message.contains("format tables"))
+        );
     }
 
     fn dv_pk_table(table_path: &str, merge_engine: &str) -> Table {


### PR DESCRIPTION
`FormatTableScan::plan` rejects row ranges, but `FormatReadBuilder::new_read` never reads
`self.row_ranges`, so `with_row_ranges(..).new_read()` on a format table silently ignores the
request instead of reporting it. Reachable from core Rust callers, which reach
`FormatReadBuilder` through `ReadBuilder::new_read`.

**Fix**: fail closed in `new_read` too, matching `ReadBuilder::new_read`, which guards the
same way for the same reason.
