### PR TITLE
fix(btree): read LZ4-compressed global index blocks written by Java

### DIFF
--- a/crates/paimon/src/btree/sst_file.rs
+++ b/crates/paimon/src/btree/sst_file.rs
@@ -155,7 +155,7 @@ impl SstFileWriter {
                 }
             }
             _ => {
-                // LZ4/LZO not implemented yet, fall back to no compression
+                // LZ4/LZO writing is not implemented yet, fall back to no compression
                 (Cow::Borrowed(block), BlockCompressionType::None)
             }
         }
@@ -235,6 +235,12 @@ fn decompress_block(data: &[u8], trailer: &BlockTrailer) -> io::Result<Vec<u8>> 
             }
             Ok(decompressed)
         }
+        BlockCompressionType::Lz4 => {
+            let mut cursor = Cursor::new(data);
+            let uncompressed_size = crate::btree::var_len::decode_var_int(&mut cursor)? as usize;
+            let frame_start = cursor.position() as usize;
+            decompress_lz4_frame(&data[frame_start..], uncompressed_size)
+        }
         _ => Err(io::Error::new(
             io::ErrorKind::Unsupported,
             format!(
@@ -243,6 +249,76 @@ fn decompress_block(data: &[u8], trailer: &BlockTrailer) -> io::Result<Vec<u8>> 
             ),
         )),
     }
+}
+
+/// Number of bytes in the LZ4 frame header Paimon writes ahead of the raw block:
+/// two little-endian `i32`s holding the compressed and uncompressed lengths.
+const LZ4_FRAME_HEADER_LEN: usize = 8;
+
+/// Decode Paimon's LZ4 frame: `[compressedLen: i32le][uncompressedLen: i32le]`
+/// followed by a raw LZ4 block (`Lz4BlockCompressor` on the Java side, which is
+/// not the LZ4 frame format). `expected_size` comes from the var-int the block
+/// writer puts ahead of the frame and must agree with the header's own copy.
+fn decompress_lz4_frame(frame: &[u8], expected_size: usize) -> io::Result<Vec<u8>> {
+    if frame.len() < LZ4_FRAME_HEADER_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "LZ4 block is too short for its {LZ4_FRAME_HEADER_LEN}-byte header: {} bytes",
+                frame.len()
+            ),
+        ));
+    }
+
+    let compressed_len = i32::from_le_bytes(frame[0..4].try_into().unwrap());
+    let uncompressed_len = i32::from_le_bytes(frame[4..8].try_into().unwrap());
+    let compressed_len = usize::try_from(compressed_len).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Negative LZ4 compressed length: {compressed_len}"),
+        )
+    })?;
+    let uncompressed_len = usize::try_from(uncompressed_len).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Negative LZ4 uncompressed length: {uncompressed_len}"),
+        )
+    })?;
+
+    // The uncompressed length is stored twice -- once by the block writer as a
+    // var-int, once inside this header. Disagreement means a corrupt file.
+    if uncompressed_len != expected_size {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "LZ4 length mismatch: block header says {uncompressed_len}, \
+                 block prefix says {expected_size}"
+            ),
+        ));
+    }
+
+    let payload = &frame[LZ4_FRAME_HEADER_LEN..];
+    if payload.len() < compressed_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "LZ4 block is truncated: header says {compressed_len} compressed bytes, \
+                 {} available",
+                payload.len()
+            ),
+        ));
+    }
+
+    let mut decompressed = vec![0u8; uncompressed_len];
+    let actual = lz4_flex::block::decompress_into(&payload[..compressed_len], &mut decompressed)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    if actual != uncompressed_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Decompressed size mismatch: expected {uncompressed_len}, got {actual}"),
+        ));
+    }
+    Ok(decompressed)
 }
 
 /// SstFileReader reads an SST file index block for async on-demand data block loading.

--- a/crates/paimon/src/btree/tests.rs
+++ b/crates/paimon/src/btree/tests.rs
@@ -664,25 +664,51 @@ async fn test_java_compat_varchar_no_compress() {
 }
 
 #[tokio::test]
