### PR TITLE
chore(deps): refresh locked arrow and opendal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -114,7 +125,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -125,7 +136,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -208,9 +219,9 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arrow"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -230,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -244,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -263,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
 dependencies = [
  "bytes",
  "half",
@@ -275,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -286,7 +297,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "comfy-table",
  "half",
@@ -297,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
+checksum = "af0dd6d90d1955e9f9a014c1e563ee8aeffc21909085d25623e1da44d96eca26"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -312,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -325,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
+checksum = "29a908a11fcfb3fb2f6730f4ac15e367bc644e419155e96238f68cf3adde572b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -341,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
+checksum = "b8a96aed3931c076adee39ec2a40d8219fc7f09e79bcdaca1df16272993e1e14"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -366,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -379,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-pyarrow"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29abdf672a81c1aeb57fd2661457f9918964d49aed0e9f18932535f2a9e49ce"
+checksum = "3ffb9be5a873590f825aef50df20e0f8dff5fd42a77058e28bbe7bd44bb53dec"
 dependencies = [
  "arrow-array",
  "arrow-data",
@@ -391,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -404,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
 dependencies = [
  "bitflags 2.13.1",
  "serde_core",
@@ -415,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -429,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -615,6 +626,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "asyncband"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a214ba60d6231afd0e805e3c27c45a1626d9debaa5a5061c45a1ea1b2f1ed0"
+dependencies = [
+ "hashbrown 0.17.1",
+ "slab",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +762,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -879,6 +906,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,7 +1027,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1084,7 +1129,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -1286,6 +1342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,11 +1481,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1880,7 +1942,7 @@ checksum = "14872c47bfc3d21e53ec82f57074e6987a15941c1e2f43cde4ac6ae2746634e3"
 dependencies = [
  "arrow",
  "arrow-buffer",
- "base64",
+ "base64 0.22.1",
  "blake2",
  "blake3",
  "chrono",
@@ -2288,11 +2350,11 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -2440,7 +2502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2788,7 +2850,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2916,18 +2978,18 @@ dependencies = [
 
 [[package]]
 name = "hdfs-native"
-version = "0.13.5"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51610510377a0847d53b78b53f9c6c9b7df3ffb300d1181b2e04f68bba363734"
+checksum = "5cf4000cab03f95f56fac82175a2978c21517e6072e577ac8d402f00ce996997"
 dependencies = [
- "aes",
- "base64",
+ "aes 0.9.2",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "bumpalo",
  "bytes",
- "cbc",
+ "cbc 0.2.1",
  "chrono",
- "cipher",
+ "cipher 0.5.2",
  "crc",
  "ctr",
  "des",
@@ -2935,16 +2997,16 @@ dependencies = [
  "futures",
  "g2p",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "libc",
  "libloading 0.9.0",
  "log",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "num-traits",
  "once_cell",
  "prost 0.14.4",
  "prost-types",
- "rand 0.9.5",
+ "rand 0.10.2",
  "regex",
  "roxmltree",
  "socket2",
@@ -3125,7 +3187,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -3339,8 +3401,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3748,10 +3820,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags 2.13.1",
  "libc",
- "plain",
- "redox_syscall 0.9.0",
 ]
 
 [[package]]
@@ -3947,7 +4016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -4185,6 +4254,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4248,19 +4335,19 @@ checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
 
 [[package]]
 name = "opendal-core"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8564bd76b75d2aea59178cb5b6e9f770be1da73b1bca062720ec151cc56215a"
+checksum = "48dbcef97d3eb7591db2c18d5cae95c836bcce07359b98d98dd6f4e861eb77b7"
 dependencies = [
  "anyhow",
- "base64",
+ "asyncband",
+ "base64 0.23.1",
  "bytes",
  "futures",
  "http",
  "jiff",
  "log",
  "md-5 0.11.0",
- "mea",
  "percent-encoding",
  "quick-xml",
  "reqsign-core",
@@ -4274,9 +4361,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-http-transport-reqwest"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7fd001b204df76be5d2b3f7a81c48b5cf25b28e2cfb3b8a819bb89cdc0ea3a"
+checksum = "85663452ea32bbc17e8f79ab29788c846d116ec7de31451be9c787e462dcb36c"
 dependencies = [
  "bytes",
  "futures",
@@ -4288,9 +4375,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2df70875ab7fd6f80720d4787c49c70883cef0d81bfae947ecba88b8d1cd62e"
+checksum = "e94db301964a25366090484d61e6da16d5979cc8faf02c3e12210dc74fafed38"
 dependencies = [
  "backon",
  "log",
@@ -4299,15 +4386,15 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azdls"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b03a371e8266b6995884399dff28b28b71fbb00f5ff8dbb98eb0d7ccb2a839"
+checksum = "2d564484a8f7d091827e825cfc91ed45bd48e64d262451ee041fe843db81bd8a"
 dependencies = [
- "base64",
+ "asyncband",
+ "base64 0.23.1",
  "bytes",
  "http",
  "log",
- "mea",
  "opendal-core",
  "opendal-service-azure-common",
  "quick-xml",
@@ -4320,9 +4407,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c2419a8fd504849580943560066f8a68a188763606bc6fa3052f2b4a612972"
+checksum = "cfcc1bfdac4f54d9018c462dd32ad9e2f68fdf584f825c811550c8ffc87894cd"
 dependencies = [
  "http",
  "opendal-core",
@@ -4330,9 +4417,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cos"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2466f1da8abaccc5ef26a19bf0bcc3d9429a45803dbab72ee62ba37e6c1f42"
+checksum = "bb021c128ebde42e6f3e719d4cfed27e994017aa503a7a1e5818bdb61fd67dc9"
 dependencies = [
  "bytes",
  "http",
@@ -4347,9 +4434,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-fs"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f26a923b72b96d1a3dbbe961fcad4d534bf586c3f48c583e9f35649b1b6175f"
+checksum = "c7ef1e1c45f3f89282a59073897e0d685e51385fed0aea771714789525cff996"
 dependencies = [
  "bytes",
  "log",
@@ -4361,9 +4448,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbde2f65ee021ff8849e9ea864aa5cf9ef6a59f4c7a71bc774a8d89ceaa7eef"
+checksum = "da1f2a8c975fd22fea01f0409bcb8774f1ac02ad79863a3490098203121555d3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4382,9 +4469,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs-native"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11dc8477864d2b4e52e700825bca45fa3e2ad1c50fcbb60c5e99d6750f2f019d"
+checksum = "8aebbf956ea9e64d70fc8d1f25381604c02528805c23bd55443b8e924b438222"
 dependencies = [
  "bytes",
  "futures",
@@ -4396,9 +4483,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-obs"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af6300577f3ad1152aa9ef25d0ff9cbe4ff9e433db81c3b46ded283db617f3b"
+checksum = "9e03c635ea35bdb07c1168612d42386635d16a1583c753efaf70bc7c8ac68c83"
 dependencies = [
  "bytes",
  "http",
@@ -4413,9 +4500,9 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-oss"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f73f24e7b5b00b1fbd7b598c877893a517d5c8466b2f61cd00a255fd21a972"
+checksum = "8e3ce7a2ceb925e0f28f545b169eb57d04cec6116aae94b8584d2bdbe7d456c6"
 dependencies = [
  "bytes",
  "http",
@@ -4430,11 +4517,11 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750d9cc8588c19b27c4c2c5d06d7eb6f2bff62549c48652f1f9a7603cd872377"
+checksum = "c64335f9f24ccb62ac36f1d976342b48611a75ba61979813a4f78a4ebd94de42"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "bytes",
  "crc-fast",
  "http",
@@ -4573,7 +4660,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "bytes",
  "chrono",
@@ -4788,16 +4875,16 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
 
 [[package]]
 name = "parquet"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+checksum = "d298093b2dec60289dce0684c986d0f7679e9dd15771c2c65406e1aaf604a704"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -4806,7 +4893,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64",
+ "base64 0.22.1",
  "brotli",
  "bytes",
  "chrono",
@@ -4859,11 +4946,11 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.6"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "serde_core",
 ]
 
@@ -5005,8 +5092,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
- "aes",
- "cbc",
+ "aes 0.8.4",
+ "cbc 0.1.2",
  "der",
  "pbkdf2",
  "scrypt",
@@ -5031,12 +5118,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "polling"
@@ -5184,7 +5265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5197,7 +5278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5367,7 +5448,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5547,15 +5628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
-dependencies = [
- "bitflags 2.13.1",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5612,9 +5684,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqsign-aliyun-oss"
-version = "3.1.1"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2a76ce7588780351c0f68eb8feaba8d23a99b40655195edbf50bfbce2af09b"
+checksum = "10909dbc9fcb78f913014d78a5c9d1d51c477f491b1006fd1baba4fd286181df"
 dependencies = [
  "anyhow",
  "form_urlencoded",
@@ -5628,12 +5700,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqsign-aws-v4"
-version = "3.0.2"
+name = "reqsign-aws-core"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9e1168fab3883ec6afed1c2e20c25b2a09f366cdb662ac3e0878ae0332d63e"
+checksum = "bac4749b7dfa7bfaccd01eb03e9dc795ed37e3f20d6f0f38e2c67ee85ad6bc86"
 dependencies = [
- "anyhow",
  "bytes",
  "form_urlencoded",
  "hex",
@@ -5650,13 +5721,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqsign-azure-storage"
-version = "3.1.0"
+name = "reqsign-aws-v4"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee8b9e5d0fc927551a6ac25ba5dc6518860c54ddb592fecf685523e528e77bd"
+checksum = "ff250f0fd0b913fbd565e405acc553da0f13bde30bfb5403178c9d0313cdc15f"
+dependencies = [
+ "bytes",
+ "http",
+ "log",
+ "quick-xml",
+ "reqsign-aws-core",
+ "reqsign-core",
+ "serde",
+]
+
+[[package]]
+name = "reqsign-azure-storage"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f1fbc9add082f54e51e3bd9730f18d850a1f09d246baff5cd612c74ae4290e"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.23.1",
  "bytes",
  "form_urlencoded",
  "http",
@@ -5672,20 +5758,20 @@ dependencies = [
 
 [[package]]
 name = "reqsign-core"
-version = "3.1.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514a1e0b4aa288652a3fdbda4f0a610f379cdf5374e55a37c9edd03d57ed856b"
+checksum = "ff052daffb0599681c50f85c59e7236438976efe991ab864edd9f3b235501a0f"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.23.1",
  "bytes",
- "form_urlencoded",
  "futures",
  "hex",
  "hmac 0.13.0",
  "http",
  "jiff",
  "log",
+ "mea",
  "percent-encoding",
  "rsa",
  "serde",
@@ -5697,9 +5783,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign-file-read-tokio"
-version = "3.0.2"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b472a8d1f2e5a4be8ce13bb7bdf4b59e9bee613ce124aca23959ddb42176b39"
+checksum = "b3235df90a6bca681aa47dd86f2393d122a6d77042aa8a7c81e218cd45c5bfc0"
 dependencies = [
  "anyhow",
  "reqsign-core",
@@ -5708,10 +5794,11 @@ dependencies = [
 
 [[package]]
 name = "reqsign-google"
-version = "3.0.2"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296b34f3b0b312a447e8eb7c9b21f12944b25578c84ffa105eb8d5bd10828212"
+checksum = "272a5813571885c1455ffe106f0c768577e6ce69313446d4476e8d41dcf6ac5a"
 dependencies = [
+ "bytes",
  "form_urlencoded",
  "http",
  "log",
@@ -5726,9 +5813,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign-huaweicloud-obs"
-version = "3.0.2"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a013a1a6711baf24fdc5d15e78611001c068cf305351d0d68f32067f40eec7f6"
+checksum = "c77eead23660b7e216289cc054cd285868fb91f28bd2c0a480e91ae95603f163"
 dependencies = [
  "anyhow",
  "http",
@@ -5739,9 +5826,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign-tencent-cos"
-version = "3.0.2"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f5c353c69bdbd6e3deb8b067a5547504cc155b7f024998fef005e37d65d646c"
+checksum = "ce37101efdda1e52f08d98a4fbb5e9fbcfff92dd74911b51ec7779e9d2279fef"
 dependencies = [
  "anyhow",
  "http",
@@ -5758,7 +5845,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -5798,7 +5885,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5935,7 +6022,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5992,7 +6079,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6040,7 +6127,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -6230,7 +6317,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -6472,7 +6559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6569,7 +6656,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6696,7 +6783,7 @@ checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64",
+ "base64 0.22.1",
  "bitpacking",
  "bon",
  "byteorder",
@@ -6880,7 +6967,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7943,6 +8030,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7953,9 +8049,12 @@ dependencies = [
 
 [[package]]
 name = "wasite"
-version = "0.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -8056,11 +8155,13 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 dependencies = [
+ "libc",
  "libredox",
+ "objc2-system-configuration",
  "wasite",
  "web-sys",
 ]
@@ -8097,7 +8198,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/DEPENDENCIES.rust.tsv
+++ b/DEPENDENCIES.rust.tsv
@@ -2,6 +2,7 @@ crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	B
 adler2@2.0.1	X	X										X							
 adler32@1.2.0																	X		
 aes@0.8.4		X										X							
+aes@0.9.2		X										X							
 ahash@0.8.12		X										X							
 aho-corasick@1.1.4												X				X			
 alloc-no-stdlib@2.0.4					X														
@@ -21,21 +22,21 @@ arc-swap@1.9.2		X										X
 arcref@0.2.0												X							
 arrayref@0.3.9				X															
 arrayvec@0.7.8		X										X							
-arrow@58.3.0		X																	
-arrow-arith@58.3.0		X																	
-arrow-array@58.3.0		X										X							
-arrow-buffer@58.3.0		X																	
-arrow-cast@58.3.0		X																	
-arrow-csv@58.3.0		X																	
-arrow-data@58.3.0		X																	
-arrow-ipc@58.3.0		X																	
-arrow-json@58.3.0		X																	
-arrow-ord@58.3.0		X																	
-arrow-pyarrow@58.3.0		X																	
-arrow-row@58.3.0		X																	
-arrow-schema@58.3.0		X																	
-arrow-select@58.3.0		X																	
-arrow-string@58.3.0		X																	
+arrow@58.4.0		X																	
+arrow-arith@58.4.0		X																	
+arrow-array@58.4.0		X										X							
+arrow-buffer@58.4.0		X																	
+arrow-cast@58.4.0		X																	
+arrow-csv@58.4.0		X																	
+arrow-data@58.4.0		X																	
+arrow-ipc@58.4.0		X																	
+arrow-json@58.4.0		X																	
+arrow-ord@58.4.0		X																	
+arrow-pyarrow@58.4.0		X																	
+arrow-row@58.4.0		X																	
+arrow-schema@58.4.0		X																	
+arrow-select@58.4.0		X																	
+arrow-string@58.4.0		X																	
 async-channel@2.5.0		X										X							
 async-compression@0.4.42		X										X							
 async-executor@1.14.0		X										X							
@@ -50,6 +51,7 @@ async-stream@0.3.6												X
 async-stream-impl@0.3.6												X							
 async-task@4.7.1		X										X							
 async-trait@0.1.91		X										X							
+asyncband@0.6.7		X																	
 atoi@2.0.0												X							
 atomic-waker@1.1.2		X										X							
 autocfg@1.5.1		X										X							
@@ -60,6 +62,7 @@ axum-core@0.4.5												X
 axum-macros@0.4.2												X							
 backon@1.6.0		X																	
 base64@0.22.1		X										X							
+base64@0.23.1		X										X							
 base64ct@1.8.3		X										X							
 better_io@0.2.0		X																	
 bigdecimal@0.4.10		X										X							
@@ -73,6 +76,7 @@ blake3@1.8.5		X	X				X
 block-buffer@0.10.4		X										X							
 block-buffer@0.12.1		X										X							
 block-padding@0.3.3		X										X							
+block-padding@0.4.2		X										X							
 blocking@1.6.2		X										X							
 bon@3.9.3		X										X							
 bon-macros@3.9.3		X										X							
@@ -85,6 +89,7 @@ byteorder@1.5.0												X				X
 bytes@1.12.1												X							
 bzip2@0.6.1		X										X							
 cbc@0.1.2		X										X							
+cbc@0.2.1		X										X							
 cc@1.3.0		X										X							
 cedarwood@0.5.0				X															
 census@0.4.2												X							
@@ -94,6 +99,7 @@ chacha20@0.10.1		X										X
 chrono@0.4.45		X										X							
 chrono-tz@0.10.4		X										X							
 cipher@0.4.4		X										X							
+cipher@0.5.2		X										X							
 clang-sys@1.8.1		X																	
 clap@4.6.2		X										X							
 clap_builder@4.6.2		X										X							
@@ -117,6 +123,7 @@ core-foundation@0.10.1		X										X
 core-foundation@0.9.4		X										X							
 core-foundation-sys@0.8.7		X										X							
 core_detect@1.0.0		X										X							
+cpubits@0.1.1		X										X							
 cpufeatures@0.2.17		X										X							
 cpufeatures@0.3.0		X										X							
 crc@3.4.0		X										X							
@@ -132,7 +139,7 @@ crypto-common@0.1.7		X										X
 crypto-common@0.2.2		X										X							
 csv@1.4.0												X				X			
 csv-core@0.1.13												X				X			
-ctr@0.9.2		X										X							
+ctr@0.10.1		X										X							
 ctutils@0.4.2		X										X							
 custom-labels@0.4.6		X																	
 darling@0.23.0												X							
@@ -177,7 +184,7 @@ datafusion-sql@54.0.0		X
 datasketches@0.2.0		X																	
 der@0.7.10		X										X							
 deranged@0.5.8		X										X							
-des@0.8.1		X										X							
+des@0.9.0		X										X							
 diff@0.1.13		X										X							
 digest@0.10.7		X										X							
 digest@0.11.3		X										X							
@@ -242,7 +249,7 @@ hashbrown@0.14.5		X										X
 hashbrown@0.15.5		X										X							
 hashbrown@0.16.1		X										X							
 hashbrown@0.17.1		X										X							
-hdfs-native@0.13.5		X																	
+hdfs-native@0.14.5		X																	
 heck@0.5.0		X										X							
 hermit-abi@0.5.2		X										X							
 hex@0.4.3		X										X							
@@ -278,6 +285,7 @@ include-flate-codegen@0.3.4		X
 include-flate-compress@0.3.4		X																	
 indexmap@2.14.0		X										X							
 inout@0.1.4		X										X							
+inout@0.2.2		X										X							
 integer-encoding@3.0.4												X							
 inventory@0.3.24		X										X							
 ipnet@2.12.0		X										X							
@@ -363,24 +371,26 @@ num-rational@0.4.2		X										X
 num-traits@0.2.19		X										X							
 num_enum@0.7.6		X			X							X							
 num_enum_derive@0.7.6		X			X							X							
+objc2-core-foundation@0.3.2		X										X					X		
+objc2-system-configuration@0.3.2		X										X					X		
 object@0.37.3		X										X							
 object_store@0.13.2		X										X							
 once_cell@1.21.4		X										X							
 once_cell_polyfill@1.70.2		X										X							
 oneshot@0.1.13		X										X							
 oneshot@0.2.1		X										X							
-opendal-core@0.58.0		X																	
-opendal-http-transport-reqwest@0.58.0		X																	
-opendal-layer-retry@0.58.0		X																	
-opendal-service-azdls@0.58.0		X																	
-opendal-service-azure-common@0.58.0		X																	
-opendal-service-cos@0.58.0		X																	
-opendal-service-fs@0.58.0		X																	
-opendal-service-gcs@0.58.0		X																	
-opendal-service-hdfs-native@0.58.0		X																	
-opendal-service-obs@0.58.0		X																	
-opendal-service-oss@0.58.0		X																	
-opendal-service-s3@0.58.0		X																	
+opendal-core@0.58.2		X																	
+opendal-http-transport-reqwest@0.58.2		X																	
+opendal-layer-retry@0.58.2		X																	
+opendal-service-azdls@0.58.2		X																	
+opendal-service-azure-common@0.58.2		X																	
+opendal-service-cos@0.58.2		X																	
+opendal-service-fs@0.58.2		X																	
+opendal-service-gcs@0.58.2		X																	
+opendal-service-hdfs-native@0.58.2		X																	
+opendal-service-obs@0.58.2		X																	
+opendal-service-oss@0.58.2		X																	
+opendal-service-s3@0.58.2		X																	
 openssl@0.10.81		X																	
 openssl-macros@0.1.1		X										X							
 openssl-probe@0.2.1		X										X							
@@ -402,11 +412,11 @@ paimon-vindex-core@0.4.0		X
 parking@2.2.1		X										X							
 parking_lot@0.12.5		X										X							
 parking_lot_core@0.9.12		X										X							
-parquet@58.3.0		X																	
+parquet@58.4.0		X																	
 paste@1.0.15		X										X							
 pbkdf2@0.12.2		X										X							
 pco@1.0.2		X																	
-pem@3.0.6												X							
+pem@4.0.0												X							
 pem-rfc7468@0.7.0		X										X							
 percent-encoding@2.3.2		X										X							
 petgraph@0.8.3		X										X							
@@ -424,7 +434,6 @@ pkcs1@0.7.5		X										X
 pkcs5@0.7.1		X										X							
 pkcs8@0.10.2		X										X							
 pkg-config@0.3.33		X										X							
-plain@0.2.3		X										X							
 polling@3.11.0		X										X							
 polonius-the-crab@0.2.1		X										X					X		
 portable-atomic@1.14.0		X										X							
@@ -471,19 +480,19 @@ rayon-core@1.13.0		X										X
 recursive@0.1.1												X							
 recursive-proc-macro-impl@0.1.1												X							
 redox_syscall@0.5.18												X							
-redox_syscall@0.9.0												X							
 regex@1.13.1		X										X							
 regex-automata@0.4.16		X										X							
 regex-lite@0.1.9		X										X							
 regex-syntax@0.8.11		X										X							
-reqsign-aliyun-oss@3.1.1		X																	
-reqsign-aws-v4@3.0.2		X																	
-reqsign-azure-storage@3.1.0		X																	
-reqsign-core@3.1.0		X																	
-reqsign-file-read-tokio@3.0.2		X																	
-reqsign-google@3.0.2		X																	
-reqsign-huaweicloud-obs@3.0.2		X																	
-reqsign-tencent-cos@3.0.2		X																	
+reqsign-aliyun-oss@3.1.5		X																	
+reqsign-aws-core@3.1.1		X																	
+reqsign-aws-v4@3.3.0		X																	
+reqsign-azure-storage@3.2.1		X																	
+reqsign-core@3.3.1		X																	
+reqsign-file-read-tokio@3.0.6		X																	
+reqsign-google@3.1.1		X																	
+reqsign-huaweicloud-obs@3.0.6		X																	
+reqsign-tencent-cos@3.0.6		X																	
 reqwest@0.12.28		X										X							
 reqwest@0.13.4		X										X							
 rle-decode-fast@1.0.3		X										X							
@@ -662,8 +671,9 @@ vortex-zstd@0.75.0		X
 walkdir@2.5.0												X				X			
 want@0.3.1												X							
 wasi@0.11.1+wasi-snapshot-preview1		X	X									X							
+wasi@0.14.7+wasi-0.2.4		X	X									X							
 wasip2@1.0.4+wasi-0.2.12		X	X									X							
-wasite@0.1.0		X				X						X							
+wasite@1.0.2		X				X						X							
 wasm-bindgen@0.2.126		X										X							
 wasm-bindgen-futures@0.4.76		X										X							
 wasm-bindgen-macro@0.2.126		X										X							
@@ -673,7 +683,7 @@ wasm-streams@0.5.0		X										X
 web-sys@0.3.103		X										X							
 web-time@1.1.0		X										X							
 webpki-root-certs@1.0.9								X											
-whoami@1.6.1		X				X						X							
+whoami@2.1.3		X				X						X							
 wide@0.7.33		X										X					X		
 winapi@0.3.9		X										X							
 winapi-i686-pc-windows-gnu@0.4.0		X										X							
@@ -686,6 +696,7 @@ windows-link@0.2.1		X										X
 windows-registry@0.6.1		X										X							
 windows-result@0.4.1		X										X							
 windows-strings@0.5.1		X										X							
+windows-sys@0.52.0		X										X							
 windows-sys@0.59.0		X										X							
 windows-sys@0.60.2		X										X							
 windows-sys@0.61.2		X										X							

--- a/benchmarks/tpcds/DEPENDENCIES.rust.tsv
+++ b/benchmarks/tpcds/DEPENDENCIES.rust.tsv
@@ -17,24 +17,25 @@ approx@0.5.1		X
 ar_archive_writer@0.5.2			X													
 arrayref@0.3.9				X												
 arrayvec@0.7.8		X									X					
-arrow@58.3.0		X														
-arrow-arith@58.3.0		X														
-arrow-array@58.3.0		X									X					
-arrow-buffer@58.3.0		X														
-arrow-cast@58.3.0		X														
-arrow-csv@58.3.0		X														
-arrow-data@58.3.0		X														
-arrow-ipc@58.3.0		X														
-arrow-json@58.3.0		X														
-arrow-ord@58.3.0		X														
-arrow-row@58.3.0		X														
-arrow-schema@58.3.0		X														
-arrow-select@58.3.0		X														
-arrow-string@58.3.0		X														
+arrow@58.4.0		X														
+arrow-arith@58.4.0		X														
+arrow-array@58.4.0		X									X					
+arrow-buffer@58.4.0		X														
+arrow-cast@58.4.0		X														
+arrow-csv@58.4.0		X														
+arrow-data@58.4.0		X														
+arrow-ipc@58.4.0		X														
+arrow-json@58.4.0		X														
+arrow-ord@58.4.0		X														
+arrow-row@58.4.0		X														
+arrow-schema@58.4.0		X														
+arrow-select@58.4.0		X														
+arrow-string@58.4.0		X														
 async-compression@0.4.42		X									X					
 async-stream@0.3.6											X					
 async-stream-impl@0.3.6											X					
 async-trait@0.1.91		X									X					
+asyncband@0.6.7		X														
 atoi@2.0.0											X					
 atomic-waker@1.1.2		X									X					
 autocfg@1.5.1		X									X					
@@ -42,6 +43,7 @@ aws-lc-rs@1.17.3		X							X
 aws-lc-sys@0.43.0		X			X				X		X	X				
 backon@1.6.0		X														
 base64@0.22.1		X									X					
+base64@0.23.1		X									X					
 bigdecimal@0.4.10		X									X					
 bitflags@2.13.1		X									X					
 blake2@0.10.6		X									X					
@@ -201,6 +203,7 @@ indexmap@2.14.0		X									X
 integer-encoding@3.0.4											X					
 ipnet@2.12.0		X									X					
 is_terminal_polyfill@1.70.2		X									X					
+itertools@0.13.0		X									X					
 itertools@0.14.0		X									X					
 itoa@1.0.18		X									X					
 jiff@0.2.34											X			X		
@@ -255,11 +258,11 @@ object@0.37.3		X									X
 object_store@0.13.2		X									X					
 once_cell@1.21.4		X									X					
 once_cell_polyfill@1.70.2		X									X					
-opendal-core@0.58.0		X														
-opendal-http-transport-reqwest@0.58.0		X														
-opendal-layer-retry@0.58.0		X														
-opendal-service-fs@0.58.0		X														
-opendal-service-oss@0.58.0		X														
+opendal-core@0.58.2		X														
+opendal-http-transport-reqwest@0.58.2		X														
+opendal-layer-retry@0.58.2		X														
+opendal-service-fs@0.58.2		X														
+opendal-service-oss@0.58.2		X														
 openssl@0.10.81		X														
 openssl-macros@0.1.1		X									X					
 openssl-probe@0.2.1		X									X					
@@ -274,7 +277,7 @@ paimon-tpcds-bench@0.4.0		X
 paimon-vindex-core@0.4.0		X														
 parking_lot@0.12.5		X									X					
 parking_lot_core@0.9.12		X									X					
-parquet@58.3.0		X														
+parquet@58.4.0		X														
 paste@1.0.15		X									X					
 percent-encoding@2.3.2		X									X					
 petgraph@0.8.3		X									X					
@@ -315,9 +318,9 @@ regex@1.13.1		X									X
 regex-automata@0.4.16		X									X					
 regex-lite@0.1.9		X									X					
 regex-syntax@0.8.11		X									X					
-reqsign-aliyun-oss@3.1.1		X														
-reqsign-core@3.1.0		X														
-reqsign-file-read-tokio@3.0.2		X														
+reqsign-aliyun-oss@3.1.5		X														
+reqsign-core@3.3.1		X														
+reqsign-file-read-tokio@3.0.6		X														
 reqwest@0.12.28		X									X					
 reqwest@0.13.4		X									X					
 roaring@0.11.4		X									X					
@@ -440,7 +443,27 @@ windows-link@0.2.1		X									X
 windows-registry@0.6.1		X									X					
 windows-result@0.4.1		X									X					
 windows-strings@0.5.1		X									X					
+windows-sys@0.52.0		X									X					
+windows-sys@0.60.2		X									X					
 windows-sys@0.61.2		X									X					
+windows-targets@0.52.6		X									X					
+windows-targets@0.53.5		X									X					
+windows_aarch64_gnullvm@0.52.6		X									X					
+windows_aarch64_gnullvm@0.53.1		X									X					
+windows_aarch64_msvc@0.52.6		X									X					
+windows_aarch64_msvc@0.53.1		X									X					
+windows_i686_gnu@0.52.6		X									X					
+windows_i686_gnu@0.53.1		X									X					
+windows_i686_gnullvm@0.52.6		X									X					
+windows_i686_gnullvm@0.53.1		X									X					
+windows_i686_msvc@0.52.6		X									X					
+windows_i686_msvc@0.53.1		X									X					
+windows_x86_64_gnu@0.52.6		X									X					
+windows_x86_64_gnu@0.53.1		X									X					
+windows_x86_64_gnullvm@0.52.6		X									X					
+windows_x86_64_gnullvm@0.53.1		X									X					
+windows_x86_64_msvc@0.52.6		X									X					
+windows_x86_64_msvc@0.53.1		X									X					
 wit-bindgen@0.57.1		X	X								X					
 writeable@0.6.3													X			
 xattr@1.6.1		X									X					

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -9,23 +9,24 @@ android_system_properties@0.1.5		X									X
 anyhow@1.0.104		X									X				
 apache-avro@0.21.0		X													
 approx@0.5.1		X													
-arrow@58.3.0		X													
-arrow-arith@58.3.0		X													
-arrow-array@58.3.0		X									X				
-arrow-buffer@58.3.0		X													
-arrow-cast@58.3.0		X													
-arrow-csv@58.3.0		X													
-arrow-data@58.3.0		X													
-arrow-ipc@58.3.0		X													
-arrow-json@58.3.0		X													
-arrow-ord@58.3.0		X													
-arrow-row@58.3.0		X													
-arrow-schema@58.3.0		X													
-arrow-select@58.3.0		X													
-arrow-string@58.3.0		X													
+arrow@58.4.0		X													
+arrow-arith@58.4.0		X													
+arrow-array@58.4.0		X									X				
+arrow-buffer@58.4.0		X													
+arrow-cast@58.4.0		X													
+arrow-csv@58.4.0		X													
+arrow-data@58.4.0		X													
+arrow-ipc@58.4.0		X													
+arrow-json@58.4.0		X													
+arrow-ord@58.4.0		X													
+arrow-row@58.4.0		X													
+arrow-schema@58.4.0		X													
+arrow-select@58.4.0		X													
+arrow-string@58.4.0		X													
 async-stream@0.3.6											X				
 async-stream-impl@0.3.6											X				
 async-trait@0.1.91		X									X				
+asyncband@0.6.7		X													
 atoi@2.0.0											X				
 atomic-waker@1.1.2		X									X				
 autocfg@1.5.1		X									X				
@@ -33,6 +34,7 @@ aws-lc-rs@1.17.3		X							X
 aws-lc-sys@0.43.0		X			X				X		X	X			
 backon@1.6.0		X													
 base64@0.22.1		X									X				
+base64@0.23.1		X									X				
 bigdecimal@0.4.10		X									X				
 bitflags@2.13.1		X									X				
 block-buffer@0.10.4		X									X				
@@ -143,7 +145,7 @@ idna_adapter@1.2.2		X									X
 indexmap@2.14.0		X									X				
 integer-encoding@3.0.4											X				
 ipnet@2.12.0		X									X				
-itertools@0.14.0		X									X				
+itertools@0.13.0		X									X				
 itoa@1.0.18		X									X				
 jiff@0.2.34											X			X	
 jiff-core@0.1.0											X			X	
@@ -190,11 +192,11 @@ num-iter@0.1.46		X									X
 num-rational@0.4.2		X									X				
 num-traits@0.2.19		X									X				
 once_cell@1.21.4		X									X				
-opendal-core@0.58.0		X													
-opendal-http-transport-reqwest@0.58.0		X													
-opendal-layer-retry@0.58.0		X													
-opendal-service-fs@0.58.0		X													
-opendal-service-oss@0.58.0		X													
+opendal-core@0.58.2		X													
+opendal-http-transport-reqwest@0.58.2		X													
+opendal-layer-retry@0.58.2		X													
+opendal-service-fs@0.58.2		X													
+opendal-service-oss@0.58.2		X													
 openssl@0.10.81		X													
 openssl-macros@0.1.1		X									X				
 openssl-probe@0.2.1		X									X				
@@ -206,7 +208,7 @@ paimon@0.4.0		X
 paimon-c@0.4.0		X													
 paimon-mosaic-core@0.2.0		X													
 paimon-vindex-core@0.4.0		X													
-parquet@58.3.0		X													
+parquet@58.4.0		X													
 paste@1.0.15		X									X				
 percent-encoding@2.3.2		X									X				
 phf@0.12.1											X				
@@ -240,9 +242,9 @@ regex@1.13.1		X									X
 regex-automata@0.4.16		X									X				
 regex-lite@0.1.9		X									X				
 regex-syntax@0.8.11		X									X				
-reqsign-aliyun-oss@3.1.1		X													
-reqsign-core@3.1.0		X													
-reqsign-file-read-tokio@3.0.2		X													
+reqsign-aliyun-oss@3.1.5		X													
+reqsign-core@3.3.1		X													
+reqsign-file-read-tokio@3.0.6		X													
 reqwest@0.12.28		X									X				
 reqwest@0.13.4		X									X				
 roaring@0.11.4		X									X				
@@ -358,7 +360,27 @@ windows-link@0.2.1		X									X
 windows-registry@0.6.1		X									X				
 windows-result@0.4.1		X									X				
 windows-strings@0.5.1		X									X				
+windows-sys@0.52.0		X									X				
+windows-sys@0.60.2		X									X				
 windows-sys@0.61.2		X									X				
+windows-targets@0.52.6		X									X				
+windows-targets@0.53.5		X									X				
+windows_aarch64_gnullvm@0.52.6		X									X				
+windows_aarch64_gnullvm@0.53.1		X									X				
+windows_aarch64_msvc@0.52.6		X									X				
+windows_aarch64_msvc@0.53.1		X									X				
+windows_i686_gnu@0.52.6		X									X				
+windows_i686_gnu@0.53.1		X									X				
+windows_i686_gnullvm@0.52.6		X									X				
+windows_i686_gnullvm@0.53.1		X									X				
+windows_i686_msvc@0.52.6		X									X				
+windows_i686_msvc@0.53.1		X									X				
+windows_x86_64_gnu@0.52.6		X									X				
+windows_x86_64_gnu@0.53.1		X									X				
+windows_x86_64_gnullvm@0.52.6		X									X				
+windows_x86_64_gnullvm@0.53.1		X									X				
+windows_x86_64_msvc@0.52.6		X									X				
+windows_x86_64_msvc@0.53.1		X									X				
 wit-bindgen@0.57.1		X	X								X				
 writeable@0.6.3													X		
 xattr@1.6.1		X									X				

--- a/bindings/go/DEPENDENCIES.rust.tsv
+++ b/bindings/go/DEPENDENCIES.rust.tsv
@@ -9,23 +9,24 @@ android_system_properties@0.1.5		X									X
 anyhow@1.0.104		X									X				
 apache-avro@0.21.0		X													
 approx@0.5.1		X													
-arrow@58.3.0		X													
-arrow-arith@58.3.0		X													
-arrow-array@58.3.0		X									X				
-arrow-buffer@58.3.0		X													
-arrow-cast@58.3.0		X													
-arrow-csv@58.3.0		X													
-arrow-data@58.3.0		X													
-arrow-ipc@58.3.0		X													
-arrow-json@58.3.0		X													
-arrow-ord@58.3.0		X													
-arrow-row@58.3.0		X													
-arrow-schema@58.3.0		X													
-arrow-select@58.3.0		X													
-arrow-string@58.3.0		X													
+arrow@58.4.0		X													
+arrow-arith@58.4.0		X													
+arrow-array@58.4.0		X									X				
+arrow-buffer@58.4.0		X													
+arrow-cast@58.4.0		X													
+arrow-csv@58.4.0		X													
+arrow-data@58.4.0		X													
+arrow-ipc@58.4.0		X													
+arrow-json@58.4.0		X													
+arrow-ord@58.4.0		X													
+arrow-row@58.4.0		X													
+arrow-schema@58.4.0		X													
+arrow-select@58.4.0		X													
+arrow-string@58.4.0		X													
 async-stream@0.3.6											X				
 async-stream-impl@0.3.6											X				
 async-trait@0.1.91		X									X				
+asyncband@0.6.7		X													
 atoi@2.0.0											X				
 atomic-waker@1.1.2		X									X				
 autocfg@1.5.1		X									X				
@@ -33,6 +34,7 @@ aws-lc-rs@1.17.3		X							X
 aws-lc-sys@0.43.0		X			X				X		X	X			
 backon@1.6.0		X													
 base64@0.22.1		X									X				
+base64@0.23.1		X									X				
 bigdecimal@0.4.10		X									X				
 bitflags@2.13.1		X									X				
 block-buffer@0.10.4		X									X				
@@ -143,7 +145,7 @@ idna_adapter@1.2.2		X									X
 indexmap@2.14.0		X									X				
 integer-encoding@3.0.4											X				
 ipnet@2.12.0		X									X				
-itertools@0.14.0		X									X				
+itertools@0.13.0		X									X				
 itoa@1.0.18		X									X				
 jiff@0.2.34											X			X	
 jiff-core@0.1.0											X			X	
@@ -190,11 +192,11 @@ num-iter@0.1.46		X									X
 num-rational@0.4.2		X									X				
 num-traits@0.2.19		X									X				
 once_cell@1.21.4		X									X				
-opendal-core@0.58.0		X													
-opendal-http-transport-reqwest@0.58.0		X													
-opendal-layer-retry@0.58.0		X													
-opendal-service-fs@0.58.0		X													
-opendal-service-oss@0.58.0		X													
+opendal-core@0.58.2		X													
+opendal-http-transport-reqwest@0.58.2		X													
+opendal-layer-retry@0.58.2		X													
+opendal-service-fs@0.58.2		X													
+opendal-service-oss@0.58.2		X													
 openssl@0.10.81		X													
 openssl-macros@0.1.1		X									X				
 openssl-probe@0.2.1		X									X				
@@ -206,7 +208,7 @@ paimon@0.4.0		X
 paimon-c@0.4.0		X													
 paimon-mosaic-core@0.2.0		X													
 paimon-vindex-core@0.4.0		X													
-parquet@58.3.0		X													
+parquet@58.4.0		X													
 paste@1.0.15		X									X				
 percent-encoding@2.3.2		X									X				
 phf@0.12.1											X				
@@ -240,9 +242,9 @@ regex@1.13.1		X									X
 regex-automata@0.4.16		X									X				
 regex-lite@0.1.9		X									X				
 regex-syntax@0.8.11		X									X				
-reqsign-aliyun-oss@3.1.1		X													
-reqsign-core@3.1.0		X													
-reqsign-file-read-tokio@3.0.2		X													
+reqsign-aliyun-oss@3.1.5		X													
+reqsign-core@3.3.1		X													
+reqsign-file-read-tokio@3.0.6		X													
 reqwest@0.12.28		X									X				
 reqwest@0.13.4		X									X				
 roaring@0.11.4		X									X				
@@ -358,7 +360,27 @@ windows-link@0.2.1		X									X
 windows-registry@0.6.1		X									X				
 windows-result@0.4.1		X									X				
 windows-strings@0.5.1		X									X				
+windows-sys@0.52.0		X									X				
+windows-sys@0.60.2		X									X				
 windows-sys@0.61.2		X									X				
+windows-targets@0.52.6		X									X				
+windows-targets@0.53.5		X									X				
+windows_aarch64_gnullvm@0.52.6		X									X				
+windows_aarch64_gnullvm@0.53.1		X									X				
+windows_aarch64_msvc@0.52.6		X									X				
+windows_aarch64_msvc@0.53.1		X									X				
+windows_i686_gnu@0.52.6		X									X				
+windows_i686_gnu@0.53.1		X									X				
+windows_i686_gnullvm@0.52.6		X									X				
+windows_i686_gnullvm@0.53.1		X									X				
+windows_i686_msvc@0.52.6		X									X				
+windows_i686_msvc@0.53.1		X									X				
+windows_x86_64_gnu@0.52.6		X									X				
+windows_x86_64_gnu@0.53.1		X									X				
+windows_x86_64_gnullvm@0.52.6		X									X				
+windows_x86_64_gnullvm@0.53.1		X									X				
+windows_x86_64_msvc@0.52.6		X									X				
+windows_x86_64_msvc@0.53.1		X									X				
 wit-bindgen@0.57.1		X	X								X				
 writeable@0.6.3													X		
 xattr@1.6.1		X									X				

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -2,6 +2,7 @@ crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	B
 adler2@2.0.1	X	X										X							
 adler32@1.2.0																	X		
 aes@0.8.4		X										X							
+aes@0.9.2		X										X							
 ahash@0.8.12		X										X							
 aho-corasick@1.1.4												X				X			
 alloc-no-stdlib@2.0.4					X														
@@ -15,26 +16,27 @@ ar_archive_writer@0.5.2			X
 arc-swap@1.9.2		X										X							
 arrayref@0.3.9				X															
 arrayvec@0.7.8		X										X							
-arrow@58.3.0		X																	
-arrow-arith@58.3.0		X																	
-arrow-array@58.3.0		X										X							
-arrow-buffer@58.3.0		X																	
-arrow-cast@58.3.0		X																	
-arrow-csv@58.3.0		X																	
-arrow-data@58.3.0		X																	
-arrow-ipc@58.3.0		X																	
-arrow-json@58.3.0		X																	
-arrow-ord@58.3.0		X																	
-arrow-pyarrow@58.3.0		X																	
-arrow-row@58.3.0		X																	
-arrow-schema@58.3.0		X																	
-arrow-select@58.3.0		X																	
-arrow-string@58.3.0		X																	
+arrow@58.4.0		X																	
+arrow-arith@58.4.0		X																	
+arrow-array@58.4.0		X										X							
+arrow-buffer@58.4.0		X																	
+arrow-cast@58.4.0		X																	
+arrow-csv@58.4.0		X																	
+arrow-data@58.4.0		X																	
+arrow-ipc@58.4.0		X																	
+arrow-json@58.4.0		X																	
+arrow-ord@58.4.0		X																	
+arrow-pyarrow@58.4.0		X																	
+arrow-row@58.4.0		X																	
+arrow-schema@58.4.0		X																	
+arrow-select@58.4.0		X																	
+arrow-string@58.4.0		X																	
 async-compression@0.4.42		X										X							
 async-ffi@0.5.0												X							
 async-stream@0.3.6												X							
 async-stream-impl@0.3.6												X							
 async-trait@0.1.91		X										X							
+asyncband@0.6.7		X																	
 atoi@2.0.0												X							
 atomic-waker@1.1.2		X										X							
 autocfg@1.5.1		X										X							
@@ -42,6 +44,7 @@ aws-lc-rs@1.17.3		X								X
 aws-lc-sys@0.43.0		X			X					X		X	X						
 backon@1.6.0		X																	
 base64@0.22.1		X										X							
+base64@0.23.1		X										X							
 base64ct@1.8.3		X										X							
 bigdecimal@0.4.10		X										X							
 bitflags@2.13.1		X										X							
@@ -51,6 +54,7 @@ blake3@1.8.5		X	X				X
 block-buffer@0.10.4		X										X							
 block-buffer@0.12.1		X										X							
 block-padding@0.3.3		X										X							
+block-padding@0.4.2		X										X							
 bon@3.9.3		X										X							
 bon-macros@3.9.3		X										X							
 brotli@8.0.4					X							X							
@@ -62,13 +66,16 @@ byteorder@1.5.0												X				X
 bytes@1.12.1												X							
 bzip2@0.6.1		X										X							
 cbc@0.1.2		X										X							
+cbc@0.2.1		X										X							
 cc@1.3.0		X										X							
 cedarwood@0.5.0				X															
 census@0.4.2												X							
 cfg-if@1.0.4		X										X							
+chacha20@0.10.1		X										X							
 chrono@0.4.45		X										X							
 chrono-tz@0.10.4		X										X							
 cipher@0.4.4		X										X							
+cipher@0.5.2		X										X							
 cmake@0.1.58		X										X							
 cmov@0.5.4		X										X							
 combine@4.6.7												X							
@@ -83,6 +90,7 @@ constant_time_eq@0.4.2		X					X						X
 core-foundation@0.10.1		X										X							
 core-foundation@0.9.4		X										X							
 core-foundation-sys@0.8.7		X										X							
+cpubits@0.1.1		X										X							
 cpufeatures@0.2.17		X										X							
 cpufeatures@0.3.0		X										X							
 crc@3.4.0		X										X							
@@ -98,7 +106,7 @@ crypto-common@0.1.7		X										X
 crypto-common@0.2.2		X										X							
 csv@1.4.0												X				X			
 csv-core@0.1.13												X				X			
-ctr@0.9.2		X										X							
+ctr@0.10.1		X										X							
 ctutils@0.4.2		X										X							
 darling@0.23.0												X							
 darling_core@0.23.0												X							
@@ -142,7 +150,7 @@ datafusion-sql@54.0.0		X
 datasketches@0.2.0		X																	
 der@0.7.10		X										X							
 deranged@0.5.8		X										X							
-des@0.8.1		X										X							
+des@0.9.0		X										X							
 diff@0.1.13		X										X							
 digest@0.10.7		X										X							
 digest@0.11.3		X										X							
@@ -195,7 +203,7 @@ hashbrown@0.14.5		X										X
 hashbrown@0.15.5		X										X							
 hashbrown@0.16.1		X										X							
 hashbrown@0.17.1		X										X							
-hdfs-native@0.13.5		X																	
+hdfs-native@0.14.5		X																	
 heck@0.5.0		X										X							
 hex@0.4.3		X										X							
 hmac@0.12.1		X										X							
@@ -229,9 +237,11 @@ include-flate-codegen@0.3.4		X
 include-flate-compress@0.3.4		X																	
 indexmap@2.14.0		X										X							
 inout@0.1.4		X										X							
+inout@0.2.2		X										X							
 integer-encoding@3.0.4												X							
 inventory@0.3.24		X										X							
 ipnet@2.12.0		X										X							
+itertools@0.13.0		X										X							
 itertools@0.14.0		X										X							
 itoa@1.0.18		X										X							
 jieba-macros@0.10.3												X							
@@ -298,22 +308,24 @@ num-integer@0.1.46		X										X
 num-iter@0.1.46		X										X							
 num-rational@0.4.2		X										X							
 num-traits@0.2.19		X										X							
+objc2-core-foundation@0.3.2		X										X					X		
+objc2-system-configuration@0.3.2		X										X					X		
 object@0.37.3		X										X							
 object_store@0.13.2		X										X							
 once_cell@1.21.4		X										X							
 oneshot@0.1.13		X										X							
-opendal-core@0.58.0		X																	
-opendal-http-transport-reqwest@0.58.0		X																	
-opendal-layer-retry@0.58.0		X																	
-opendal-service-azdls@0.58.0		X																	
-opendal-service-azure-common@0.58.0		X																	
-opendal-service-cos@0.58.0		X																	
-opendal-service-fs@0.58.0		X																	
-opendal-service-gcs@0.58.0		X																	
-opendal-service-hdfs-native@0.58.0		X																	
-opendal-service-obs@0.58.0		X																	
-opendal-service-oss@0.58.0		X																	
-opendal-service-s3@0.58.0		X																	
+opendal-core@0.58.2		X																	
+opendal-http-transport-reqwest@0.58.2		X																	
+opendal-layer-retry@0.58.2		X																	
+opendal-service-azdls@0.58.2		X																	
+opendal-service-azure-common@0.58.2		X																	
+opendal-service-cos@0.58.2		X																	
+opendal-service-fs@0.58.2		X																	
+opendal-service-gcs@0.58.2		X																	
+opendal-service-hdfs-native@0.58.2		X																	
+opendal-service-obs@0.58.2		X																	
+opendal-service-oss@0.58.2		X																	
+opendal-service-s3@0.58.2		X																	
 openssl@0.10.81		X																	
 openssl-macros@0.1.1		X										X							
 openssl-probe@0.2.1		X										X							
@@ -330,10 +342,10 @@ paimon-mosaic-core@0.2.0		X
 paimon-vindex-core@0.4.0		X																	
 parking_lot@0.12.5		X										X							
 parking_lot_core@0.9.12		X										X							
-parquet@58.3.0		X																	
+parquet@58.4.0		X																	
 paste@1.0.15		X										X							
 pbkdf2@0.12.2		X										X							
-pem@3.0.6												X							
+pem@4.0.0												X							
 pem-rfc7468@0.7.0		X										X							
 percent-encoding@2.3.2		X										X							
 petgraph@0.8.3		X										X							
@@ -350,7 +362,6 @@ pkcs1@0.7.5		X										X
 pkcs5@0.7.1		X										X							
 pkcs8@0.10.2		X										X							
 pkg-config@0.3.33		X										X							
-plain@0.2.3		X										X							
 portable-atomic@1.14.0		X										X							
 portable-atomic-util@0.2.7		X										X							
 potential_utf@0.1.5															X				
@@ -379,10 +390,12 @@ quick-xml@0.41.0												X
 quote@1.0.47		X										X							
 r-efi@5.3.0		X									X	X							
 r-efi@6.0.0		X									X	X							
+rand@0.10.2		X										X							
 rand@0.8.7		X										X							
 rand@0.9.5		X										X							
 rand_chacha@0.3.1		X										X							
 rand_chacha@0.9.0		X										X							
+rand_core@0.10.1		X										X							
 rand_core@0.6.4		X										X							
 rand_core@0.9.5		X										X							
 rawpointer@0.2.1		X										X							
@@ -391,19 +404,19 @@ rayon-core@1.13.0		X										X
 recursive@0.1.1												X							
 recursive-proc-macro-impl@0.1.1												X							
 redox_syscall@0.5.18												X							
-redox_syscall@0.9.0												X							
 regex@1.13.1		X										X							
 regex-automata@0.4.16		X										X							
 regex-lite@0.1.9		X										X							
 regex-syntax@0.8.11		X										X							
-reqsign-aliyun-oss@3.1.1		X																	
-reqsign-aws-v4@3.0.2		X																	
-reqsign-azure-storage@3.1.0		X																	
-reqsign-core@3.1.0		X																	
-reqsign-file-read-tokio@3.0.2		X																	
-reqsign-google@3.0.2		X																	
-reqsign-huaweicloud-obs@3.0.2		X																	
-reqsign-tencent-cos@3.0.2		X																	
+reqsign-aliyun-oss@3.1.5		X																	
+reqsign-aws-core@3.1.1		X																	
+reqsign-aws-v4@3.3.0		X																	
+reqsign-azure-storage@3.2.1		X																	
+reqsign-core@3.3.1		X																	
+reqsign-file-read-tokio@3.0.6		X																	
+reqsign-google@3.1.1		X																	
+reqsign-huaweicloud-obs@3.0.6		X																	
+reqsign-tencent-cos@3.0.6		X																	
 reqwest@0.12.28		X										X							
 reqwest@0.13.4		X										X							
 rle-decode-fast@1.0.3		X										X							
@@ -542,8 +555,9 @@ version_check@0.9.5		X										X
 walkdir@2.5.0												X				X			
 want@0.3.1												X							
 wasi@0.11.1+wasi-snapshot-preview1		X	X									X							
+wasi@0.14.7+wasi-0.2.4		X	X									X							
 wasip2@1.0.4+wasi-0.2.12		X	X									X							
-wasite@0.1.0		X				X						X							
+wasite@1.0.2		X				X						X							
 wasm-bindgen@0.2.126		X										X							
 wasm-bindgen-futures@0.4.76		X										X							
 wasm-bindgen-macro@0.2.126		X										X							
@@ -553,7 +567,7 @@ wasm-streams@0.5.0		X										X
 web-sys@0.3.103		X										X							
 web-time@1.1.0		X										X							
 webpki-root-certs@1.0.9								X											
-whoami@1.6.1		X				X						X							
+whoami@2.1.3		X				X						X							
 wide@0.7.33		X										X					X		
 winapi@0.3.9		X										X							
 winapi-i686-pc-windows-gnu@0.4.0		X										X							
@@ -566,6 +580,7 @@ windows-link@0.2.1		X										X
 windows-registry@0.6.1		X										X							
 windows-result@0.4.1		X										X							
 windows-strings@0.5.1		X										X							
+windows-sys@0.52.0		X										X							
 windows-sys@0.59.0		X										X							
 windows-sys@0.60.2		X										X							
 windows-sys@0.61.2		X										X							

--- a/crates/integration_tests/DEPENDENCIES.rust.tsv
+++ b/crates/integration_tests/DEPENDENCIES.rust.tsv
@@ -9,23 +9,24 @@ android_system_properties@0.1.5		X									X
 anyhow@1.0.104		X									X				
 apache-avro@0.21.0		X													
 approx@0.5.1		X													
-arrow@58.3.0		X													
-arrow-arith@58.3.0		X													
-arrow-array@58.3.0		X									X				
-arrow-buffer@58.3.0		X													
-arrow-cast@58.3.0		X													
-arrow-csv@58.3.0		X													
-arrow-data@58.3.0		X													
-arrow-ipc@58.3.0		X													
-arrow-json@58.3.0		X													
-arrow-ord@58.3.0		X													
-arrow-row@58.3.0		X													
-arrow-schema@58.3.0		X													
-arrow-select@58.3.0		X													
-arrow-string@58.3.0		X													
+arrow@58.4.0		X													
+arrow-arith@58.4.0		X													
+arrow-array@58.4.0		X									X				
+arrow-buffer@58.4.0		X													
+arrow-cast@58.4.0		X													
+arrow-csv@58.4.0		X													
+arrow-data@58.4.0		X													
+arrow-ipc@58.4.0		X													
+arrow-json@58.4.0		X													
+arrow-ord@58.4.0		X													
+arrow-row@58.4.0		X													
+arrow-schema@58.4.0		X													
+arrow-select@58.4.0		X													
+arrow-string@58.4.0		X													
 async-stream@0.3.6											X				
 async-stream-impl@0.3.6											X				
 async-trait@0.1.91		X									X				
+asyncband@0.6.7		X													
 atoi@2.0.0											X				
 atomic-waker@1.1.2		X									X				
 autocfg@1.5.1		X									X				
@@ -33,6 +34,7 @@ aws-lc-rs@1.17.3		X							X
 aws-lc-sys@0.43.0		X			X				X		X	X			
 backon@1.6.0		X													
 base64@0.22.1		X									X				
+base64@0.23.1		X									X				
 bigdecimal@0.4.10		X									X				
 bitflags@2.13.1		X									X				
 block-buffer@0.10.4		X									X				
@@ -143,7 +145,7 @@ idna_adapter@1.2.2		X									X
 indexmap@2.14.0		X									X				
 integer-encoding@3.0.4											X				
 ipnet@2.12.0		X									X				
-itertools@0.14.0		X									X				
+itertools@0.13.0		X									X				
 itoa@1.0.18		X									X				
 jiff@0.2.34											X			X	
 jiff-core@0.1.0											X			X	
@@ -190,11 +192,11 @@ num-iter@0.1.46		X									X
 num-rational@0.4.2		X									X				
 num-traits@0.2.19		X									X				
 once_cell@1.21.4		X									X				
-opendal-core@0.58.0		X													
-opendal-http-transport-reqwest@0.58.0		X													
-opendal-layer-retry@0.58.0		X													
-opendal-service-fs@0.58.0		X													
-opendal-service-oss@0.58.0		X													
+opendal-core@0.58.2		X													
+opendal-http-transport-reqwest@0.58.2		X													
+opendal-layer-retry@0.58.2		X													
+opendal-service-fs@0.58.2		X													
+opendal-service-oss@0.58.2		X													
 openssl@0.10.81		X													
 openssl-macros@0.1.1		X									X				
 openssl-probe@0.2.1		X									X				
@@ -206,7 +208,7 @@ paimon@0.4.0		X
 paimon-integration-tests@0.4.0		X													
 paimon-mosaic-core@0.2.0		X													
 paimon-vindex-core@0.4.0		X													
-parquet@58.3.0		X													
+parquet@58.4.0		X													
 paste@1.0.15		X									X				
 percent-encoding@2.3.2		X									X				
 phf@0.12.1											X				
@@ -240,9 +242,9 @@ regex@1.13.1		X									X
 regex-automata@0.4.16		X									X				
 regex-lite@0.1.9		X									X				
 regex-syntax@0.8.11		X									X				
-reqsign-aliyun-oss@3.1.1		X													
-reqsign-core@3.1.0		X													
-reqsign-file-read-tokio@3.0.2		X													
+reqsign-aliyun-oss@3.1.5		X													
+reqsign-core@3.3.1		X													
+reqsign-file-read-tokio@3.0.6		X													
 reqwest@0.12.28		X									X				
 reqwest@0.13.4		X									X				
 roaring@0.11.4		X									X				
@@ -358,7 +360,27 @@ windows-link@0.2.1		X									X
 windows-registry@0.6.1		X									X				
 windows-result@0.4.1		X									X				
 windows-strings@0.5.1		X									X				
+windows-sys@0.52.0		X									X				
+windows-sys@0.60.2		X									X				
 windows-sys@0.61.2		X									X				
+windows-targets@0.52.6		X									X				
+windows-targets@0.53.5		X									X				
+windows_aarch64_gnullvm@0.52.6		X									X				
+windows_aarch64_gnullvm@0.53.1		X									X				
+windows_aarch64_msvc@0.52.6		X									X				
+windows_aarch64_msvc@0.53.1		X									X				
+windows_i686_gnu@0.52.6		X									X				
+windows_i686_gnu@0.53.1		X									X				
+windows_i686_gnullvm@0.52.6		X									X				
+windows_i686_gnullvm@0.53.1		X									X				
+windows_i686_msvc@0.52.6		X									X				
+windows_i686_msvc@0.53.1		X									X				
+windows_x86_64_gnu@0.52.6		X									X				
+windows_x86_64_gnu@0.53.1		X									X				
+windows_x86_64_gnullvm@0.52.6		X									X				
+windows_x86_64_gnullvm@0.53.1		X									X				
+windows_x86_64_msvc@0.52.6		X									X				
+windows_x86_64_msvc@0.53.1		X									X				
 wit-bindgen@0.57.1		X	X								X				
 writeable@0.6.3													X		
 xattr@1.6.1		X									X				

--- a/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
+++ b/crates/integrations/datafusion/DEPENDENCIES.rust.tsv
@@ -15,20 +15,20 @@ arc-swap@1.9.2		X									X
 arcref@0.2.0											X							
 arrayref@0.3.9				X														
 arrayvec@0.7.8		X									X							
-arrow@58.3.0		X																
-arrow-arith@58.3.0		X																
-arrow-array@58.3.0		X									X							
-arrow-buffer@58.3.0		X																
-arrow-cast@58.3.0		X																
-arrow-csv@58.3.0		X																
-arrow-data@58.3.0		X																
-arrow-ipc@58.3.0		X																
-arrow-json@58.3.0		X																
-arrow-ord@58.3.0		X																
-arrow-row@58.3.0		X																
-arrow-schema@58.3.0		X																
-arrow-select@58.3.0		X																
-arrow-string@58.3.0		X																
+arrow@58.4.0		X																
+arrow-arith@58.4.0		X																
+arrow-array@58.4.0		X									X							
+arrow-buffer@58.4.0		X																
+arrow-cast@58.4.0		X																
+arrow-csv@58.4.0		X																
+arrow-data@58.4.0		X																
+arrow-ipc@58.4.0		X																
+arrow-json@58.4.0		X																
+arrow-ord@58.4.0		X																
+arrow-row@58.4.0		X																
+arrow-schema@58.4.0		X																
+arrow-select@58.4.0		X																
+arrow-string@58.4.0		X																
 async-channel@2.5.0		X									X							
 async-compression@0.4.42		X									X							
 async-executor@1.14.0		X									X							
@@ -42,6 +42,7 @@ async-stream@0.3.6											X
 async-stream-impl@0.3.6											X							
 async-task@4.7.1		X									X							
 async-trait@0.1.91		X									X							
+asyncband@0.6.7		X																
 atoi@2.0.0											X							
 atomic-waker@1.1.2		X									X							
 autocfg@1.5.1		X									X							
@@ -49,6 +50,7 @@ aws-lc-rs@1.17.3		X							X
 aws-lc-sys@0.43.0		X			X				X		X	X						
 backon@1.6.0		X																
 base64@0.22.1		X									X							
+base64@0.23.1		X									X							
 better_io@0.2.0		X																
 bigdecimal@0.4.10		X									X							
 bindgen@0.72.1					X													
@@ -328,11 +330,11 @@ object_store@0.13.2		X									X
 once_cell@1.21.4		X									X							
 oneshot@0.1.13		X									X							
 oneshot@0.2.1		X									X							
-opendal-core@0.58.0		X																
-opendal-http-transport-reqwest@0.58.0		X																
-opendal-layer-retry@0.58.0		X																
-opendal-service-fs@0.58.0		X																
-opendal-service-oss@0.58.0		X																
+opendal-core@0.58.2		X																
+opendal-http-transport-reqwest@0.58.2		X																
+opendal-layer-retry@0.58.2		X																
+opendal-service-fs@0.58.2		X																
+opendal-service-oss@0.58.2		X																
 openssl@0.10.81		X																
 openssl-macros@0.1.1		X									X							
 openssl-probe@0.2.1		X									X							
@@ -350,7 +352,7 @@ paimon-vindex-core@0.4.0		X
 parking@2.2.1		X									X							
 parking_lot@0.12.5		X									X							
 parking_lot_core@0.9.12		X									X							
-parquet@58.3.0		X																
+parquet@58.4.0		X																
 paste@1.0.15		X									X							
 pco@1.0.2		X																
 percent-encoding@2.3.2		X									X							
@@ -409,9 +411,9 @@ regex@1.13.1		X									X
 regex-automata@0.4.16		X									X							
 regex-lite@0.1.9		X									X							
 regex-syntax@0.8.11		X									X							
-reqsign-aliyun-oss@3.1.1		X																
-reqsign-core@3.1.0		X																
-reqsign-file-read-tokio@3.0.2		X																
+reqsign-aliyun-oss@3.1.5		X																
+reqsign-core@3.3.1		X																
+reqsign-file-read-tokio@3.0.6		X																
 reqwest@0.12.28		X									X							
 reqwest@0.13.4		X									X							
 rle-decode-fast@1.0.3		X									X							
@@ -594,17 +596,28 @@ windows-link@0.2.1		X									X
 windows-registry@0.6.1		X									X							
 windows-result@0.4.1		X									X							
 windows-strings@0.5.1		X									X							
+windows-sys@0.52.0		X									X							
 windows-sys@0.59.0		X									X							
+windows-sys@0.60.2		X									X							
 windows-sys@0.61.2		X									X							
 windows-targets@0.52.6		X									X							
+windows-targets@0.53.5		X									X							
 windows_aarch64_gnullvm@0.52.6		X									X							
+windows_aarch64_gnullvm@0.53.1		X									X							
 windows_aarch64_msvc@0.52.6		X									X							
+windows_aarch64_msvc@0.53.1		X									X							
 windows_i686_gnu@0.52.6		X									X							
+windows_i686_gnu@0.53.1		X									X							
 windows_i686_gnullvm@0.52.6		X									X							
+windows_i686_gnullvm@0.53.1		X									X							
 windows_i686_msvc@0.52.6		X									X							
+windows_i686_msvc@0.53.1		X									X							
 windows_x86_64_gnu@0.52.6		X									X							
+windows_x86_64_gnu@0.53.1		X									X							
 windows_x86_64_gnullvm@0.52.6		X									X							
+windows_x86_64_gnullvm@0.53.1		X									X							
 windows_x86_64_msvc@0.52.6		X									X							
+windows_x86_64_msvc@0.53.1		X									X							
 wit-bindgen@0.57.1		X	X								X							
 writeable@0.6.3														X				
 wyz@0.5.1											X							

--- a/crates/paimon-rest-server/DEPENDENCIES.rust.tsv
+++ b/crates/paimon-rest-server/DEPENDENCIES.rust.tsv
@@ -9,23 +9,24 @@ android_system_properties@0.1.5		X									X
 anyhow@1.0.104		X									X				
 apache-avro@0.21.0		X													
 approx@0.5.1		X													
-arrow@58.3.0		X													
-arrow-arith@58.3.0		X													
-arrow-array@58.3.0		X									X				
-arrow-buffer@58.3.0		X													
-arrow-cast@58.3.0		X													
-arrow-csv@58.3.0		X													
-arrow-data@58.3.0		X													
-arrow-ipc@58.3.0		X													
-arrow-json@58.3.0		X													
-arrow-ord@58.3.0		X													
-arrow-row@58.3.0		X													
-arrow-schema@58.3.0		X													
-arrow-select@58.3.0		X													
-arrow-string@58.3.0		X													
+arrow@58.4.0		X													
+arrow-arith@58.4.0		X													
+arrow-array@58.4.0		X									X				
+arrow-buffer@58.4.0		X													
+arrow-cast@58.4.0		X													
+arrow-csv@58.4.0		X													
+arrow-data@58.4.0		X													
+arrow-ipc@58.4.0		X													
+arrow-json@58.4.0		X													
+arrow-ord@58.4.0		X													
+arrow-row@58.4.0		X													
+arrow-schema@58.4.0		X													
+arrow-select@58.4.0		X													
+arrow-string@58.4.0		X													
 async-stream@0.3.6											X				
 async-stream-impl@0.3.6											X				
 async-trait@0.1.91		X									X				
+asyncband@0.6.7		X													
 atoi@2.0.0											X				
 atomic-waker@1.1.2		X									X				
 autocfg@1.5.1		X									X				
@@ -36,6 +37,7 @@ axum-core@0.4.5											X
 axum-macros@0.4.2											X				
 backon@1.6.0		X													
 base64@0.22.1		X									X				
+base64@0.23.1		X									X				
 bigdecimal@0.4.10		X									X				
 bitflags@2.13.1		X									X				
 block-buffer@0.10.4		X									X				
@@ -146,7 +148,7 @@ idna_adapter@1.2.2		X									X
 indexmap@2.14.0		X									X				
 integer-encoding@3.0.4											X				
 ipnet@2.12.0		X									X				
-itertools@0.14.0		X									X				
+itertools@0.13.0		X									X				
 itoa@1.0.18		X									X				
 jiff@0.2.34											X			X	
 jiff-core@0.1.0											X			X	
@@ -194,11 +196,11 @@ num-iter@0.1.46		X									X
 num-rational@0.4.2		X									X				
 num-traits@0.2.19		X									X				
 once_cell@1.21.4		X									X				
-opendal-core@0.58.0		X													
-opendal-http-transport-reqwest@0.58.0		X													
-opendal-layer-retry@0.58.0		X													
-opendal-service-fs@0.58.0		X													
-opendal-service-oss@0.58.0		X													
+opendal-core@0.58.2		X													
+opendal-http-transport-reqwest@0.58.2		X													
+opendal-layer-retry@0.58.2		X													
+opendal-service-fs@0.58.2		X													
+opendal-service-oss@0.58.2		X													
 openssl@0.10.81		X													
 openssl-macros@0.1.1		X									X				
 openssl-probe@0.2.1		X									X				
@@ -210,7 +212,7 @@ paimon@0.4.0		X
 paimon-mosaic-core@0.2.0		X													
 paimon-rest-server@0.4.0		X													
 paimon-vindex-core@0.4.0		X													
-parquet@58.3.0		X													
+parquet@58.4.0		X													
 paste@1.0.15		X									X				
 percent-encoding@2.3.2		X									X				
 phf@0.12.1											X				
@@ -244,9 +246,9 @@ regex@1.13.1		X									X
 regex-automata@0.4.16		X									X				
 regex-lite@0.1.9		X									X				
 regex-syntax@0.8.11		X									X				
-reqsign-aliyun-oss@3.1.1		X													
-reqsign-core@3.1.0		X													
-reqsign-file-read-tokio@3.0.2		X													
+reqsign-aliyun-oss@3.1.5		X													
+reqsign-core@3.3.1		X													
+reqsign-file-read-tokio@3.0.6		X													
 reqwest@0.12.28		X									X				
 reqwest@0.13.4		X									X				
 roaring@0.11.4		X									X				
@@ -364,7 +366,27 @@ windows-link@0.2.1		X									X
 windows-registry@0.6.1		X									X				
 windows-result@0.4.1		X									X				
 windows-strings@0.5.1		X									X				
+windows-sys@0.52.0		X									X				
+windows-sys@0.60.2		X									X				
 windows-sys@0.61.2		X									X				
+windows-targets@0.52.6		X									X				
+windows-targets@0.53.5		X									X				
+windows_aarch64_gnullvm@0.52.6		X									X				
+windows_aarch64_gnullvm@0.53.1		X									X				
+windows_aarch64_msvc@0.52.6		X									X				
+windows_aarch64_msvc@0.53.1		X									X				
+windows_i686_gnu@0.52.6		X									X				
+windows_i686_gnu@0.53.1		X									X				
+windows_i686_gnullvm@0.52.6		X									X				
+windows_i686_gnullvm@0.53.1		X									X				
+windows_i686_msvc@0.52.6		X									X				
+windows_i686_msvc@0.53.1		X									X				
+windows_x86_64_gnu@0.52.6		X									X				
+windows_x86_64_gnu@0.53.1		X									X				
+windows_x86_64_gnullvm@0.52.6		X									X				
+windows_x86_64_gnullvm@0.53.1		X									X				
+windows_x86_64_msvc@0.52.6		X									X				
+windows_x86_64_msvc@0.53.1		X									X				
 wit-bindgen@0.57.1		X	X								X				
 writeable@0.6.3													X		
 xattr@1.6.1		X									X				

--- a/crates/paimon/DEPENDENCIES.rust.tsv
+++ b/crates/paimon/DEPENDENCIES.rust.tsv
@@ -2,6 +2,7 @@ crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	B
 adler2@2.0.1	X	X									X						
 adler32@1.2.0																X	
 aes@0.8.4		X									X						
+aes@0.9.2		X									X						
 ahash@0.8.12		X									X						
 aho-corasick@1.1.4											X				X		
 alloc-no-stdlib@2.0.4					X												
@@ -13,20 +14,20 @@ apache-avro@0.21.0		X
 approx@0.5.1		X															
 arc-swap@1.9.2		X									X						
 arcref@0.2.0											X						
-arrow@58.3.0		X															
-arrow-arith@58.3.0		X															
-arrow-array@58.3.0		X									X						
-arrow-buffer@58.3.0		X															
-arrow-cast@58.3.0		X															
-arrow-csv@58.3.0		X															
-arrow-data@58.3.0		X															
-arrow-ipc@58.3.0		X															
-arrow-json@58.3.0		X															
-arrow-ord@58.3.0		X															
-arrow-row@58.3.0		X															
-arrow-schema@58.3.0		X															
-arrow-select@58.3.0		X															
-arrow-string@58.3.0		X															
+arrow@58.4.0		X															
+arrow-arith@58.4.0		X															
+arrow-array@58.4.0		X									X						
+arrow-buffer@58.4.0		X															
+arrow-cast@58.4.0		X															
+arrow-csv@58.4.0		X															
+arrow-data@58.4.0		X															
+arrow-ipc@58.4.0		X															
+arrow-json@58.4.0		X															
+arrow-ord@58.4.0		X															
+arrow-row@58.4.0		X															
+arrow-schema@58.4.0		X															
+arrow-select@58.4.0		X															
+arrow-string@58.4.0		X															
 async-channel@2.5.0		X									X						
 async-executor@1.14.0		X									X						
 async-fs@2.2.0		X									X						
@@ -39,6 +40,7 @@ async-stream@0.3.6											X
 async-stream-impl@0.3.6											X						
 async-task@4.7.1		X									X						
 async-trait@0.1.91		X									X						
+asyncband@0.6.7		X															
 atoi@2.0.0											X						
 atomic-waker@1.1.2		X									X						
 autocfg@1.5.1		X									X						
@@ -46,6 +48,7 @@ aws-lc-rs@1.17.3		X							X
 aws-lc-sys@0.43.0		X			X				X		X	X					
 backon@1.6.0		X															
 base64@0.22.1		X									X						
+base64@0.23.1		X									X						
 base64ct@1.8.3		X									X						
 better_io@0.2.0		X															
 bigdecimal@0.4.10		X									X						
@@ -57,6 +60,7 @@ bitvec@1.1.1											X
 block-buffer@0.10.4		X									X						
 block-buffer@0.12.1		X									X						
 block-padding@0.3.3		X									X						
+block-padding@0.4.2		X									X						
 blocking@1.6.2		X									X						
 bon@3.9.3		X									X						
 bon-macros@3.9.3		X									X						
@@ -68,6 +72,7 @@ bytemuck@1.25.2		X									X					X
 byteorder@1.5.0											X				X		
 bytes@1.12.1											X						
 cbc@0.1.2		X									X						
+cbc@0.2.1		X									X						
 cc@1.3.0		X									X						
 cedarwood@0.5.0				X													
 census@0.4.2											X						
@@ -77,6 +82,7 @@ chacha20@0.10.1		X									X
 chrono@0.4.45		X									X						
 chrono-tz@0.10.4		X									X						
 cipher@0.4.4		X									X						
+cipher@0.5.2		X									X						
 clang-sys@1.8.1		X															
 cmake@0.1.58		X									X						
 cmov@0.5.4		X									X						
@@ -92,6 +98,7 @@ core-foundation@0.10.1		X									X
 core-foundation@0.9.4		X									X						
 core-foundation-sys@0.8.7		X									X						
 core_detect@1.0.0		X									X						
+cpubits@0.1.1		X									X						
 cpufeatures@0.2.17		X									X						
 cpufeatures@0.3.0		X									X						
 crc@3.4.0		X									X						
@@ -107,7 +114,7 @@ crypto-common@0.1.7		X									X
 crypto-common@0.2.2		X									X						
 csv@1.4.0											X				X		
 csv-core@0.1.13											X				X		
-ctr@0.9.2		X									X						
+ctr@0.10.1		X									X						
 ctutils@0.4.2		X									X						
 custom-labels@0.4.6		X															
 darling@0.23.0											X						
@@ -118,7 +125,7 @@ dashmap@6.2.1											X
 datasketches@0.2.0		X															
 der@0.7.10		X									X						
 deranged@0.5.8		X									X						
-des@0.8.1		X									X						
+des@0.9.0		X									X						
 diff@0.1.13		X									X						
 digest@0.10.7		X									X						
 digest@0.11.3		X									X						
@@ -180,7 +187,7 @@ half@2.7.1		X									X
 hashbrown@0.14.5		X									X						
 hashbrown@0.16.1		X									X						
 hashbrown@0.17.1		X									X						
-hdfs-native@0.13.5		X															
+hdfs-native@0.14.5		X															
 heck@0.5.0		X									X						
 hermit-abi@0.5.2		X									X						
 hex@0.4.3		X									X						
@@ -215,6 +222,7 @@ include-flate-codegen@0.3.4		X
 include-flate-compress@0.3.4		X															
 indexmap@2.14.0		X									X						
 inout@0.1.4		X									X						
+inout@0.2.2		X									X						
 integer-encoding@3.0.4											X						
 inventory@0.3.24		X									X						
 ipnet@2.12.0		X									X						
@@ -295,21 +303,23 @@ num-rational@0.4.2		X									X
 num-traits@0.2.19		X									X						
 num_enum@0.7.6		X			X						X						
 num_enum_derive@0.7.6		X			X						X						
+objc2-core-foundation@0.3.2		X									X					X	
+objc2-system-configuration@0.3.2		X									X					X	
 once_cell@1.21.4		X									X						
 oneshot@0.1.13		X									X						
 oneshot@0.2.1		X									X						
-opendal-core@0.58.0		X															
-opendal-http-transport-reqwest@0.58.0		X															
-opendal-layer-retry@0.58.0		X															
-opendal-service-azdls@0.58.0		X															
-opendal-service-azure-common@0.58.0		X															
-opendal-service-cos@0.58.0		X															
-opendal-service-fs@0.58.0		X															
-opendal-service-gcs@0.58.0		X															
-opendal-service-hdfs-native@0.58.0		X															
-opendal-service-obs@0.58.0		X															
-opendal-service-oss@0.58.0		X															
-opendal-service-s3@0.58.0		X															
+opendal-core@0.58.2		X															
+opendal-http-transport-reqwest@0.58.2		X															
+opendal-layer-retry@0.58.2		X															
+opendal-service-azdls@0.58.2		X															
+opendal-service-azure-common@0.58.2		X															
+opendal-service-cos@0.58.2		X															
+opendal-service-fs@0.58.2		X															
+opendal-service-gcs@0.58.2		X															
+opendal-service-hdfs-native@0.58.2		X															
+opendal-service-obs@0.58.2		X															
+opendal-service-oss@0.58.2		X															
+opendal-service-s3@0.58.2		X															
 openssl@0.10.81		X															
 openssl-macros@0.1.1		X									X						
 openssl-probe@0.2.1		X									X						
@@ -326,11 +336,11 @@ paimon-vindex-core@0.4.0		X
 parking@2.2.1		X									X						
 parking_lot@0.12.5		X									X						
 parking_lot_core@0.9.12		X									X						
-parquet@58.3.0		X															
+parquet@58.4.0		X															
 paste@1.0.15		X									X						
 pbkdf2@0.12.2		X									X						
 pco@1.0.2		X															
-pem@3.0.6											X						
+pem@4.0.0											X						
 pem-rfc7468@0.7.0		X									X						
 percent-encoding@2.3.2		X									X						
 phf@0.12.1											X						
@@ -345,7 +355,6 @@ pkcs1@0.7.5		X									X
 pkcs5@0.7.1		X									X						
 pkcs8@0.10.2		X									X						
 pkg-config@0.3.33		X									X						
-plain@0.2.3		X									X						
 polling@3.11.0		X									X						
 polonius-the-crab@0.2.1		X									X					X	
 portable-atomic@1.14.0		X									X						
@@ -382,19 +391,19 @@ rawpointer@0.2.1		X									X
 rayon@1.12.0		X									X						
 rayon-core@1.13.0		X									X						
 redox_syscall@0.5.18											X						
-redox_syscall@0.9.0											X						
 regex@1.13.1		X									X						
 regex-automata@0.4.16		X									X						
 regex-lite@0.1.9		X									X						
 regex-syntax@0.8.11		X									X						
-reqsign-aliyun-oss@3.1.1		X															
-reqsign-aws-v4@3.0.2		X															
-reqsign-azure-storage@3.1.0		X															
-reqsign-core@3.1.0		X															
-reqsign-file-read-tokio@3.0.2		X															
-reqsign-google@3.0.2		X															
-reqsign-huaweicloud-obs@3.0.2		X															
-reqsign-tencent-cos@3.0.2		X															
+reqsign-aliyun-oss@3.1.5		X															
+reqsign-aws-core@3.1.1		X															
+reqsign-aws-v4@3.3.0		X															
+reqsign-azure-storage@3.2.1		X															
+reqsign-core@3.3.1		X															
+reqsign-file-read-tokio@3.0.6		X															
+reqsign-google@3.1.1		X															
+reqsign-huaweicloud-obs@3.0.6		X															
+reqsign-tencent-cos@3.0.6		X															
 reqwest@0.12.28		X									X						
 reqwest@0.13.4		X									X						
 rle-decode-fast@1.0.3		X									X						
@@ -559,8 +568,9 @@ vortex-zstd@0.75.0		X
 walkdir@2.5.0											X				X		
 want@0.3.1											X						
 wasi@0.11.1+wasi-snapshot-preview1		X	X								X						
+wasi@0.14.7+wasi-0.2.4		X	X								X						
 wasip2@1.0.4+wasi-0.2.12		X	X								X						
-wasite@0.1.0		X				X					X						
+wasite@1.0.2		X				X					X						
 wasm-bindgen@0.2.126		X									X						
 wasm-bindgen-futures@0.4.76		X									X						
 wasm-bindgen-macro@0.2.126		X									X						
@@ -570,7 +580,7 @@ wasm-streams@0.5.0		X									X
 web-sys@0.3.103		X									X						
 web-time@1.1.0		X									X						
 webpki-root-certs@1.0.9								X									
-whoami@1.6.1		X				X					X						
+whoami@2.1.3		X				X					X						
 wide@0.7.33		X									X					X	
 winapi@0.3.9		X									X						
 winapi-i686-pc-windows-gnu@0.4.0		X									X						
@@ -583,6 +593,7 @@ windows-link@0.2.1		X									X
 windows-registry@0.6.1		X									X						
 windows-result@0.4.1		X									X						
 windows-strings@0.5.1		X									X						
+windows-sys@0.52.0		X									X						
 windows-sys@0.59.0		X									X						
 windows-sys@0.60.2		X									X						
 windows-sys@0.61.2		X									X						


### PR DESCRIPTION
  ### Purpose

  `arrow` and `opendal` are locked a few releases behind what the manifests already allow. Both moves stay inside the declared ranges (`arrow = "58.0"`, `opendal-core = "0.58.0"`), so this is a lockfile refresh with no manifest change — noticed while refreshing by hand.

  - `arrow` 58.3.0 → 58.4.0 — a 58-line maintenance release carrying backported cargo audit fixes. `arrow-array`, `arrow-buffer` and `arrow-ipc` are unchanged in it; the changes sit under `parquet`.
  - `opendal` 0.58.0 → 0.58.2 — a patch release. It brings its own dependencies forward with it, which is most of the churn below: `reqsign` 3.0.2 → 3.3.0 and the ciphers under it (`aes`, `cipher`, `cbc`, `ctr`).

  `arrow` 59 exists but is outside the declared range, so it is not part of this.

  ### Brief change log

  - `cargo update` for the arrow and opendal families; 52 packages move version.
  - Regenerated the nine dependency reports so `dependencies.py verify` stays green.

  ### Tests

  Against this branch, with the Spark fixture warehouse provisioned from `dev/spark/provision.py`:

  - `cargo build -p paimon -p paimon-datafusion` — clean.
  - `paimon` lib — 2405 passed.
  - `paimon-datafusion` lib — 346 passed, none failed.
  - `paimon-datafusion` `read_tables` — 45 passed. The two failures left are `vector_search_tests`, which need `liblumina_py.so` on the host.
  - `python3 scripts/dependencies.py verify` — passes.

  The python, go and c suites were not run locally; CI covers them.

  ### API and Format

  No API change, no format change.