### PR TITLE
fix(vindex): avoid full index reads during refine

### DIFF
--- a/crates/paimon/src/table/vector_search_builder.rs
+++ b/crates/paimon/src/table/vector_search_builder.rs
@@ -17,7 +17,7 @@
 
 use crate::arrow::format::FilePredicates;
 use crate::arrow::residual::{evaluate_predicates_mask, widen_scan_fields};
-use crate::io::FileIO;
+use crate::io::{FileIO, FileRead};
 use crate::lumina::reader::LuminaVectorGlobalIndexReader;
 use crate::lumina::{
     is_lumina_index_type, LuminaIndexMeta, LuminaVectorIndexOptions, LuminaVectorMetric,
@@ -64,6 +64,7 @@ use crate::vindex::{is_vindex_index_type, VindexVectorIndexOptions};
 use arrow_array::{Array, FixedSizeListArray, Float32Array, Int64Array, ListArray, RecordBatch};
 use arrow_select::interleave::interleave_record_batch;
 use futures::{stream, TryStreamExt};
+use paimon_vindex_core::diskann_io::DISKANN_HEADER_SIZE;
 use paimon_vindex_core::distance::MetricType;
 use paimon_vindex_core::index::VectorIndexReader as VIndexReader;
 use paimon_vindex_core::io::SeekRead;
@@ -2534,16 +2535,39 @@ async fn resolve_raw_vector_metric(
                 }
             }
             VectorIndexBackend::Vindex => {
+                if let Some(index_meta) = global_meta.index_meta.as_ref() {
+                    if let Ok(options) =
+                        serde_json::from_slice::<HashMap<String, String>>(index_meta)
+                    {
+                        if let Some(metric) = options.get("metric") {
+                            return RawVectorMetric::parse(metric);
+                        }
+                    }
+                }
                 let path = format!("{table_path}/{INDEX_DIR}/{}", entry.index_file.file_name);
                 let input = file_io.new_input(&path)?;
-                let bytes = input.read().await.map_err(|e| crate::Error::DataInvalid {
-                    message: format!(
-                        "Failed to read vindex index file '{}' for raw search metric: {}",
-                        entry.index_file.file_name, e
-                    ),
-                    source: None,
+                let file_reader = input
+                    .reader()
+                    .await
+                    .map_err(|e| crate::Error::DataInvalid {
+                        message: format!(
+                            "Failed to read vindex index file '{}' for raw search metric: {}",
+                            entry.index_file.file_name, e
+                        ),
+                        source: Some(Box::new(e)),
+                    })?;
+                let header_size =
+                    (entry.index_file.file_size as u64).min(DISKANN_HEADER_SIZE as u64);
+                let bytes = file_reader.read(0..header_size).await.map_err(|e| {
+                    crate::Error::DataInvalid {
+                        message: format!(
+                            "Failed to read vindex index file '{}' for raw search metric: {}",
+                            entry.index_file.file_name, e
+                        ),
+                        source: Some(Box::new(e)),
+                    }
                 })?;
-                let reader = VIndexReader::open(Cursor::new(bytes.to_vec())).map_err(|e| {
+                let reader = VIndexReader::open(Cursor::new(bytes)).map_err(|e| {
                     crate::Error::DataInvalid {
                         message: format!(
                             "Failed to open paimon-vindex-core reader for raw search metric: {}",
@@ -3165,6 +3189,69 @@ mod tests {
             configured_raw_vector_metric(&options, "embedding").unwrap(),
             RawVectorMetric::L2
         );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_raw_vector_metric_uses_vindex_manifest_metadata() {
+        let file_io = FileIOBuilder::new("memory").build().unwrap();
+        let mut entry = make_lumina_entry("missing.idx", IVF_FLAT_IDENTIFIER, FileKind::Add, 2);
+        let index_meta = serde_json::to_vec(&HashMap::from([(
+            "metric".to_string(),
+            "cosine".to_string(),
+        )]))
+        .unwrap();
+        entry
+            .index_file
+            .global_index_meta
+            .as_mut()
+            .unwrap()
+            .index_meta = Some(index_meta);
+
+        let metric = resolve_raw_vector_metric(
+            &file_io,
+            "memory:///test_table",
+            &HashMap::new(),
+            &[entry],
+            2,
+            "embedding",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(metric, RawVectorMetric::Cosine);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_raw_vector_metric_reads_vindex_header_for_legacy_metadata() {
+        let file_io = FileIOBuilder::new("memory").build().unwrap();
+        let index = build_vindex_segment_bytes("inner_product");
+        file_io
+            .new_output("memory:///test_table/index/test.idx")
+            .unwrap()
+            .write(bytes::Bytes::from(index.clone()))
+            .await
+            .unwrap();
+        let mut entry = make_lumina_entry("test.idx", IVF_FLAT_IDENTIFIER, FileKind::Add, 2);
+        entry.index_file.file_size = index.len() as i64;
+        entry
+            .index_file
+            .global_index_meta
+            .as_mut()
+            .unwrap()
+            .index_meta = Some(b"{}".to_vec());
+
+        let metric = resolve_raw_vector_metric(
+            &file_io,
+            "memory:///test_table",
+            &HashMap::new(),
+            &[entry],
+            2,
+            "embedding",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(metric, RawVectorMetric::InnerProduct);
     }
 
     #[test]

--- a/crates/paimon/src/table/vector_search_builder.rs
+++ b/crates/paimon/src/table/vector_search_builder.rs
@@ -2540,33 +2540,35 @@ async fn resolve_raw_vector_metric(
                         serde_json::from_slice::<HashMap<String, String>>(index_meta)
                     {
                         if let Some(metric) = options.get("metric") {
-                            return RawVectorMetric::parse(metric);
+                            if let Some(metric) =
+                                RawVectorMetric::parse_normalized(&normalize_metric(metric))
+                            {
+                                return Ok(metric);
+                            }
                         }
                     }
                 }
                 let path = format!("{table_path}/{INDEX_DIR}/{}", entry.index_file.file_name);
                 let input = file_io.new_input(&path)?;
-                let file_reader = input
-                    .reader()
-                    .await
-                    .map_err(|e| crate::Error::DataInvalid {
-                        message: format!(
-                            "Failed to read vindex index file '{}' for raw search metric: {}",
-                            entry.index_file.file_name, e
-                        ),
-                        source: Some(Box::new(e)),
-                    })?;
-                let header_size =
-                    (entry.index_file.file_size as u64).min(DISKANN_HEADER_SIZE as u64);
-                let bytes = file_reader.read(0..header_size).await.map_err(|e| {
-                    crate::Error::DataInvalid {
-                        message: format!(
-                            "Failed to read vindex index file '{}' for raw search metric: {}",
-                            entry.index_file.file_name, e
-                        ),
-                        source: Some(Box::new(e)),
-                    }
-                })?;
+                let read_error = |e| crate::Error::DataInvalid {
+                    message: format!(
+                        "Failed to read vindex index file '{}' for raw search metric: {}",
+                        entry.index_file.file_name, e
+                    ),
+                    source: Some(Box::new(e)),
+                };
+                let header_size = if entry.index_file.file_size > 0 {
+                    (entry.index_file.file_size as u64).min(DISKANN_HEADER_SIZE as u64)
+                } else {
+                    input
+                        .metadata()
+                        .await
+                        .map_err(&read_error)?
+                        .size
+                        .min(DISKANN_HEADER_SIZE as u64)
+                };
+                let file_reader = input.reader().await.map_err(&read_error)?;
+                let bytes = file_reader.read(0..header_size).await.map_err(read_error)?;
                 let reader = VIndexReader::open(Cursor::new(bytes)).map_err(|e| {
                     crate::Error::DataInvalid {
                         message: format!(
@@ -3222,7 +3224,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_resolve_raw_vector_metric_reads_vindex_header_for_legacy_metadata() {
+    async fn test_resolve_raw_vector_metric_falls_back_to_vindex_header() {
         let file_io = FileIOBuilder::new("memory").build().unwrap();
         let index = build_vindex_segment_bytes("inner_product");
         file_io
@@ -3231,27 +3233,33 @@ mod tests {
             .write(bytes::Bytes::from(index.clone()))
             .await
             .unwrap();
-        let mut entry = make_lumina_entry("test.idx", IVF_FLAT_IDENTIFIER, FileKind::Add, 2);
-        entry.index_file.file_size = index.len() as i64;
-        entry
-            .index_file
-            .global_index_meta
-            .as_mut()
-            .unwrap()
-            .index_meta = Some(b"{}".to_vec());
+        for (file_size, index_meta) in [
+            (index.len() as i64, br#"{"metric":"euclidean"}"#.to_vec()),
+            (0, b"{}".to_vec()),
+            (-1, b"{}".to_vec()),
+        ] {
+            let mut entry = make_lumina_entry("test.idx", IVF_FLAT_IDENTIFIER, FileKind::Add, 2);
+            entry.index_file.file_size = file_size;
+            entry
+                .index_file
+                .global_index_meta
+                .as_mut()
+                .unwrap()
+                .index_meta = Some(index_meta);
 
-        let metric = resolve_raw_vector_metric(
-            &file_io,
-            "memory:///test_table",
-            &HashMap::new(),
-            &[entry],
-            2,
-            "embedding",
-        )
-        .await
-        .unwrap();
+            let metric = resolve_raw_vector_metric(
+                &file_io,
+                "memory:///test_table",
+                &HashMap::new(),
+                &[entry],
+                2,
+                "embedding",
+            )
+            .await
+            .unwrap();
 
-        assert_eq!(metric, RawVectorMetric::InnerProduct);
+            assert_eq!(metric, RawVectorMetric::InnerProduct);
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Purpose

During vector refine and raw reranking, resolve_raw_vector_metric read the entire Vindex file only to obtain the metric. For a 1.95 GB index, this still reconstructed the full file from local-cache blocks and copied it again, making refine slow even on a cache hit.

### Brief change log

- Resolve the Vindex metric directly from global-index manifest metadata when the metric is present.
- Keep compatibility with Java and legacy indexes whose metadata is empty by range-reading at most the 256-byte Vindex header.
- Pass the returned Bytes directly to the Vindex reader, removing the additional to_vec copy.
- Preserve the underlying error source for header reader failures.

### Tests

- Added coverage proving manifest metadata resolves the metric without an index file read.
- Added coverage for the Java and legacy empty-metadata header fallback.
- cargo +1.97.0 test -p paimon test_resolve_raw_vector_metric -- --nocapture
- cargo +1.97.0 clippy -p paimon --lib -- -D warnings
- cargo +1.97.0 fmt --all -- --check

### API and Format

No API or storage-format changes. Existing Java and legacy Vindex files remain compatible through the bounded header fallback.

### Documentation

No documentation changes are required.