### PR TITLE
fix(c): align append vector filter with core behavior

### DIFF
--- a/bindings/c/src/tests.rs
+++ b/bindings/c/src/tests.rs
@@ -3263,32 +3263,48 @@ fn vector_search_pk_filter_excludes_neighbor() {
 }
 
 #[test]
-fn vector_search_append_filter_returns_invalid_input() {
-    let path = "memory:/vsearch_append_filter_err";
+fn vector_search_append_filter_matches_rust() {
+    let path = "memory:/vsearch_append_filter_read";
     let table = build_append_vector_table(path);
+    let query = [1.0f32, 0.0];
+    let limit = 3;
+
+    let unfiltered = rust_execute_read_pairs(&table, "embedding", query.to_vec(), limit, None);
+    assert!(
+        unfiltered.iter().any(|(id, _)| *id == 0),
+        "fixture must include the filtered nearest neighbor in the unfiltered Top-K"
+    );
+
+    let rust_filter = PredicateBuilder::new(table.schema().fields())
+        .greater_or_equal("id", Datum::Int(1))
+        .unwrap();
+    let rust_pairs = rust_execute_read_pairs(
+        &table,
+        "embedding",
+        query.to_vec(),
+        limit,
+        Some(rust_filter),
+    );
+    assert_eq!(
+        rust_pairs.len(),
+        limit,
+        "filter-before-Top-K must refill the result after excluding id 0"
+    );
+    assert!(
+        rust_pairs.iter().all(|(id, _)| *id >= 1),
+        "Rust core returned a row excluded by the filter"
+    );
+
     let handle = unsafe { wrap_table(table) };
     unsafe {
         let predicate = build_predicate_ge(handle, "id", 1);
-        let builder = c_vector_builder(handle, "embedding", &[1.0f32, 0.0], 3, predicate);
-        let result = paimon_vector_search_builder_execute_read(builder);
-        paimon_vector_search_builder_free(builder);
+        let builder = c_vector_builder(handle, "embedding", &query, limit, predicate);
+        let c_pairs = c_execute_read_pairs(builder);
 
-        assert!(
-            result.reader.is_null(),
-            "errored read must not yield a reader"
-        );
-        assert!(!result.error.is_null(), "DE filter must fail loud");
         assert_eq!(
-            (*result.error).code,
-            PaimonErrorCode::InvalidInput as i32,
-            "DE filter error must map to InvalidInput"
+            c_pairs, rust_pairs,
+            "filtered C pairs must match the Rust core reference"
         );
-        let message = error_message(result.error);
-        assert!(
-            message.contains("primary-key vector path"),
-            "unexpected error message: {message}"
-        );
-        paimon_error_free(result.error);
         unwrap_table(handle);
     }
 }

--- a/bindings/c/src/vector_search.rs
+++ b/bindings/c/src/vector_search.rs
@@ -185,7 +185,10 @@ pub unsafe extern "C" fn paimon_vector_search_builder_with_options(
     std::ptr::null_mut()
 }
 
-/// Set an optional scalar residual filter for a vector-search builder.
+/// Set an optional scalar predicate applied before vector Top-K.
+///
+/// The Rust core resolves the predicate to an allow-list for the selected
+/// primary-key or data-evolution/global-index search path.
 ///
 /// The predicate is consumed (ownership transferred to the builder). Pass null
 /// to clear any previously set filter.


### PR DESCRIPTION
<!--
Thank you very much for contributing to Paimon Rust - we are happy that you want to help us improve it. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/paimon-rust/issues). Exceptions are made for typos in documentation or comments, which need no issue.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `cargo test` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
The C binding test still expected scalar filters on data-evolution vector searches to be rejected, although the Rust core now supports applying them before Top-K.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

  - Update the C vector filter documentation to match the current contract.
  - Replace the obsolete error assertion with a filtered append-table read test.
  - Verify that the C result matches the Rust core and refills the requested Top-K result.

### Tests

<!-- List unit tests or integration cases to verify this change -->

  - `cargo test -p paimon-c --lib`
  - `cargo clippy -p paimon-c --all-targets -- -D warnings`
  - `cargo fmt --all -- --check`
  - `cargo +1.94.0 check --locked --workspace --all-targets --all-features`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature or require documentation updates -->

Updated the inline C API documentation.
