### PR TITLE
fix(datafusion): make table definitions optional for queries

### DIFF
--- a/crates/integrations/datafusion/src/table/mod.rs
+++ b/crates/integrations/datafusion/src/table/mod.rs
@@ -113,8 +113,8 @@ impl PaimonTableProvider {
     ///
     /// Loads the table schema and converts it to Arrow for DataFusion.
     pub fn try_new(table: Table) -> DFResult<Self> {
-        let table_definition = build_table_definition(&table)?;
-        Self::try_new_with_table_definition(table, Some(table_definition))
+        let table_definition = build_table_definition(&table).ok();
+        Self::try_new_with_table_definition(table, table_definition)
     }
 
     fn try_new_with_table_definition(

--- a/crates/integrations/datafusion/tests/sql_context_tests.rs
+++ b/crates/integrations/datafusion/tests/sql_context_tests.rs
@@ -2834,3 +2834,31 @@ async fn test_show_create_table_rejects_non_round_trippable_types() {
         );
     }
 }
+
+#[tokio::test]
+async fn test_vector_search_plans_vector_column_without_show_create_support() {
+    let (_tmp, catalog) = create_test_env();
+    let sql_context = create_sql_context(catalog.clone()).await;
+    let identifier = Identifier::new("default", "vector_t");
+    let schema = paimon::spec::Schema::builder()
+        .column("id", DataType::Int(IntType::new()))
+        .column(
+            "embedding",
+            DataType::Vector(VectorType::new(2, DataType::Float(FloatType::new())).unwrap()),
+        )
+        .build()
+        .unwrap();
+
+    catalog
+        .create_table(&identifier, schema, false)
+        .await
+        .unwrap();
+
+    sql_context
+        .sql(
+            "SELECT * FROM vector_search(\
+             'paimon.default.vector_t', 'embedding', '[1.0, 2.0]', 1)",
+        )
+        .await
+        .expect("vector_search should plan without requiring SHOW CREATE TABLE support");
+}


### PR DESCRIPTION
### Purpose

`vector_search` creates a `PaimonTableProvider` while planning a query. The provider eagerly built a `CREATE TABLE` definition, so tables containing `VECTOR` columns failed before search execution because `VECTOR` cannot currently be round-tripped by `SHOW CREATE TABLE`.

Table definitions are optional query metadata and should not prevent a table from being queried.

### Brief change log

- Treat failure to build the optional table definition as non-blocking when creating a `PaimonTableProvider`.
- Keep explicit `SHOW CREATE TABLE` validation unchanged.
- Add a regression test that plans `vector_search` against a `VECTOR<FLOAT>` column.

### Tests

- `cargo fmt --all -- --check`
- Added `test_vector_search_plans_vector_column_without_show_create_support`

### API and Format

No API or storage format changes.

### Documentation

No documentation changes are required.
