### PR TITLE
fix(ci): restore cargo-deny after h2 security advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2838,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/DEPENDENCIES.rust.tsv
+++ b/DEPENDENCIES.rust.tsv
@@ -236,7 +236,7 @@ getrandom@0.3.4		X										X
 getrandom@0.4.3		X										X							
 glob@0.3.3		X										X							
 gloo-timers@0.3.0		X										X							
-h2@0.4.15												X							
+h2@0.4.16												X							
 half@2.7.1		X										X							
 hashbrown@0.14.5		X										X							
 hashbrown@0.15.5		X										X							

--- a/benchmarks/tpcds/DEPENDENCIES.rust.tsv
+++ b/benchmarks/tpcds/DEPENDENCIES.rust.tsv
@@ -165,7 +165,7 @@ getrandom@0.3.4		X									X
 getrandom@0.4.3		X									X					
 glob@0.3.3		X									X					
 gloo-timers@0.3.0		X									X					
-h2@0.4.15											X					
+h2@0.4.16											X					
 half@2.7.1		X									X					
 hashbrown@0.14.5		X									X					
 hashbrown@0.15.5		X									X					

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -110,7 +110,7 @@ getrandom@0.2.17		X									X
 getrandom@0.3.4		X									X				
 getrandom@0.4.3		X									X				
 gloo-timers@0.3.0		X									X				
-h2@0.4.15											X				
+h2@0.4.16											X				
 half@2.7.1		X									X				
 hashbrown@0.14.5		X									X				
 hashbrown@0.17.1		X									X				

--- a/bindings/go/DEPENDENCIES.rust.tsv
+++ b/bindings/go/DEPENDENCIES.rust.tsv
@@ -110,7 +110,7 @@ getrandom@0.2.17		X									X
 getrandom@0.3.4		X									X				
 getrandom@0.4.3		X									X				
 gloo-timers@0.3.0		X									X				
-h2@0.4.15											X				
+h2@0.4.16											X				
 half@2.7.1		X									X				
 hashbrown@0.14.5		X									X				
 hashbrown@0.17.1		X									X				

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -189,7 +189,7 @@ getrandom@0.3.4		X										X
 getrandom@0.4.3		X										X							
 glob@0.3.3		X										X							
 gloo-timers@0.3.0		X										X							
-h2@0.4.15												X							
+h2@0.4.16												X							
 half@2.7.1		X										X							
 hashbrown@0.14.5		X										X							
 hashbrown@0.15.5		X										X							

--- a/crates/integration_tests/DEPENDENCIES.rust.tsv
+++ b/crates/integration_tests/DEPENDENCIES.rust.tsv
@@ -110,7 +110,7 @@ getrandom@0.2.17		X									X
 getrandom@0.3.4		X									X				
 getrandom@0.4.3		X									X				
 gloo-timers@0.3.0		X									X				
-h2@0.4.15											X				
+h2@0.4.16											X				
 half@2.7.1		X									X				
 hashbrown@0.14.5		X									X				
 hashbrown@0.17.1		X									X				

--- a/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
@@ -202,7 +202,7 @@ getrandom@0.3.4		X									X
 getrandom@0.4.3		X									X							
 glob@0.3.3		X									X							
 gloo-timers@0.3.0		X									X							
-h2@0.4.15											X							
+h2@0.4.16											X							
 half@2.7.1		X									X							
 hashbrown@0.14.5		X									X							
 hashbrown@0.15.5		X									X							

--- a/crates/paimon-rest-server/DEPENDENCIES.rust.tsv
+++ b/crates/paimon-rest-server/DEPENDENCIES.rust.tsv
@@ -113,7 +113,7 @@ getrandom@0.2.17		X									X
 getrandom@0.3.4		X									X				
 getrandom@0.4.3		X									X				
 gloo-timers@0.3.0		X									X				
-h2@0.4.15											X				
+h2@0.4.16											X				
 half@2.7.1		X									X				
 hashbrown@0.14.5		X									X				
 hashbrown@0.17.1		X									X				

--- a/crates/paimon/DEPENDENCIES.rust.tsv
+++ b/crates/paimon/DEPENDENCIES.rust.tsv
@@ -175,7 +175,7 @@ getrandom@0.3.4		X									X
 getrandom@0.4.3		X									X						
 glob@0.3.3		X									X						
 gloo-timers@0.3.0		X									X						
-h2@0.4.15											X						
+h2@0.4.16											X						
 half@2.7.1		X									X						
 hashbrown@0.14.5		X									X						
 hashbrown@0.16.1		X									X						


### PR DESCRIPTION
### Purpose

Restore the `check` CI job after `h2` 0.4.15 was reported by RUSTSEC-2026-0258.

### Changes

- Update the locked `h2` version from 0.4.15 to 0.4.16.
- Refresh the generated Rust dependency reports that reference the locked version.

### Validation

- `cargo fetch --locked`
- `cargo deny --locked --all-features check --warn unmaintained advisories licenses`
- `python3.11 scripts/dependencies.py verify`

The existing `paste` unmaintained advisory remains a warning; advisories and licenses pass.
