### PR TITLE
feat(c): expose FileIO cache callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4726,6 +4726,7 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
+ "async-trait",
  "bytes",
  "futures",
  "paimon",

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -38,9 +38,10 @@ arrow = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
 serde_json = "1.0.120"
+async-trait = "0.1.81"
+bytes = "1.7.1"
 
 [dev-dependencies]
 # Test-only: the vector-search integration tests build a real primary-key vindex
 # IVF-flat ANN segment fixture in-process. Versions match crates/paimon.
-bytes = "1.7.1"
 paimon-vindex-core = "0.4.0"

--- a/bindings/c/src/file_io.rs
+++ b/bindings/c/src/file_io.rs
@@ -1,0 +1,293 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::ffi::{c_char, c_void};
+use std::ops::Range;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use paimon::io::{FileBlockCache, FileIO};
+
+use crate::error::{paimon_error, validate_cstr, PaimonErrorCode};
+use crate::result::paimon_result_file_io_new;
+use crate::types::{paimon_file_cache_callbacks_v1, paimon_file_io, paimon_option};
+
+#[derive(Debug)]
+struct CFileBlockCache {
+    inner: Arc<CFileBlockCacheInner>,
+}
+
+struct CFileBlockCacheInner {
+    context: usize,
+    get: unsafe extern "C" fn(*mut c_void, *const u8, usize, u64, usize, *mut u8) -> i64,
+    put: Option<unsafe extern "C" fn(*mut c_void, *const u8, usize, u64, *const u8, usize) -> i32>,
+    invalidate_path: Option<unsafe extern "C" fn(*mut c_void, *const u8, usize) -> i32>,
+    invalidate_prefix: Option<unsafe extern "C" fn(*mut c_void, *const u8, usize) -> i32>,
+    destroy: Option<unsafe extern "C" fn(*mut c_void)>,
+}
+
+impl std::fmt::Debug for CFileBlockCacheInner {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CFileBlockCacheInner")
+            .field("context", &self.context)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for CFileBlockCacheInner {
+    fn drop(&mut self) {
+        if let Some(destroy) = self.destroy {
+            unsafe { destroy(self.context as *mut c_void) };
+        }
+    }
+}
+
+impl CFileBlockCache {
+    unsafe fn from_callbacks(callbacks: &paimon_file_cache_callbacks_v1) -> Result<Self, String> {
+        let get = callbacks
+            .get
+            .ok_or_else(|| "file cache callback `get` must not be null".to_string())?;
+        Ok(Self {
+            inner: Arc::new(CFileBlockCacheInner {
+                context: callbacks.context as usize,
+                get,
+                put: callbacks.put,
+                invalidate_path: callbacks.invalidate_path,
+                invalidate_prefix: callbacks.invalidate_prefix,
+                destroy: callbacks.destroy,
+            }),
+        })
+    }
+
+    async fn invalidate(
+        &self,
+        path: &str,
+        callback: Option<unsafe extern "C" fn(*mut c_void, *const u8, usize) -> i32>,
+    ) {
+        let Some(callback) = callback else {
+            return;
+        };
+        let path = path.as_bytes().to_vec();
+        let inner = self.inner.clone();
+        let _ = tokio::task::spawn_blocking(move || unsafe {
+            callback(inner.context as *mut c_void, path.as_ptr(), path.len())
+        })
+        .await;
+    }
+}
+
+#[async_trait::async_trait]
+impl FileBlockCache for CFileBlockCache {
+    async fn get(&self, path: &str, range: Range<u64>) -> Option<Bytes> {
+        let length = usize::try_from(range.end.checked_sub(range.start)?).ok()?;
+        let expected = i64::try_from(length).ok()?;
+        let path = path.as_bytes().to_vec();
+        let inner = self.inner.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut output = vec![0_u8; length];
+            let copied = unsafe {
+                (inner.get)(
+                    inner.context as *mut c_void,
+                    path.as_ptr(),
+                    path.len(),
+                    range.start,
+                    length,
+                    output.as_mut_ptr(),
+                )
+            };
+            (copied == expected).then(|| Bytes::from(output))
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+
+    async fn put(&self, path: &str, offset: u64, data: Bytes) {
+        let Some(put) = self.inner.put else {
+            return;
+        };
+        let path = path.as_bytes().to_vec();
+        let inner = self.inner.clone();
+        let _ = tokio::task::spawn_blocking(move || unsafe {
+            put(
+                inner.context as *mut c_void,
+                path.as_ptr(),
+                path.len(),
+                offset,
+                data.as_ptr(),
+                data.len(),
+            )
+        })
+        .await;
+    }
+
+    async fn invalidate_path(&self, path: &str) {
+        self.invalidate(path, self.inner.invalidate_path).await;
+    }
+
+    async fn invalidate_prefix(&self, prefix: &str) {
+        self.invalidate(prefix, self.inner.invalidate_prefix).await;
+    }
+}
+
+unsafe fn parse_options(
+    options: *const paimon_option,
+    options_len: usize,
+) -> Result<HashMap<String, String>, *mut paimon_error> {
+    if options.is_null() && options_len > 0 {
+        return Err(paimon_error::new(
+            PaimonErrorCode::InvalidInput,
+            "null options pointer with non-zero length".to_string(),
+        ));
+    }
+    let mut parsed = HashMap::with_capacity(options_len);
+    if options_len > 0 {
+        for option in std::slice::from_raw_parts(options, options_len) {
+            let key = validate_cstr(option.key, "storage option key")?;
+            let value = validate_cstr(option.value, "storage option value")?;
+            parsed.insert(key, value);
+        }
+    }
+    Ok(parsed)
+}
+
+unsafe fn create_file_io(
+    path: *const c_char,
+    options: *const paimon_option,
+    options_len: usize,
+) -> Result<FileIO, *mut paimon_error> {
+    let path = validate_cstr(path, "path")?;
+    let options = parse_options(options, options_len)?;
+    FileIO::from_path(path)
+        .and_then(|builder| builder.with_props(options).build())
+        .map_err(paimon_error::from_paimon)
+}
+
+fn file_io_result(result: Result<FileIO, *mut paimon_error>) -> paimon_result_file_io_new {
+    match result {
+        Ok(file_io) => paimon_result_file_io_new {
+            file_io: Box::into_raw(Box::new(paimon_file_io {
+                inner: Box::into_raw(Box::new(file_io)) as *mut c_void,
+            })),
+            error: std::ptr::null_mut(),
+        },
+        Err(error) => paimon_result_file_io_new {
+            file_io: std::ptr::null_mut(),
+            error,
+        },
+    }
+}
+
+/// Create a reusable FileIO from a representative storage path and options.
+#[no_mangle]
+pub unsafe extern "C" fn paimon_file_io_create(
+    path: *const c_char,
+    options: *const paimon_option,
+    options_len: usize,
+) -> paimon_result_file_io_new {
+    file_io_result(create_file_io(path, options, options_len))
+}
+
+/// Create a reusable FileIO backed by a caller-managed block cache.
+///
+/// A non-null `callbacks->get` and a non-zero `block_size` are required.
+/// `whitelist` may be null to use `meta,global-index`. Once validation and
+/// storage construction succeed, Rust owns `callbacks->context` and invokes
+/// `destroy` exactly once after the last derived FileIO/table is dropped.
+#[no_mangle]
+pub unsafe extern "C" fn paimon_file_io_create_with_cache_v1(
+    path: *const c_char,
+    options: *const paimon_option,
+    options_len: usize,
+    callbacks: *const paimon_file_cache_callbacks_v1,
+    block_size: u64,
+    whitelist: *const c_char,
+) -> paimon_result_file_io_new {
+    if callbacks.is_null() {
+        return file_io_result(Err(paimon_error::new(
+            PaimonErrorCode::InvalidInput,
+            "null pointer passed for `callbacks`".to_string(),
+        )));
+    }
+    if block_size == 0 || usize::try_from(block_size).is_err() {
+        return file_io_result(Err(paimon_error::new(
+            PaimonErrorCode::InvalidInput,
+            "file cache block_size must be representable by size_t and greater than zero"
+                .to_string(),
+        )));
+    }
+    let whitelist = if whitelist.is_null() {
+        "meta,global-index".to_string()
+    } else {
+        match validate_cstr(whitelist, "whitelist") {
+            Ok(value) => value,
+            Err(error) => return file_io_result(Err(error)),
+        }
+    };
+    let file_io = match create_file_io(path, options, options_len) {
+        Ok(file_io) => file_io,
+        Err(error) => return file_io_result(Err(error)),
+    };
+    let cache = match CFileBlockCache::from_callbacks(&*callbacks) {
+        Ok(cache) => Arc::new(cache),
+        Err(message) => {
+            return file_io_result(Err(paimon_error::new(
+                PaimonErrorCode::InvalidInput,
+                message,
+            )))
+        }
+    };
+    file_io_result(
+        file_io
+            .with_file_block_cache(cache, block_size, &whitelist)
+            .map_err(paimon_error::from_paimon),
+    )
+}
+
+/// Free a FileIO handle. Tables created from it retain their own clone.
+#[no_mangle]
+pub unsafe extern "C" fn paimon_file_io_free(file_io: *mut paimon_file_io) {
+    if !file_io.is_null() {
+        let wrapper = Box::from_raw(file_io);
+        if !wrapper.inner.is_null() {
+            drop(Box::from_raw(wrapper.inner as *mut FileIO));
+        }
+    }
+}
+
+pub(crate) unsafe fn file_io_ref<'a>(file_io: *const paimon_file_io) -> &'a FileIO {
+    &*((*file_io).inner as *const FileIO)
+}
+
+// Additive C ABI signature guards. Existing symbols must never gain parameters;
+// introduce a new versioned symbol when the callback table changes.
+const _: unsafe extern "C" fn(
+    *const c_char,
+    *const paimon_option,
+    usize,
+) -> paimon_result_file_io_new = paimon_file_io_create;
+const _: unsafe extern "C" fn(
+    *const c_char,
+    *const paimon_option,
+    usize,
+    *const paimon_file_cache_callbacks_v1,
+    u64,
+    *const c_char,
+) -> paimon_result_file_io_new = paimon_file_io_create_with_cache_v1;
+const _: unsafe extern "C" fn(*mut paimon_file_io) = paimon_file_io_free;

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -21,6 +21,7 @@
 
 mod catalog;
 mod error;
+mod file_io;
 mod identifier;
 mod result;
 mod table;

--- a/bindings/c/src/result.rs
+++ b/bindings/c/src/result.rs
@@ -25,6 +25,12 @@ pub struct paimon_result_catalog_new {
 }
 
 #[repr(C)]
+pub struct paimon_result_file_io_new {
+    pub file_io: *mut paimon_file_io,
+    pub error: *mut paimon_error,
+}
+
+#[repr(C)]
 pub struct paimon_result_identifier_new {
     pub identifier: *mut paimon_identifier,
     pub error: *mut paimon_error,

--- a/bindings/c/src/table.rs
+++ b/bindings/c/src/table.rs
@@ -28,6 +28,7 @@ use paimon::table::{ArrowRecordBatchStream, DataSplit, Table};
 use paimon::Plan;
 
 use crate::error::{check_non_null, paimon_error, validate_cstr, PaimonErrorCode};
+use crate::file_io::file_io_ref;
 use crate::result::{
     paimon_result_get_table, paimon_result_new_read, paimon_result_next_batch, paimon_result_plan,
     paimon_result_predicate, paimon_result_read_builder, paimon_result_record_batch_reader,
@@ -60,6 +61,38 @@ unsafe fn box_table_read_state(state: TableReadState) -> *mut paimon_table_read 
 }
 
 // ======================= Table ===============================
+
+fn resolved_table_result(
+    file_io: FileIO,
+    table_path: String,
+    schema: TableSchema,
+    database: String,
+    table_name: String,
+    branch: String,
+) -> paimon_result_get_table {
+    let table = match Table::from_resolved_schema(
+        file_io,
+        Identifier::new(database, table_name),
+        table_path,
+        schema,
+        branch,
+    ) {
+        Ok(table) => table,
+        Err(error) => {
+            return paimon_result_get_table {
+                table: std::ptr::null_mut(),
+                error: paimon_error::from_paimon(error),
+            }
+        }
+    };
+    let wrapper = Box::new(paimon_table {
+        inner: Box::into_raw(Box::new(table)) as *mut c_void,
+    });
+    paimon_result_get_table {
+        table: Box::into_raw(wrapper),
+        error: std::ptr::null_mut(),
+    }
+}
 
 /// Create a table directly from a resolved Paimon table schema JSON.
 ///
@@ -192,35 +225,112 @@ pub unsafe extern "C" fn paimon_table_from_schema_json(
             }
         }
     };
-    let table = match Table::from_resolved_schema(
-        file_io,
-        Identifier::new(database, table_name),
-        table_path,
-        schema,
-        branch,
-    ) {
-        Ok(table) => table,
+    resolved_table_result(file_io, table_path, schema, database, table_name, branch)
+}
+
+/// Create a table from a resolved schema and a caller-created FileIO.
+///
+/// The FileIO is cloned into the table, so its handle may be freed immediately
+/// after this call. This additive API allows native embedders to share storage
+/// and an externally managed cache across tables.
+///
+/// # Safety
+/// `file_io` must be returned by a Paimon FileIO constructor. All string
+/// pointers except `branch` must be valid null-terminated C strings. `branch`
+/// may be null to select `main`.
+#[no_mangle]
+pub unsafe extern "C" fn paimon_table_from_schema_json_with_file_io(
+    file_io: *const paimon_file_io,
+    table_path: *const c_char,
+    table_schema_json: *const c_char,
+    database: *const c_char,
+    table_name: *const c_char,
+    branch: *const c_char,
+) -> paimon_result_get_table {
+    if let Err(error) = check_non_null(file_io, "file_io") {
+        return paimon_result_get_table {
+            table: std::ptr::null_mut(),
+            error,
+        };
+    }
+    let table_path = match validate_cstr(table_path, "table_path") {
+        Ok(value) => value,
         Err(error) => {
             return paimon_result_get_table {
                 table: std::ptr::null_mut(),
-                error: paimon_error::from_paimon(error),
+                error,
             }
         }
     };
-    let wrapper = Box::new(paimon_table {
-        inner: Box::into_raw(Box::new(table)) as *mut c_void,
-    });
-    paimon_result_get_table {
-        table: Box::into_raw(wrapper),
-        error: std::ptr::null_mut(),
-    }
+    let table_schema_json = match validate_cstr(table_schema_json, "table_schema_json") {
+        Ok(value) => value,
+        Err(error) => {
+            return paimon_result_get_table {
+                table: std::ptr::null_mut(),
+                error,
+            }
+        }
+    };
+    let database = match validate_cstr(database, "database") {
+        Ok(value) => value,
+        Err(error) => {
+            return paimon_result_get_table {
+                table: std::ptr::null_mut(),
+                error,
+            }
+        }
+    };
+    let table_name = match validate_cstr(table_name, "table_name") {
+        Ok(value) => value,
+        Err(error) => {
+            return paimon_result_get_table {
+                table: std::ptr::null_mut(),
+                error,
+            }
+        }
+    };
+    let branch = if branch.is_null() {
+        DEFAULT_MAIN_BRANCH.to_string()
+    } else {
+        match validate_cstr(branch, "branch") {
+            Ok(value) => value,
+            Err(error) => {
+                return paimon_result_get_table {
+                    table: std::ptr::null_mut(),
+                    error,
+                }
+            }
+        }
+    };
+    let schema = match serde_json::from_str::<TableSchema>(&table_schema_json) {
+        Ok(schema) => schema,
+        Err(error) => {
+            return paimon_result_get_table {
+                table: std::ptr::null_mut(),
+                error: paimon_error::new(
+                    PaimonErrorCode::InvalidInput,
+                    format!("Failed to parse table schema JSON: {error}"),
+                ),
+            }
+        }
+    };
+
+    resolved_table_result(
+        file_io_ref(file_io).clone(),
+        table_path,
+        schema,
+        database,
+        table_name,
+        branch,
+    )
 }
 
 /// Free a paimon_table.
 ///
 /// # Safety
-/// Only call with a table returned from `paimon_catalog_get_table` or
-/// `paimon_table_from_schema_json`.
+/// Only call with a table returned from `paimon_catalog_get_table`,
+/// `paimon_table_from_schema_json`, or
+/// `paimon_table_from_schema_json_with_file_io`.
 #[no_mangle]
 pub unsafe extern "C" fn paimon_table_free(table: *mut paimon_table) {
     free_table_wrapper(table, |t| t.inner);
@@ -1944,6 +2054,14 @@ const _: unsafe extern "C" fn(
     *const paimon_option,
     usize,
 ) -> paimon_result_get_table = paimon_table_from_schema_json;
+const _: unsafe extern "C" fn(
+    *const paimon_file_io,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+    *const c_char,
+) -> paimon_result_get_table = paimon_table_from_schema_json_with_file_io;
 const _: unsafe extern "C" fn(*const paimon_table) -> paimon_result_read_builder =
     paimon_table_new_read_builder;
 const _: unsafe extern "C" fn(

--- a/bindings/c/src/tests.rs
+++ b/bindings/c/src/tests.rs
@@ -26,11 +26,13 @@
 //! must NOT wrap C FFI calls inside another `block_on`. Use the global
 //! runtime only for Rust-API setup (write_data_rust, setup_table_dirs).
 
+use std::collections::HashMap;
 use std::ffi::{c_void, CString};
 use std::mem::ManuallyDrop;
 use std::process::Command;
 use std::ptr;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use arrow::buffer::NullBuffer;
 use arrow_array::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
@@ -42,6 +44,7 @@ use paimon::spec::{CommitKind, DataType, IntType, Schema, TableSchema, VarCharTy
 use paimon::table::{SnapshotManager, Table};
 
 use crate::error::*;
+use crate::file_io::*;
 use crate::table::*;
 use crate::types::*;
 use crate::vector_search::*;
@@ -345,6 +348,304 @@ unsafe fn read_rows_ffi(table: *const paimon_table) -> Vec<(i32, String)> {
 // =========================================================================
 //  Catalog-free table construction tests
 // =========================================================================
+
+#[derive(Default)]
+struct TestFileCacheState {
+    blocks: Mutex<HashMap<(String, u64), Vec<u8>>>,
+    hits: AtomicUsize,
+    misses: AtomicUsize,
+    puts: AtomicUsize,
+    invalidations: AtomicUsize,
+    destroys: AtomicUsize,
+}
+
+struct TestFileCacheContext {
+    state: Arc<TestFileCacheState>,
+}
+
+unsafe extern "C" fn test_file_cache_get(
+    context: *mut c_void,
+    path_data: *const u8,
+    path_length: usize,
+    offset: u64,
+    length: usize,
+    output: *mut u8,
+) -> i64 {
+    let context = &*(context as *const TestFileCacheContext);
+    let path =
+        String::from_utf8_lossy(std::slice::from_raw_parts(path_data, path_length)).into_owned();
+    let blocks = context.state.blocks.lock().unwrap();
+    let Some(data) = blocks
+        .get(&(path, offset))
+        .filter(|data| data.len() == length)
+    else {
+        context.state.misses.fetch_add(1, Ordering::SeqCst);
+        return -1;
+    };
+    ptr::copy_nonoverlapping(data.as_ptr(), output, length);
+    context.state.hits.fetch_add(1, Ordering::SeqCst);
+    length as i64
+}
+
+unsafe extern "C" fn test_file_cache_short_get(
+    _context: *mut c_void,
+    _path_data: *const u8,
+    _path_length: usize,
+    _offset: u64,
+    length: usize,
+    output: *mut u8,
+) -> i64 {
+    if length > 0 {
+        output.write(0);
+    }
+    length.saturating_sub(1) as i64
+}
+
+unsafe extern "C" fn test_file_cache_put(
+    context: *mut c_void,
+    path_data: *const u8,
+    path_length: usize,
+    offset: u64,
+    data: *const u8,
+    length: usize,
+) -> i32 {
+    let context = &*(context as *const TestFileCacheContext);
+    let path =
+        String::from_utf8_lossy(std::slice::from_raw_parts(path_data, path_length)).into_owned();
+    let data = std::slice::from_raw_parts(data, length).to_vec();
+    context
+        .state
+        .blocks
+        .lock()
+        .unwrap()
+        .insert((path, offset), data);
+    context.state.puts.fetch_add(1, Ordering::SeqCst);
+    0
+}
+
+unsafe extern "C" fn test_file_cache_invalidate_path(
+    context: *mut c_void,
+    path_data: *const u8,
+    path_length: usize,
+) -> i32 {
+    let context = &*(context as *const TestFileCacheContext);
+    let path =
+        String::from_utf8_lossy(std::slice::from_raw_parts(path_data, path_length)).into_owned();
+    context
+        .state
+        .blocks
+        .lock()
+        .unwrap()
+        .retain(|(cached_path, _), _| cached_path != &path);
+    context.state.invalidations.fetch_add(1, Ordering::SeqCst);
+    0
+}
+
+unsafe extern "C" fn test_file_cache_invalidate_prefix(
+    context: *mut c_void,
+    prefix_data: *const u8,
+    prefix_length: usize,
+) -> i32 {
+    let context = &*(context as *const TestFileCacheContext);
+    let prefix = String::from_utf8_lossy(std::slice::from_raw_parts(prefix_data, prefix_length))
+        .into_owned();
+    context
+        .state
+        .blocks
+        .lock()
+        .unwrap()
+        .retain(|(cached_path, _), _| !cached_path.starts_with(&prefix));
+    context.state.invalidations.fetch_add(1, Ordering::SeqCst);
+    0
+}
+
+unsafe extern "C" fn test_file_cache_destroy(context: *mut c_void) {
+    let context = Box::from_raw(context as *mut TestFileCacheContext);
+    context.state.destroys.fetch_add(1, Ordering::SeqCst);
+}
+
+fn test_file_cache_callbacks(state: Arc<TestFileCacheState>) -> paimon_file_cache_callbacks_v1 {
+    paimon_file_cache_callbacks_v1 {
+        context: Box::into_raw(Box::new(TestFileCacheContext { state })) as *mut c_void,
+        get: Some(test_file_cache_get),
+        put: Some(test_file_cache_put),
+        invalidate_path: Some(test_file_cache_invalidate_path),
+        invalidate_prefix: Some(test_file_cache_invalidate_prefix),
+        destroy: Some(test_file_cache_destroy),
+    }
+}
+
+#[test]
+fn test_file_io_external_cache_miss_populates_and_hit_reuses_blocks() {
+    let state = Arc::new(TestFileCacheState::default());
+    let callbacks = test_file_cache_callbacks(state.clone());
+    let root = CString::new("memory:/ffi_external_cache").unwrap();
+    let whitelist = CString::new("meta").unwrap();
+
+    unsafe {
+        let result = paimon_file_io_create_with_cache_v1(
+            root.as_ptr(),
+            ptr::null(),
+            0,
+            &callbacks,
+            4,
+            whitelist.as_ptr(),
+        );
+        assert!(result.error.is_null());
+        let file_io = file_io_ref(result.file_io);
+        let path = "memory:/ffi_external_cache/snapshot/snapshot-1";
+        crate::runtime()
+            .block_on(
+                file_io
+                    .new_output(path)
+                    .unwrap()
+                    .write(bytes::Bytes::from_static(b"abcdefgh")),
+            )
+            .unwrap();
+
+        let first = crate::runtime()
+            .block_on(file_io.new_input(path).unwrap().read())
+            .unwrap();
+        let second = crate::runtime()
+            .block_on(file_io.new_input(path).unwrap().read())
+            .unwrap();
+        assert_eq!(first.as_ref(), b"abcdefgh");
+        assert_eq!(second.as_ref(), b"abcdefgh");
+        assert_eq!(state.puts.load(Ordering::SeqCst), 2);
+        assert!(state.misses.load(Ordering::SeqCst) >= 1);
+        assert_eq!(state.hits.load(Ordering::SeqCst), 2);
+        assert_eq!(state.invalidations.load(Ordering::SeqCst), 1);
+
+        paimon_file_io_free(result.file_io);
+        assert_eq!(state.destroys.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[test]
+fn test_table_with_file_io_retains_cache_context_until_table_is_freed() {
+    let state = Arc::new(TestFileCacheState::default());
+    let callbacks = test_file_cache_callbacks(state.clone());
+    let path = CString::new("memory:/ffi_file_io_table").unwrap();
+    let file_io = unsafe {
+        paimon_file_io_create_with_cache_v1(
+            path.as_ptr(),
+            ptr::null(),
+            0,
+            &callbacks,
+            4,
+            ptr::null(),
+        )
+    };
+    assert!(file_io.error.is_null());
+
+    let schema_json = CString::new(serde_json::to_string(&simple_table_schema()).unwrap()).unwrap();
+    let database = CString::new("default").unwrap();
+    let table_name = CString::new("test").unwrap();
+    unsafe {
+        let table = paimon_table_from_schema_json_with_file_io(
+            file_io.file_io,
+            path.as_ptr(),
+            schema_json.as_ptr(),
+            database.as_ptr(),
+            table_name.as_ptr(),
+            ptr::null(),
+        );
+        assert!(table.error.is_null());
+
+        paimon_file_io_free(file_io.file_io);
+        assert_eq!(state.destroys.load(Ordering::SeqCst), 0);
+        paimon_table_free(table.table);
+        assert_eq!(state.destroys.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[test]
+fn test_file_io_external_cache_rejects_invalid_callback_contract() {
+    let path = CString::new("memory:/ffi_invalid_cache").unwrap();
+    let callbacks = paimon_file_cache_callbacks_v1 {
+        context: ptr::null_mut(),
+        get: None,
+        put: None,
+        invalidate_path: None,
+        invalidate_prefix: None,
+        destroy: None,
+    };
+    unsafe {
+        let missing_get = paimon_file_io_create_with_cache_v1(
+            path.as_ptr(),
+            ptr::null(),
+            0,
+            &callbacks,
+            4,
+            ptr::null(),
+        );
+        assert!(missing_get.file_io.is_null());
+        assert_eq!(
+            (*missing_get.error).code,
+            PaimonErrorCode::InvalidInput as i32
+        );
+        paimon_error_free(missing_get.error);
+
+        let zero_block = paimon_file_io_create_with_cache_v1(
+            path.as_ptr(),
+            ptr::null(),
+            0,
+            &paimon_file_cache_callbacks_v1 {
+                get: Some(test_file_cache_get),
+                ..callbacks
+            },
+            0,
+            ptr::null(),
+        );
+        assert!(zero_block.file_io.is_null());
+        assert_eq!(
+            (*zero_block.error).code,
+            PaimonErrorCode::InvalidInput as i32
+        );
+        paimon_error_free(zero_block.error);
+    }
+}
+
+#[test]
+fn test_file_io_external_cache_short_hit_fails_open_to_storage() {
+    let callbacks = paimon_file_cache_callbacks_v1 {
+        context: ptr::null_mut(),
+        get: Some(test_file_cache_short_get),
+        put: None,
+        invalidate_path: None,
+        invalidate_prefix: None,
+        destroy: None,
+    };
+    let root = CString::new("memory:/ffi_short_cache_hit").unwrap();
+    let whitelist = CString::new("meta").unwrap();
+    unsafe {
+        let result = paimon_file_io_create_with_cache_v1(
+            root.as_ptr(),
+            ptr::null(),
+            0,
+            &callbacks,
+            4,
+            whitelist.as_ptr(),
+        );
+        assert!(result.error.is_null());
+        let file_io = file_io_ref(result.file_io);
+        let path = "memory:/ffi_short_cache_hit/snapshot/snapshot-1";
+        crate::runtime()
+            .block_on(
+                file_io
+                    .new_output(path)
+                    .unwrap()
+                    .write(bytes::Bytes::from_static(b"source")),
+            )
+            .unwrap();
+
+        let actual = crate::runtime()
+            .block_on(file_io.new_input(path).unwrap().read())
+            .unwrap();
+        assert_eq!(actual.as_ref(), b"source");
+        paimon_file_io_free(result.file_io);
+    }
+}
 
 #[test]
 fn test_table_from_schema_json_preserves_resolved_schema_and_branch() {
@@ -2222,8 +2523,6 @@ fn test_two_commits_same_builder() {
 //
 // The materialized stream carries the user table columns plus a unified
 // `__paimon_search_score` Float32 column; row order is best-first.
-
-use std::collections::HashMap;
 
 use arrow_array::builder::{FixedSizeListBuilder, Float32Builder, ListBuilder};
 use arrow_array::{ArrayRef, Float32Array};

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -68,6 +68,57 @@ pub struct paimon_catalog {
     pub inner: *mut c_void,
 }
 
+/// Opaque wrapper around a cloneable Paimon FileIO.
+#[repr(C)]
+pub struct paimon_file_io {
+    pub inner: *mut c_void,
+}
+
+/// Version 1 callbacks for an externally managed file-block cache.
+///
+/// Callbacks may run concurrently on arbitrary Rust runtime blocking threads.
+/// They must not unwind across the C ABI. `get` returns the number of bytes
+/// copied into `output`; return `-1` for a miss and any value other than the
+/// requested length for a fail-open miss. All callback buffers and paths are
+/// borrowed only for the duration of the call. Paths use pointer-plus-length
+/// because canonical storage keys may contain embedded NUL separators.
+#[repr(C)]
+pub struct paimon_file_cache_callbacks_v1 {
+    pub context: *mut c_void,
+    pub get: Option<
+        unsafe extern "C" fn(
+            context: *mut c_void,
+            path_data: *const u8,
+            path_length: usize,
+            offset: u64,
+            length: usize,
+            output: *mut u8,
+        ) -> i64,
+    >,
+    pub put: Option<
+        unsafe extern "C" fn(
+            context: *mut c_void,
+            path_data: *const u8,
+            path_length: usize,
+            offset: u64,
+            data: *const u8,
+            length: usize,
+        ) -> i32,
+    >,
+    pub invalidate_path: Option<
+        unsafe extern "C" fn(context: *mut c_void, path_data: *const u8, path_length: usize) -> i32,
+    >,
+    pub invalidate_prefix: Option<
+        unsafe extern "C" fn(
+            context: *mut c_void,
+            prefix_data: *const u8,
+            prefix_length: usize,
+        ) -> i32,
+    >,
+    /// Releases `context` after the last FileIO/table clone is dropped.
+    pub destroy: Option<unsafe extern "C" fn(context: *mut c_void)>,
+}
+
 #[repr(C)]
 pub struct paimon_identifier {
     pub inner: *mut c_void,

--- a/crates/paimon/src/io/cache/mod.rs
+++ b/crates/paimon/src/io/cache/mod.rs
@@ -25,6 +25,7 @@ use self::file_type::FileType;
 use self::memory::MemoryCache;
 use self::state::{BlockKey, CacheCoordinator, CacheReadToken};
 use crate::common::{CatalogOptions, Options};
+use crate::io::FileBlockCache;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -50,9 +51,30 @@ pub(crate) struct LocalCache {
 enum CacheBackend {
     Memory(MemoryCache),
     Disk(Arc<DiskCache>),
+    External(Arc<dyn FileBlockCache>),
 }
 
 impl LocalCache {
+    pub(in crate::io) fn external(
+        cache: Arc<dyn FileBlockCache>,
+        block_size: u64,
+        whitelist: &str,
+    ) -> crate::Result<Self> {
+        if block_size == 0 {
+            return Err(crate::Error::ConfigInvalid {
+                message: "External file cache block size must be greater than zero".to_string(),
+            });
+        }
+        Ok(Self {
+            backend: CacheBackend::External(cache),
+            coordinator: Arc::new(CacheCoordinator::default()),
+            namespace: String::new(),
+            block_size,
+            whitelist: FileType::parse_whitelist(whitelist),
+            file_size_capacity: DEFAULT_FILE_SIZE_CAPACITY,
+        })
+    }
+
     pub(super) fn new(config: LocalCacheConfig) -> crate::Result<Self> {
         let file_size_capacity = config
             .max_size
@@ -92,7 +114,12 @@ impl LocalCache {
         !FileType::is_mutable(path) && self.whitelist.contains(&FileType::classify(path))
     }
 
-    async fn get_block(&self, key: &BlockKey, token: &CacheReadToken) -> Option<bytes::Bytes> {
+    async fn get_block(
+        &self,
+        key: &BlockKey,
+        expected_len: usize,
+        token: &CacheReadToken,
+    ) -> Option<bytes::Bytes> {
         let _prefix_guard = self.coordinator.prefix_read_guard().await;
         let _publish_guard = token.publish_guard().await;
         if !token.is_current() {
@@ -101,6 +128,12 @@ impl LocalCache {
         let payload = match &self.backend {
             CacheBackend::Memory(memory) => memory.get_block(key),
             CacheBackend::Disk(disk) => disk.get_block(key).await,
+            CacheBackend::External(cache) => {
+                let start = key.block_index.checked_mul(key.block_size)?;
+                let length = u64::try_from(expected_len).ok()?;
+                let end = start.checked_add(length)?;
+                cache.get(&key.path, start..end).await
+            }
         };
         if token.is_current() {
             payload
@@ -118,6 +151,11 @@ impl LocalCache {
         match &self.backend {
             CacheBackend::Memory(memory) => memory.put_block(key, payload),
             CacheBackend::Disk(disk) => disk.put_block(key, payload).await,
+            CacheBackend::External(cache) => {
+                if let Some(offset) = key.block_index.checked_mul(key.block_size) {
+                    cache.put(&key.path, offset, payload).await;
+                }
+            }
         }
     }
 
@@ -125,6 +163,7 @@ impl LocalCache {
         match &self.backend {
             CacheBackend::Memory(memory) => memory.remove_block(key),
             CacheBackend::Disk(disk) => disk.remove_block(key).await,
+            CacheBackend::External(cache) => cache.invalidate_path(&key.path).await,
         }
     }
 
@@ -167,6 +206,7 @@ impl LocalCache {
         match &self.backend {
             CacheBackend::Memory(memory) => memory.invalidate_path(&self.namespace, path),
             CacheBackend::Disk(disk) => disk.invalidate_path(&self.namespace, path).await,
+            CacheBackend::External(cache) => cache.invalidate_path(path).await,
         }
     }
 
@@ -181,6 +221,7 @@ impl LocalCache {
         match &self.backend {
             CacheBackend::Memory(memory) => memory.invalidate_prefix(&self.namespace, prefix),
             CacheBackend::Disk(disk) => disk.invalidate_prefix(&self.namespace, prefix).await,
+            CacheBackend::External(cache) => cache.invalidate_prefix(prefix).await,
         }
     }
 }

--- a/crates/paimon/src/io/cache/reader.rs
+++ b/crates/paimon/src/io/cache/reader.rs
@@ -70,7 +70,11 @@ impl CachedFileReader {
             message: format!("Cache block is too large for '{}'", self.path),
             source: None,
         })?;
-        if let Some(payload) = self.cache.get_block(&key, &self.read_token).await {
+        if let Some(payload) = self
+            .cache
+            .get_block(&key, expected_len, &self.read_token)
+            .await
+        {
             if payload.len() == expected_len {
                 return Ok(payload);
             }
@@ -79,7 +83,11 @@ impl CachedFileReader {
 
         let load_lock = self.cache.block_load_lock(&key).await;
         let load_guard = load_lock.lock().await;
-        let result = if let Some(payload) = self.cache.get_block(&key, &self.read_token).await {
+        let result = if let Some(payload) = self
+            .cache
+            .get_block(&key, expected_len, &self.read_token)
+            .await
+        {
             if payload.len() == expected_len {
                 Ok(payload)
             } else {
@@ -182,9 +190,12 @@ impl CachedFileReader {
         let mut output = BytesMut::with_capacity(output_len);
         for block_index in 0..block_count {
             let key = self.cache.block_key(&self.path, block_index);
-            let payload = self.cache.get_block(&key, &self.read_token).await?;
             let start = block_index * block_size;
             let expected_len = (self.file_size - start).min(block_size) as usize;
+            let payload = self
+                .cache
+                .get_block(&key, expected_len, &self.read_token)
+                .await?;
             if payload.len() != expected_len {
                 self.cache.remove_block(&key).await;
                 return None;

--- a/crates/paimon/src/io/file_io.rs
+++ b/crates/paimon/src/io/file_io.rs
@@ -37,6 +37,25 @@ use url::Url;
 use super::cache::{CachedFileReader, LocalCache};
 use super::Storage;
 
+/// An externally managed block cache used by [`FileIO`].
+///
+/// Implementations store immutable file ranges. Cache failures must be handled
+/// as misses/no-ops so the storage backend remains the source of truth.
+#[async_trait::async_trait]
+pub trait FileBlockCache: std::fmt::Debug + Send + Sync + 'static {
+    /// Return the exact requested range on a hit, or `None` on a miss.
+    async fn get(&self, path: &str, range: Range<u64>) -> Option<Bytes>;
+
+    /// Store a range. Implementations may silently decline the write.
+    async fn put(&self, path: &str, offset: u64, data: Bytes);
+
+    /// Remove all cached ranges for one file.
+    async fn invalidate_path(&self, path: &str);
+
+    /// Remove all cached ranges under a directory prefix.
+    async fn invalidate_prefix(&self, prefix: &str);
+}
+
 #[async_trait::async_trait]
 pub(crate) trait FileIOProvider: std::fmt::Debug + Send + Sync {
     async fn create(&self, path: &str) -> crate::Result<(Operator, String)>;
@@ -60,6 +79,24 @@ impl std::fmt::Debug for FileIO {
 }
 
 impl FileIO {
+    /// Attach an externally managed block cache.
+    ///
+    /// `block_size` controls the aligned ranges presented to the cache.
+    /// `whitelist` uses the same comma-separated values as
+    /// `local-cache.whitelist`: `meta`, `global-index`, `bucket-index`, `data`,
+    /// and `file-index`.
+    pub fn with_file_block_cache(
+        mut self,
+        cache: Arc<dyn FileBlockCache>,
+        block_size: u64,
+        whitelist: &str,
+    ) -> crate::Result<Self> {
+        self.cache = Some(Arc::new(LocalCache::external(
+            cache, block_size, whitelist,
+        )?));
+        Ok(self)
+    }
+
     pub(crate) fn with_provider(mut self, provider: Arc<dyn FileIOProvider>) -> Self {
         self.provider = Some(provider);
         self

--- a/docs/src/c-binding.md
+++ b/docs/src/c-binding.md
@@ -176,6 +176,60 @@ paimon_option options[] = {
 paimon_result_catalog_new result = paimon_catalog_create(options, 3);
 ```
 
+## Caller-managed File Cache
+
+Native engines can create a reusable `paimon_file_io` and connect Paimon reads
+to their own block-cache framework. The callback table is versioned so future
+extensions do not change an existing C ABI:
+
+```c
+paimon_file_cache_callbacks_v1 cache = {
+    .context = engine_cache,
+    .get = engine_cache_get,
+    .put = engine_cache_put,
+    .invalidate_path = engine_cache_invalidate_path,
+    .invalidate_prefix = engine_cache_invalidate_prefix,
+    .destroy = engine_cache_release,
+};
+
+paimon_result_file_io_new io_result =
+    paimon_file_io_create_with_cache_v1(
+        "s3://bucket/table",
+        storage_options,
+        storage_options_len,
+        &cache,
+        1024 * 1024,
+        "meta,global-index");
+CHECK_RESULT(io_result);
+
+paimon_result_get_table table_result =
+    paimon_table_from_schema_json_with_file_io(
+        io_result.file_io,
+        "s3://bucket/table",
+        table_schema_json,
+        "default",
+        "orders",
+        NULL);
+CHECK_RESULT(table_result);
+
+// The table retained a FileIO clone.
+paimon_file_io_free(io_result.file_io);
+```
+
+`get` receives an output buffer with exactly `length` writable bytes. It returns
+the number of bytes copied, `-1` for a miss, or any other negative value for a
+fail-open error. A nonnegative value different from `length` is also treated as
+a miss. `put` and invalidation failures are ignored so object storage remains
+the source of truth.
+
+Callbacks may execute concurrently on arbitrary blocking-worker threads and
+must not throw or unwind across the C ABI. Callback cache keys use
+`path_data + path_length` rather than null-terminated strings because canonical
+storage keys may contain embedded NUL separators. Paths and buffers are borrowed
+only for the duration of each call. After successful FileIO creation, Paimon
+owns `context`; `destroy` runs exactly once after the FileIO handle and all
+tables cloned from it have been freed.
+
 ## Reading Arrow Record Batches
 
 Paimon uses a **scan-then-read** flow. A scan creates a plan, and a table read


### PR DESCRIPTION
## Summary

- expose reusable FileIO handles through the C ABI
- add a versioned caller-managed block-cache callback table for get, put, invalidation, and context destruction
- allow catalog-free table construction from a caller-created FileIO
- preserve Rust cache policy, source fallback, and cache invalidation semantics
- document native-engine integration and callback lifetime/threading requirements

## Tests

- cargo test -p paimon-c --lib --locked
- cargo test -p paimon io::cache --locked
- cargo check -p paimon-c --locked
- cargo fmt --all -- --check
- git diff --check

Clippy passes for the changed crates with one pre-existing nonminimal_bool warning in crates/paimon/src/table/object_table.rs:77.