### PR TITLE
fix(vindex): bound a deletion-vector position by its own source file

### DIFF
--- a/crates/paimon/src/vindex/pkvector/ann.rs
+++ b/crates/paimon/src/vindex/pkvector/ann.rs
@@ -121,6 +121,18 @@ pub(crate) fn build_live_row_ids(
         if active {
             if let Some(dv) = deletion_vectors.get(source_file.file_name()) {
                 for position in dv.iter() {
+                    // Bound the position against ITS OWN source file, as the residual
+                    // path above already does. Source files share one ordinal space
+                    // (`global = file_offset + position`), so a position past this
+                    // file's rows does not fall out of the mask -- it lands inside the
+                    // NEXT source file's range and deletes one of that file's rows.
+                    if position >= row_count {
+                        return Err(data_invalid(format!(
+                            "deleted position {position} is out of range for source file {} ({} rows)",
+                            source_file.file_name(),
+                            row_count
+                        )));
+                    }
                     let global = file_offset.checked_add(position).ok_or_else(|| {
                         data_invalid("vector source deleted position overflows u64")
                     })?;
@@ -889,6 +901,38 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(live.iter().collect::<Vec<u64>>(), vec![0, 2]);
+    }
+
+    #[test]
+    fn a_deletion_vector_position_past_its_own_file_is_refused() {
+        // f0 holds 3 rows (global 0,1,2) and f1 holds 2 (global 3,4). A deletion
+        // vector on f0 naming position 3 has no row of f0 to delete; without the
+        // bound it becomes global 0 + 3 = 3, which is f1's FIRST row. The mask would
+        // come back well-formed, having silently dropped a row of a different file.
+        let files = vec![
+            PkVectorSourceFile::new("f0".into(), 3).unwrap(),
+            PkVectorSourceFile::new("f1".into(), 2).unwrap(),
+        ];
+        let mut dvs = HashMap::new();
+        dvs.insert("f0".to_string(), dv(&[3]));
+        let error = build_live_row_ids(&files, &active_set(&["f0", "f1"]), &dvs, None)
+            .map(|_| ())
+            .expect_err("a position past f0's rows names no row of f0");
+        assert!(
+            error
+                .to_string()
+                .contains("out of range for source file f0"),
+            "{error}"
+        );
+
+        // The last VALID position of f0 still deletes f0's own row, and f1 is
+        // untouched -- the bound is `>= row_count`, not one row tighter.
+        let mut dvs = HashMap::new();
+        dvs.insert("f0".to_string(), dv(&[2]));
+        let live = build_live_row_ids(&files, &active_set(&["f0", "f1"]), &dvs, None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(live.iter().collect::<Vec<u64>>(), vec![0, 1, 3, 4]);
     }
 
     #[test]


### PR DESCRIPTION
### Purpose

Split out of #771 at the reviewer's request: an independent hardening fix that was riding along in that PR.

An ANN segment's source files share one ordinal space — a position is mapped to `global = file_offset + position`. `build_live_row_ids` bounds the residual predicate's positions against the source file they belong to, but not the deletion vector's.

A deletion-vector position past its own file's row count therefore does not fall *outside* the mask. It lands inside the **next** source file's ordinal range and deletes one of THAT file's rows. The mask comes back well formed, so nothing downstream can tell that a row of an unrelated file was dropped.

### Brief change log

- Bound each deletion-vector position by its own source file's row count in `build_live_row_ids` (`crates/paimon/src/vindex/pkvector/ann.rs`), with the same message shape the residual path already uses.

The check is `>= row_count`, so a file's last valid position still deletes its own row.

### Tests

- `a_deletion_vector_position_past_its_own_file_is_refused` — two files of 3 and 2 rows; a deletion vector on the first naming position 3 would otherwise delete the second file's first row. Also pins the boundary in the other direction: position 2 still deletes the first file's own last row and leaves the second file untouched.
- Mutation-checked: replacing the new condition with `false` fails this test and nothing else.
- `cargo test -p paimon --lib`: 2622 passed, 2 ignored.
- `cargo clippy -p paimon --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean.

### API and Format

No public API or storage-format change. A malformed deletion vector that used to corrupt the mask silently is now refused as `DataInvalid`.

### Documentation

None needed.
