### PR TITLE
fix: satisfy Rust 1.98 chunks lint

### DIFF
--- a/crates/integrations/datafusion/src/hybrid_search.rs
+++ b/crates/integrations/datafusion/src/hybrid_search.rs
@@ -535,7 +535,7 @@ fn extract_named_struct_fields<'a>(
     }
 
     let mut fields = Vec::with_capacity(function.args.len() / 2);
-    for pair in function.args.chunks_exact(2) {
+    for pair in function.args.as_chunks::<2>().0 {
         let key = extract_string_literal(FUNCTION_NAME, &pair[0], "route field name")?;
         fields.push((key, &pair[1]));
     }
@@ -862,7 +862,9 @@ fn extract_options(expr: &Expr) -> DFResult<HashMap<String, String>> {
 
     function
         .args
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             Ok((
                 extract_string_literal(FUNCTION_NAME, &pair[0], "options key")?,

--- a/crates/paimon/src/spec/murmur_hash.rs
+++ b/crates/paimon/src/spec/murmur_hash.rs
@@ -60,8 +60,8 @@ pub fn hash_by_words(data: &[u8]) -> i32 {
         data.len()
     );
     let mut h1 = DEFAULT_SEED;
-    for chunk in data.chunks_exact(4) {
-        let word = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+    for chunk in data.as_chunks::<4>().0 {
+        let word = u32::from_le_bytes(*chunk);
         let k1 = mix_k1(word);
         h1 = mix_h1(h1, k1);
     }

--- a/crates/paimon/src/table/vector_search_builder.rs
+++ b/crates/paimon/src/table/vector_search_builder.rs
@@ -3786,8 +3786,8 @@ mod tests {
                 metric,
             )
             .unwrap();
-            for (row_index, stored_vector) in stored.chunks_exact(2).enumerate() {
-                for (query_index, query) in queries.chunks_exact(2).enumerate() {
+            for (row_index, stored_vector) in stored.as_chunks::<2>().0.iter().enumerate() {
+                for (query_index, query) in queries.as_chunks::<2>().0.iter().enumerate() {
                     let expected = compute_raw_vector_score(query, stored_vector, metric);
                     let actual = matrix_scores[query_index * 3 + row_index];
                     assert!(


### PR DESCRIPTION
## Summary

Restore the workspace Clippy check after Rust 1.98 enabled `chunks_exact_to_as_chunks` by default. This failure is already present on `main` and also blocks unrelated PRs such as #747 and #749.

## Changes

- Replace constant-size `chunks_exact` calls with `as_chunks` in Murmur hashing.
- Update fixed-width vector score test iteration.
- Update Hybrid Search named-struct and options pair iteration.
- Preserve the existing even-length/alignment validation and runtime behavior.

## Testing

- [x] `cargo +1.98.0 clippy --locked --all-targets --workspace --features fulltext,vortex -- -D warnings`
- [x] `cargo +1.98.0 test -p paimon spec::murmur_hash --lib`
- [x] `cargo +1.98.0 test -p paimon test_raw_vector_score_matrix_matches_scalar_metrics --lib`
- [x] `cargo +1.98.0 test -p paimon-datafusion --test read_tables hybrid_search_tests`
- [x] Verified `as_chunks` compiles with the workspace MSRV, Rust 1.91.0.
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Notes

No public API or behavior changes.
