### PR TITLE
fix: serialize unbounded varchar as string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2838,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/DEPENDENCIES.rust.tsv
+++ b/DEPENDENCIES.rust.tsv
@@ -236,7 +236,7 @@ getrandom@0.3.4		X										X
 getrandom@0.4.3		X										X							
 glob@0.3.3		X										X							
 gloo-timers@0.3.0		X										X							
-h2@0.4.15												X							
+h2@0.4.16												X							
 half@2.7.1		X										X							
 hashbrown@0.14.5		X										X							
 hashbrown@0.15.5		X										X							

--- a/benchmarks/tpcds/DEPENDENCIES.rust.tsv
+++ b/benchmarks/tpcds/DEPENDENCIES.rust.tsv
@@ -165,7 +165,7 @@ getrandom@0.3.4		X									X
 getrandom@0.4.3		X									X					
 glob@0.3.3		X									X					
 gloo-timers@0.3.0		X									X					
-h2@0.4.15											X					
+h2@0.4.16											X					
 half@2.7.1		X									X					
 hashbrown@0.14.5		X									X					
 hashbrown@0.15.5		X									X					

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -110,7 +110,7 @@ getrandom@0.2.17		X									X
 getrandom@0.3.4		X									X				
 getrandom@0.4.3		X									X				
 gloo-timers@0.3.0		X									X				
-h2@0.4.15											X				
+h2@0.4.16											X				
 half@2.7.1		X									X				
 hashbrown@0.14.5		X									X				
 hashbrown@0.17.1		X									X				

--- a/bindings/go/DEPENDENCIES.rust.tsv
+++ b/bindings/go/DEPENDENCIES.rust.tsv
@@ -110,7 +110,7 @@ getrandom@0.2.17		X									X
 getrandom@0.3.4		X									X				
 getrandom@0.4.3		X									X				
 gloo-timers@0.3.0		X									X				
-h2@0.4.15											X				
+h2@0.4.16											X				
 half@2.7.1		X									X				
 hashbrown@0.14.5		X									X				
 hashbrown@0.17.1		X									X				

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -189,7 +189,7 @@ getrandom@0.3.4		X										X
 getrandom@0.4.3		X										X							
 glob@0.3.3		X										X							
 gloo-timers@0.3.0		X										X							
-h2@0.4.15												X							
+h2@0.4.16												X							
 half@2.7.1		X										X							
 hashbrown@0.14.5		X										X							
 hashbrown@0.15.5		X										X							

--- a/crates/integration_tests/DEPENDENCIES.rust.tsv
+++ b/crates/integration_tests/DEPENDENCIES.rust.tsv
@@ -110,7 +110,7 @@ getrandom@0.2.17		X									X
 getrandom@0.3.4		X									X				
 getrandom@0.4.3		X									X				
 gloo-timers@0.3.0		X									X				
-h2@0.4.15											X				
+h2@0.4.16											X				
 half@2.7.1		X									X				
 hashbrown@0.14.5		X									X				
 hashbrown@0.17.1		X									X				

--- a/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
@@ -202,7 +202,7 @@ getrandom@0.3.4		X									X
 getrandom@0.4.3		X									X							
 glob@0.3.3		X									X							
 gloo-timers@0.3.0		X									X							
-h2@0.4.15											X							
+h2@0.4.16											X							
 half@2.7.1		X									X							
 hashbrown@0.14.5		X									X							
 hashbrown@0.15.5		X									X							

--- a/crates/paimon-rest-server/DEPENDENCIES.rust.tsv
+++ b/crates/paimon-rest-server/DEPENDENCIES.rust.tsv
@@ -113,7 +113,7 @@ getrandom@0.2.17		X									X
 getrandom@0.3.4		X									X				
 getrandom@0.4.3		X									X				
 gloo-timers@0.3.0		X									X				
-h2@0.4.15											X				
+h2@0.4.16											X				
 half@2.7.1		X									X				
 hashbrown@0.14.5		X									X				
 hashbrown@0.17.1		X									X				

