### PR TITLE
docs: correct five system-table column descriptions

### DIFF
--- a/docs/src/sql.md
+++ b/docs/src/sql.md
@@ -1729,8 +1729,8 @@ Columns:
 | `schema_id` | BIGINT | Schema ID |
 | `commit_time` | TIMESTAMP | Commit time |
 | `record_count` | BIGINT | Record count |
-| `create_time` | TIMESTAMP | Tag creation time |
-| `time_retained` | STRING | Retention duration |
+| `create_time` | TIMESTAMP | Always `NULL`: the Rust snapshot does not carry a tag creation time |
+| `time_retained` | STRING | Always `NULL`: the Rust snapshot does not carry a tag retention |
 
 ### $branches
 
@@ -1823,8 +1823,8 @@ Columns:
 | `file_count` | BIGINT | Number of data files |
 | `last_update_time` | TIMESTAMP | Latest data-file creation time |
 | `created_at` | TIMESTAMP | Partition creation time (only available with metastore-tracked catalogs) |
-| `created_by` | STRING | Snapshot id that created the partition (catalog-tracked only) |
-| `updated_by` | STRING | Snapshot id that last updated the partition (catalog-tracked only) |
+| `created_by` | STRING | User who created the partition (catalog-tracked only) |
+| `updated_by` | STRING | User who last updated the partition (catalog-tracked only) |
 | `options` | STRING | Per-partition options as flat JSON (catalog-tracked only) |
 | `total_buckets` | INT | Total bucket count for the partition (0 unless catalog-tracked) |
 | `done` | BOOLEAN | Whether the partition is marked done (false unless catalog-tracked) |
@@ -1842,7 +1842,7 @@ Columns:
 
 | Column | Type | Description |
 |---|---|---|
-| `partition` | STRING | Partition spec for the indexed data, or `NULL` for unpartitioned tables |
+| `partition` | STRING | Partition spec for the indexed data, formatted as a Java row cast string; `{}` for unpartitioned tables |
 | `bucket` | INT | Bucket id covered by the index file |
 | `index_type` | STRING | Index type, such as `btree`, `bitmap`, `ivf-flat`, `lumina`, or `DELETION_VECTORS` |
 | `file_name` | STRING | Index file name under the table index directory |
@@ -1862,7 +1862,7 @@ Files are classified by their table-relative path:
 - `manifest/manifest-*`, `manifest/manifest-list-*`, and `manifest/index-manifest-*` → manifest
 - `statistics/*` → manifest file counters for the current compatible output schema
 - `index/*` → index
-- `<partition>/bucket-*/*` and `<partition>/bucket-postpone/*` → data, using the table's partition depth
+- `<partition>/bucket-*/*` and `<partition>/bucket-postpone/*` → data, using the table's partition depth, except names starting with `index-`
 - unknown files are ignored by this summary
 
 ```sql


### PR DESCRIPTION
Five system-table column descriptions do not match what the code returns:

- `$tags.create_time` / `.time_retained` are documented as carrying data, but `tags.rs:117`
  fills both with `new_null_array` — the Rust snapshot has no tag creation time or retention.
- `$partitions.created_by` / `updated_by` are documented as snapshot ids; they are the audit
  user (`spec/partition.rs:40`).
- `$table_indexes.partition` is documented as `NULL` for unpartitioned tables; it is `"{}"`.
- `$physical_files_size` counts everything under a bucket directory as data, but
  `referenced_files.rs:677` excludes names starting with `index-`.

The `$table_indexes` one is the same mistake QuakeWang caught for `$files` in #669.
