### PR TITLE
Upgrade paimon-vindex-core to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4603,7 +4603,7 @@ dependencies = [
  "orc-rust",
  "paimon-ftindex-core",
  "paimon-mosaic-core",
- "paimon-vindex-core",
+ "paimon-vindex-core 0.4.0",
  "parquet",
  "pretty_assertions",
  "rand 0.8.7",
@@ -4641,7 +4641,7 @@ dependencies = [
  "bytes",
  "futures",
  "paimon",
- "paimon-vindex-core",
+ "paimon-vindex-core 0.3.0",
  "serde_json",
  "tokio",
 ]
@@ -4754,6 +4754,20 @@ name = "paimon-vindex-core"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2c67c916596e578ed09f78ace8b4c54fc45d262933c658e1ca7fdb61b722635"
+dependencies = [
+ "half",
+ "matrixmultiply",
+ "nalgebra",
+ "rand 0.8.7",
+ "rayon",
+ "roaring",
+]
+
+[[package]]
+name = "paimon-vindex-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3073770e80f3d82edf50a11ac4ff1f50133d2828d74532c9021c5eb3c2439c"
 dependencies = [
  "half",
  "matrixmultiply",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4603,7 +4603,7 @@ dependencies = [
  "orc-rust",
  "paimon-ftindex-core",
  "paimon-mosaic-core",
- "paimon-vindex-core 0.4.0",
+ "paimon-vindex-core",
  "parquet",
  "pretty_assertions",
  "rand 0.8.7",
@@ -4641,7 +4641,7 @@ dependencies = [
  "bytes",
  "futures",
  "paimon",
- "paimon-vindex-core 0.3.0",
+ "paimon-vindex-core",
  "serde_json",
  "tokio",
 ]
@@ -4747,20 +4747,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
-]
-
-[[package]]
-name = "paimon-vindex-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c67c916596e578ed09f78ace8b4c54fc45d262933c658e1ca7fdb61b722635"
-dependencies = [
- "half",
- "matrixmultiply",
- "nalgebra",
- "rand 0.8.7",
- "rayon",
- "roaring",
 ]
 
 [[package]]

--- a/DEPENDENCIES.rust.tsv
+++ b/DEPENDENCIES.rust.tsv
@@ -398,7 +398,7 @@ paimon-integration-tests@0.4.0		X
 paimon-mosaic-core@0.2.0		X																	
 paimon-rest-server@0.4.0		X																	
 paimon-tpcds-bench@0.4.0		X																	
-paimon-vindex-core@0.3.0		X																	
+paimon-vindex-core@0.4.0		X																	
 parking@2.2.1		X										X							
 parking_lot@0.12.5		X										X							
 parking_lot_core@0.9.12		X										X							

--- a/benchmarks/tpcds/DEPENDENCIES.rust.tsv
+++ b/benchmarks/tpcds/DEPENDENCIES.rust.tsv
@@ -271,7 +271,7 @@ paimon@0.4.0		X
 paimon-datafusion@0.4.0		X														
 paimon-mosaic-core@0.2.0		X														
 paimon-tpcds-bench@0.4.0		X														
-paimon-vindex-core@0.3.0		X														
+paimon-vindex-core@0.4.0		X														
 parking_lot@0.12.5		X									X					
 parking_lot_core@0.9.12		X									X					
 parquet@58.3.0		X														

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -43,4 +43,4 @@ serde_json = "1.0.120"
 # Test-only: the vector-search integration tests build a real primary-key vindex
 # IVF-flat ANN segment fixture in-process. Versions match crates/paimon.
 bytes = "1.7.1"
-paimon-vindex-core = "0.3.0"
+paimon-vindex-core = "0.4.0"

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -205,7 +205,7 @@ ordered-multimap@0.7.3											X
 paimon@0.4.0		X													
 paimon-c@0.4.0		X													
 paimon-mosaic-core@0.2.0		X													
-paimon-vindex-core@0.3.0		X													
+paimon-vindex-core@0.4.0		X													
 parquet@58.3.0		X													
 paste@1.0.15		X									X				
 percent-encoding@2.3.2		X									X				

--- a/bindings/go/DEPENDENCIES.rust.tsv
+++ b/bindings/go/DEPENDENCIES.rust.tsv
@@ -205,7 +205,7 @@ ordered-multimap@0.7.3											X
 paimon@0.4.0		X													
 paimon-c@0.4.0		X													
 paimon-mosaic-core@0.2.0		X													
-paimon-vindex-core@0.3.0		X													
+paimon-vindex-core@0.4.0		X													
 parquet@58.3.0		X													
 paste@1.0.15		X									X				
 percent-encoding@2.3.2		X									X				

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -327,7 +327,7 @@ paimon@0.4.0		X
 paimon-datafusion@0.4.0		X																	
 paimon-ftindex-core@0.1.0		X																	
 paimon-mosaic-core@0.2.0		X																	
-paimon-vindex-core@0.3.0		X																	
+paimon-vindex-core@0.4.0		X																	
 parking_lot@0.12.5		X										X							
 parking_lot_core@0.9.12		X										X							
 parquet@58.3.0		X																	

--- a/crates/integration_tests/DEPENDENCIES.rust.tsv
+++ b/crates/integration_tests/DEPENDENCIES.rust.tsv
@@ -205,7 +205,7 @@ ordered-multimap@0.7.3											X
 paimon@0.4.0		X													
 paimon-integration-tests@0.4.0		X													
 paimon-mosaic-core@0.2.0		X													
-paimon-vindex-core@0.3.0		X													
+paimon-vindex-core@0.4.0		X													
 parquet@58.3.0		X													
 paste@1.0.15		X									X				
 percent-encoding@2.3.2		X									X				

--- a/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
@@ -346,7 +346,7 @@ paimon@0.4.0		X
 paimon-datafusion@0.4.0		X																
 paimon-ftindex-core@0.1.0		X																
 paimon-mosaic-core@0.2.0		X																
-paimon-vindex-core@0.3.0		X																
+paimon-vindex-core@0.4.0		X																
 parking@2.2.1		X									X							
 parking_lot@0.12.5		X									X							
 parking_lot_core@0.9.12		X									X							

--- a/crates/paimon-rest-server/DEPENDENCIES.rust.tsv
+++ b/crates/paimon-rest-server/DEPENDENCIES.rust.tsv
@@ -209,7 +209,7 @@ ordered-multimap@0.7.3											X
 paimon@0.4.0		X													
 paimon-mosaic-core@0.2.0		X													
 paimon-rest-server@0.4.0		X													
-paimon-vindex-core@0.3.0		X													
+paimon-vindex-core@0.4.0		X													
 parquet@58.3.0		X													
 paste@1.0.15		X									X				
 percent-encoding@2.3.2		X									X				

--- a/crates/paimon/Cargo.toml
+++ b/crates/paimon/Cargo.toml
@@ -132,7 +132,7 @@ urlencoding = "2.1"
 paimon-mosaic-core = "0.2.0"
 paimon-ftindex-core = { version = "0.1.0", optional = true }
 tempfile = "3"
-paimon-vindex-core = "0.3.0"
+paimon-vindex-core = "0.4.0"
 vortex = { version = "0.75.0", features = ["tokio"], optional = true }
 libloading = "0.9"
 log = "0.4"

--- a/crates/paimon/DEPENDENCIES.rust.tsv
+++ b/crates/paimon/DEPENDENCIES.rust.tsv
@@ -322,7 +322,7 @@ ownedbytes@0.9.0											X
 paimon@0.4.0		X															
 paimon-ftindex-core@0.1.0		X															
 paimon-mosaic-core@0.2.0		X															
-paimon-vindex-core@0.3.0		X															
+paimon-vindex-core@0.4.0		X															
 parking@2.2.1		X									X						
 parking_lot@0.12.5		X									X						
 parking_lot_core@0.9.12		X									X						


### PR DESCRIPTION
### Purpose

Linked issue: N/A (dependency upgrade)

Upgrade the `paimon-vindex-core` crate dependency to the newly released `0.4.0` version. `paimon-vector-index` 0.4.0 has been published to Maven Central, crates.io, and PyPI.

### Brief change log

Upgrade `paimon-vindex-core` from 0.3.0 to 0.4.0:

- `crates/paimon/Cargo.toml` — workspace dependency version
- `crates/paimon/DEPENDENCIES.rust.tsv` — license/dependency manifest
- `Cargo.lock` — updated lock entries

### Tests

- `cargo check -p paimon` → BUILD SUCCESS
- `cargo test -p paimon vindex` → 171 passed, 0 failed, 1 ignored (manual perf benchmark)

### API and Format

No API or storage format changes. This is a dependency version bump only; the existing `vindex` module code compiles and all tests pass against 0.4.0 without source changes.

### Documentation

No documentation updates required.