--- a/crates/paimon/DEPENDENCIES.rust.tsv
+++ b/crates/paimon/DEPENDENCIES.rust.tsv
@@ -175,7 +175,7 @@ getrandom@0.3.4		X									X
 getrandom@0.4.3		X									X						
 glob@0.3.3		X									X						
 gloo-timers@0.3.0		X									X						
-h2@0.4.15											X						
+h2@0.4.16											X						
 half@2.7.1		X									X						
 hashbrown@0.14.5		X									X						
 hashbrown@0.16.1		X									X						

--- a/crates/paimon/src/spec/types.rs
+++ b/crates/paimon/src/spec/types.rs
@@ -1537,7 +1537,11 @@ pub struct VarCharType {
 
 impl Display for VarCharType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "VARCHAR({})", self.length)?;
+        if self.length == Self::MAX_LENGTH {
+            write!(f, "{STRING_TYPE_NAME}")?;
+        } else {
+            write!(f, "VARCHAR({})", self.length)?;
+        }
         if !self.nullable {
             write!(f, " NOT NULL")?;
         }
@@ -2534,24 +2538,32 @@ mod tests {
         }
     }
 
-    /// Regression: `MAX_LENGTH` for `VarCharType`/`VarBinaryType` must fit in a
-    /// Java `int`, otherwise `DataTypeJsonParser` rejects the `CreateTableRequest`
-    /// REST payload with `NumberFormatException` on `Integer.parseInt`.
     #[test]
-    fn test_max_length_fits_java_integer() {
+    fn test_string_type_serializes_like_java() {
+        let nullable = DataType::VarChar(VarCharType::string_type());
+        assert_eq!(serde_json::to_string(&nullable).unwrap(), r#""STRING""#);
+
+        let not_null =
+            DataType::VarChar(VarCharType::with_nullable(false, VarCharType::MAX_LENGTH).unwrap());
+        assert_eq!(
+            serde_json::to_string(&not_null).unwrap(),
+            r#""STRING NOT NULL""#
+        );
+
+        let bounded = DataType::VarChar(VarCharType::new(42).unwrap());
+        assert_eq!(serde_json::to_string(&bounded).unwrap(), r#""VARCHAR(42)""#);
+    }
+
+    /// Regression: `MAX_LENGTH` must match Java's `Integer.MAX_VALUE` even though
+    /// an unbounded `VarCharType` is serialized through Java's `STRING` alias.
+    #[test]
+    fn test_max_length_matches_java_integer() {
         const JAVA_INTEGER_MAX_VALUE: u32 = i32::MAX as u32;
 
         assert_eq!(VarCharType::MAX_LENGTH, JAVA_INTEGER_MAX_VALUE);
         assert_eq!(VarBinaryType::MAX_LENGTH, JAVA_INTEGER_MAX_VALUE);
 
-        let varchar = VarCharType::string_type().to_string();
-        let length_token = varchar
-            .strip_prefix("VARCHAR(")
-            .and_then(|s| s.split(')').next())
-            .expect("VARCHAR display format");
-        length_token
-            .parse::<i32>()
-            .expect("VARCHAR length must parse as Java int");
+        assert_eq!(VarCharType::string_type().to_string(), STRING_TYPE_NAME);
 
         let varbinary = VarBinaryType::try_new(true, VarBinaryType::MAX_LENGTH)
             .unwrap()


### PR DESCRIPTION
## Summary

- serialize unbounded `VarCharType` with Java's `STRING` alias
- preserve `STRING NOT NULL` and bounded `VARCHAR(n)` behavior
- add regression coverage for all three serialization forms

## Root cause

`VarCharType` uses display-based Serde serialization, but its `Display` implementation always emitted `VARCHAR(length)`. As a result, the maximum length used to represent `STRING` was persisted as `VARCHAR(2147483647)` instead of Java's canonical `STRING` form.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p paimon --lib` (`2317 passed`, `2 ignored`)