-async fn test_java_compat_int_lz4_unsupported() {
-    let data = Bytes::from(load_testdata("btree_int_100_lz4.bin"));
-    let file_size = data.len() as u64;
+async fn test_java_compat_int_lz4() {
     let meta = BTreeIndexMeta::new(Some(le_int_key(0)), Some(le_int_key(198)), false);
-    let reader_result =
-        BTreeIndexReader::open(Box::new(BytesFileRead(data)), file_size, &meta, le_int_cmp).await;
+    let reader = open_testdata("btree_int_100_lz4.bin", &meta, le_int_cmp).await;
 
-    match reader_result {
-        Err(e) => {
-            assert!(
-                e.to_string().contains("not supported") || e.to_string().contains("Unsupported"),
-                "Expected unsupported compression error, got: {e}"
-            );
-        }
-        Ok(reader) => {
-            // If reader creation succeeded (index block not compressed),
-            // data block read should fail
-            let result = reader.query_equal(&le_int_key(0)).await;
-            assert!(result.is_err(), "LZ4 data block read should fail");
-        }
+    let all = reader.all_non_null_rows().await.unwrap();
+    assert_eq!(all.len(), 100);
+
+    let bm = reader.query_equal(&le_int_key(100)).await.unwrap();
+    assert_eq!(bm.len(), 1);
+    assert!(bm.contains(50));
+
+    let bm = reader
+        .query_between(&le_int_key(10), &le_int_key(20))
+        .await
+        .unwrap();
+    assert_eq!(bm.len(), 6);
+
+    let bm = reader.query_equal(&le_int_key(1)).await.unwrap();
+    assert_eq!(bm.len(), 0);
+}
+
+/// The same data written by Java under three block codecs must decode to the
+/// same rows -- this is what makes the LZ4 path a compatibility fix rather than
+/// a new format.
+#[tokio::test]
+async fn test_java_compat_int_lz4_matches_other_codecs() {
+    let meta = BTreeIndexMeta::new(Some(le_int_key(0)), Some(le_int_key(198)), false);
+
+    let mut rows_per_codec = Vec::new();
+    for name in [
+        "btree_int_100_no_compress.bin",
+        "btree_int_100_zstd.bin",
+        "btree_int_100_lz4.bin",
+    ] {
+        let reader = open_testdata(name, &meta, le_int_cmp).await;
+        let mut rows: Vec<u64> = reader.all_non_null_rows().await.unwrap().iter().collect();
+        rows.sort_unstable();
+        rows_per_codec.push((name, rows));
+    }
+
+    let (baseline_name, baseline) = &rows_per_codec[0];
+    for (name, rows) in &rows_per_codec[1..] {
+        assert_eq!(
+            rows, baseline,
+            "{name} must decode to the same rows as {baseline_name}"
+        );
     }
 }


### PR DESCRIPTION
A BTree global index written by Java with LZ4 block compression cannot be read
at all: every query fails with `Compression type Lz4 not supported`, even though
the file holds the same data as the zstd and uncompressed variants. The repo
already carries the Java-written fixture for it, used only to assert that the
read fails.

Paimon's LZ4 block is not the LZ4 frame format and not a bare block either. It
is the block writer's var-int uncompressed length, then `Lz4BlockCompressor`'s
8-byte header of two little-endian `i32`s (compressed and uncompressed length),
then the raw LZ4 block. Reading the fixture's bytes confirms the layout: the
var-int says 261 and the header repeats 261 alongside a compressed length of
203.

**Fix**: decode that frame in `decompress_block`. The uncompressed length is
stored twice, so the two copies are cross-checked and a mismatch is rejected as
corrupt, as are negative lengths and a payload shorter than the header claims.
`lz4_flex` is already a dependency.

Scope is the read path only. The writer still falls back to no compression for
LZ4, unchanged — the comment is reworded to say so. A round-trip test would have
passed either way, so the two new tests read the Java fixture directly and assert
all three codecs decode to the same rows.
