### PR TITLE
perf(parquet): prune IN predicates with page stats

### DIFF
--- a/crates/paimon/src/arrow/format/parquet.rs
+++ b/crates/paimon/src/arrow/format/parquet.rs
@@ -1395,6 +1395,10 @@ impl StatsAccessor for ParquetPageStats<'_> {
         }
         page_index_value_to_datum(self.column_index, self.page_idx, data_type, false)
     }
+
+    fn supports_in_min_max_pruning(&self) -> bool {
+        true
+    }
 }
 
 /// Decode a per-page min/max from a [`ColumnIndexMetaData`] into a [`Datum`].
@@ -3484,6 +3488,22 @@ mod tests {
             .unwrap()
             .expect("all pages should be skipped");
         assert_eq!(sel.row_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_page_selection_in_keeps_only_matching_page() {
+        let bytes = write_multi_page_parquet(10, 80).await;
+        let metadata = load_metadata_with_page_index(&bytes, true);
+        let fields = vec![int_field("id"), int_field("value")];
+
+        let predicates = vec![id_leaf(
+            PredicateOperator::In,
+            vec![Datum::Int(35), Datum::Int(1000)],
+        )];
+        let sel = super::build_predicate_page_selection(&metadata, &predicates, &fields)
+            .unwrap()
+            .expect("non-matching pages should be skipped");
+        assert_eq!(sel.row_count(), 10);
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Parquet page pruning reused the shared statistics evaluator, but `ParquetPageStats` did not enable min/max pruning for `IN`. As a result, page indexes were loaded for `IN` predicates while non-matching pages were still retained.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - Enable min/max pruning for `IN` predicates using Parquet page statistics.
  - Add a multi-page regression test verifying that only the matching page is retained.

### Tests

<!-- List unit tests or integration cases to verify this change -->

  - `cargo check`
  - `cargo fmt --all -- --check`
  - `cargo build`
  - `cargo clippy --locked --all-targets --workspace --features fulltext,vortex -- -D warnings`
  - `cargo test -p paimon --all-targets --features fulltext,vortex`
  - `cargo test -p paimon-rest-server --all-targets`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->
