### PR TITLE
build: raise MSRV to Rust 1.94

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,16 @@ jobs:
         run: cargo clippy --locked --all-targets --workspace --features fulltext,vortex -- -D warnings
 
   msrv:
-    runs-on: ubuntu-latest
+    name: msrv (${{ matrix.host }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            host: x86_64-unknown-linux-gnu
+          - runner: macos-15
+            host: aarch64-apple-darwin
     env:
       PYO3_PYTHON: python3.11
     steps:
@@ -135,16 +144,22 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install Rust 1.91.0
-        run: rustup toolchain install 1.91.0 --profile minimal
+      - name: Install Rust 1.94.0
+        run: rustup toolchain install 1.94.0 --profile minimal
+
+      - name: Validate MSRV host
+        env:
+          EXPECTED_HOST: ${{ matrix.host }}
+        run: |
+          rustc +1.94.0 -vV | grep -F "host: ${EXPECTED_HOST}"
 
       - name: Validate workspace MSRV metadata
         run: |
-          cargo +1.91.0 metadata --locked --format-version 1 --no-deps |
-            jq -e '.packages | all(.rust_version == "1.91.0")' >/dev/null
+          cargo +1.94.0 metadata --locked --format-version 1 --no-deps |
+            jq -e '.packages | all(.rust_version == "1.94.0")' >/dev/null
 
       - name: Check workspace at MSRV
-        run: cargo +1.91.0 check --locked --workspace --all-targets --all-features
+        run: cargo +1.94.0 check --locked --workspace --all-targets --all-features
 
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release-go-binding.yml
+++ b/.github/workflows/release-go-binding.yml
@@ -113,7 +113,7 @@ jobs:
             expected_file: libpaimon_c.darwin.amd64.dylib.zst
             rust_target: x86_64-apple-darwin
             license_file: THIRD-PARTY-LICENSES.darwin.amd64.html
-          - runner: macos-14
+          - runner: macos-15
             expected_file: libpaimon_c.darwin.arm64.dylib.zst
             rust_target: aarch64-apple-darwin
             license_file: THIRD-PARTY-LICENSES.darwin.arm64.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ edition = "2021"
 homepage = "https://paimon.apache.org/docs/rust/"
 repository = "https://github.com/apache/paimon-rust"
 license = "Apache-2.0"
-rust-version = "1.91.0"
+rust-version = "1.94.0"
 
 [workspace.dependencies]
 arrow = "58.0"


### PR DESCRIPTION
### Purpose

Fix the declared MSRV for Apple Silicon before the 0.4.0 release.

paimon-vindex-core 0.4.0 uses AArch64 NEON FP16 intrinsics that became stable in Rust 1.94.0. The previous x86_64-only MSRV job did not compile that target-specific path, so Rust 1.91 through 1.93 failed on aarch64-apple-darwin even though the workspace declared Rust 1.91.0.

No linked issue.

### Brief change log

- Raise the workspace rust-version from 1.91.0 to 1.94.0.
- Run the MSRV check on Linux x86_64 and macOS AArch64.
- Assert the actual Rust host on each MSRV runner.
- Move the Darwin ARM64 release build from the deprecated macos-14 image to macos-15.

### Tests

- cargo +1.94.0 check --locked --workspace --all-targets --all-features on Apple Silicon
- cargo clippy --locked --all-targets --workspace --features fulltext,vortex -- -D warnings on Apple Silicon with Rust 1.94.1
- cargo +1.94.0 fmt --all -- --check
- Cargo metadata verifies all workspace packages declare Rust 1.94.0
- GitHub Actions workflow YAML parsing
- git diff --check

### API and Format

No API or storage-format changes. This changes the minimum supported Rust version.

### Documentation

No documentation files changed. The 0.4.0 release notes should call out the MSRV increase from Rust 1.91 to 1.94.