### PR TITLE
fix(table): skip staging files and list format table partitions concurrently

### DIFF
--- a/crates/paimon/src/spec/core_options.rs
+++ b/crates/paimon/src/spec/core_options.rs
@@ -44,6 +44,9 @@ const PARTITION_DEFAULT_NAME_OPTION: &str = "partition.default-name";
 const PARTITION_LEGACY_NAME_OPTION: &str = "partition.legacy-name";
 const FORMAT_TABLE_PARTITION_PATH_ONLY_VALUE_OPTION: &str =
     "format-table.partition-path-only-value";
+const FORMAT_TABLE_SCAN_LIST_PARALLELISM_OPTION: &str = "format-table.scan.list-parallelism";
+const DEFAULT_FORMAT_TABLE_SCAN_LIST_PARALLELISM: usize = 64;
+const MAX_FORMAT_TABLE_SCAN_LIST_PARALLELISM: i64 = 1000;
 pub(crate) const BUCKET_KEY_OPTION: &str = "bucket-key";
 const BUCKET_FUNCTION_TYPE_OPTION: &str = "bucket-function.type";
 const BUCKET_OPTION: &str = "bucket";
@@ -648,6 +651,18 @@ impl<'a> CoreOptions<'a> {
             .and_then(|s| s.parse().ok())
             .unwrap_or(DEFAULT_DIFF_PARALLELISM)
             .max(1)
+    }
+
+    /// How many partition directories a Format Table scan lists at once
+    /// (`format-table.scan.list-parallelism`).
+    ///
+    /// Default is 64; values are clamped to `[1, 1000]`, as Java clamps them.
+    pub fn format_table_scan_list_parallelism(&self) -> usize {
+        self.options
+            .get(FORMAT_TABLE_SCAN_LIST_PARALLELISM_OPTION)
+            .and_then(|value| value.trim().parse::<i64>().ok())
+            .map(|value| value.clamp(1, MAX_FORMAT_TABLE_SCAN_LIST_PARALLELISM) as usize)
+            .unwrap_or(DEFAULT_FORMAT_TABLE_SCAN_LIST_PARALLELISM)
     }
 
     pub fn data_evolution_enabled(&self) -> bool {
@@ -2258,6 +2273,28 @@ mod tests {
         )]);
         let core = CoreOptions::new(&options);
         assert!(core.format_table_partition_only_value_in_path());
+    }
+
+    #[test]
+    fn test_format_table_scan_list_parallelism() {
+        let parallelism = |value: Option<&str>| {
+            let options = value
+                .map(|value| {
+                    HashMap::from([(
+                        FORMAT_TABLE_SCAN_LIST_PARALLELISM_OPTION.to_string(),
+                        value.to_string(),
+                    )])
+                })
+                .unwrap_or_default();
+            CoreOptions::new(&options).format_table_scan_list_parallelism()
+        };
+
+        assert_eq!(parallelism(None), 64);
+        assert_eq!(parallelism(Some("8")), 8);
+        assert_eq!(parallelism(Some("0")), 1);
+        assert_eq!(parallelism(Some("-3")), 1);
+        assert_eq!(parallelism(Some("5000")), 1000);
+        assert_eq!(parallelism(Some("many")), 64);
     }
 
     #[test]

--- a/crates/paimon/src/table/format_table_scan.rs
+++ b/crates/paimon/src/table/format_table_scan.rs
@@ -88,12 +88,24 @@ impl<'a> FormatTableScan<'a> {
             .to_string();
 
         let partition_fields = self.table.schema().partition_fields();
+        let table_depth = path_segments(&table_path).len();
         let mut splits = Vec::new();
         for scan_root in self.scan_roots(&core_options, &table_path)? {
+            let root_segments = path_segments(&scan_root.path);
+            let partition_levels_below_root = partition_fields
+                .len()
+                .saturating_sub(root_segments.len().saturating_sub(table_depth));
             let statuses = self
                 .list_status_recursive_if_exists(&scan_root.path)
                 .await?;
             for status in statuses {
+                if is_hidden_below_partitions(
+                    &root_segments,
+                    partition_levels_below_root,
+                    &status.path,
+                ) {
+                    continue;
+                }
                 if let Some(split) = self
                     .status_to_split(
                         status,
@@ -310,6 +322,43 @@ struct ScanRoot {
 
 fn is_format_table_data_file_name(file_name: &str) -> bool {
     !file_name.is_empty() && !file_name.starts_with('.') && !file_name.starts_with('_')
+}
+
+/// Whether a listed file is, or lies inside, an entry whose name starts with `.` or `_` below
+/// the partition directories, such as a committer staging tree (`_temporary`, `__magic_*`)
+/// whose files may never be committed.
+///
+/// Partition directories are exempt: a value-only layout names the null partition
+/// `__DEFAULT_PARTITION__`. `partition_levels_below_root` is how many partition levels still
+/// lie under the scan root.
+fn is_hidden_below_partitions(
+    root_segments: &[&str],
+    partition_levels_below_root: usize,
+    file_path: &str,
+) -> bool {
+    let segments = path_segments(file_path);
+    // A listing may spell the scheme differently from the root (`file:/` against `file:///`),
+    // so what lies below the root is found by segments, not by string prefix. A path outside the
+    // root is left to the file-name check.
+    let Some(below_root) = segments.strip_prefix(root_segments) else {
+        return false;
+    };
+    below_root
+        .iter()
+        .skip(partition_levels_below_root)
+        .any(|segment| segment.starts_with('.') || segment.starts_with('_'))
+}
+
+/// The non-empty segments of a path, without its scheme.
+fn path_segments(path: &str) -> Vec<&str> {
+    let without_scheme = match path.find("://") {
+        Some(index) => &path[index + 3..],
+        None => path.split_once(':').map_or(path, |(_, rest)| rest),
+    };
+    without_scheme
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect()
 }
 
 fn split_parent_and_file(path: &str) -> Option<(&str, &str)> {
@@ -676,6 +725,205 @@ fn data_file_meta(file_name: String, file_size: i64, schema_id: i64) -> DataFile
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::catalog::Identifier;
+    use crate::io::FileIOBuilder;
+    use crate::spec::{IntType, Schema, TableSchema, VarCharType};
+    use bytes::Bytes;
+    use std::collections::HashSet;
+
+    /// A Parquet format table in memory, partitioned by the given string keys.
+    fn format_table(location: &str, partition_keys: &[&str], options: &[(&str, &str)]) -> Table {
+        let mut builder = Schema::builder();
+        for key in partition_keys {
+            builder = builder.column(*key, DataType::VarChar(VarCharType::string_type()));
+        }
+        builder = builder
+            .column("id", DataType::Int(IntType::new()))
+            .partition_keys(partition_keys.iter().map(|key| key.to_string()))
+            .option("type", "format-table")
+            .option("file.format", "parquet");
+        for (key, value) in options {
+            builder = builder.option(*key, *value);
+        }
+        Table::new(
+            FileIOBuilder::new("memory").build().unwrap(),
+            Identifier::new("default", "format_t"),
+            location.to_string(),
+            TableSchema::new(0, &builder.build().unwrap()),
+            None,
+        )
+    }
+
+    /// Planning only lists files, so their content never has to be valid Parquet.
+    async fn write_files(table: &Table, relative_paths: &[&str]) {
+        for relative_path in relative_paths {
+            let path = format!("{}/{relative_path}", table.location().trim_end_matches('/'));
+            table
+                .file_io()
+                .new_output(&path)
+                .unwrap()
+                .write(Bytes::from_static(b"planned, never read"))
+                .await
+                .unwrap();
+        }
+    }
+
+    /// The planned files, relative to the table directory, in plan order.
+    async fn planned_files(table: &Table, filter: Option<PartitionFilter>) -> Vec<String> {
+        let table_prefix = format!("{}/", table.location().trim_end_matches('/'));
+        let plan = FormatTableScan::new(table, filter, None, None)
+            .plan()
+            .await
+            .unwrap();
+        plan.splits()
+            .iter()
+            .map(|split| {
+                let path = format!(
+                    "{}/{}",
+                    split.bucket_path(),
+                    split.data_files()[0].file_name
+                );
+                path.strip_prefix(&table_prefix)
+                    .map_or(path.clone(), str::to_string)
+            })
+            .collect()
+    }
+
+    /// A filter naming exactly one partition; `None` is the null partition.
+    fn partition_set(table: &Table, values: &[Option<&str>]) -> PartitionFilter {
+        let partition_fields = table.schema().partition_fields();
+        let mut builder = BinaryRowBuilder::new(values.len() as i32);
+        for (index, value) in values.iter().enumerate() {
+            match value {
+                Some(value) => builder.write_datum(
+                    index,
+                    &Datum::String(value.to_string()),
+                    partition_fields[index].data_type(),
+                ),
+                None => builder.set_null_at(index),
+            }
+        }
+        PartitionFilter::from_partition_set(
+            HashSet::from([builder.build_serialized()]),
+            &partition_fields,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_hidden_names_count_only_below_the_partition_levels() {
+        let table_root = path_segments("file:///warehouse/db.db/t");
+        assert!(!is_hidden_below_partitions(
+            &table_root,
+            2,
+            "file:/warehouse/db.db/t/__DEFAULT_PARTITION__/b/part-0.parquet"
+        ));
+        assert!(is_hidden_below_partitions(
+            &table_root,
+            2,
+            "file:/warehouse/db.db/t/a/b/_temporary/0/part-0.parquet"
+        ));
+        assert!(is_hidden_below_partitions(
+            &table_root,
+            2,
+            "file:/warehouse/db.db/t/a/b/.part-0.parquet"
+        ));
+
+        // A root one level down, as a leading-equality scan plans it, has one partition level left.
+        let leading_root = path_segments("file:///warehouse/db.db/t/dt=a");
+        assert!(!is_hidden_below_partitions(
+            &leading_root,
+            1,
+            "file:/warehouse/db.db/t/dt=a/hh=__DEFAULT_PARTITION__/part-0.parquet"
+        ));
+        assert!(is_hidden_below_partitions(
+            &leading_root,
+            1,
+            "file:/warehouse/db.db/t/dt=a/hh=1/__magic_job/part-0.parquet"
+        ));
+
+        let partition_root = path_segments("file:///warehouse/db.db/t/dt=a/hh=1");
+        assert!(!is_hidden_below_partitions(
+            &partition_root,
+            0,
+            "file:/warehouse/db.db/t/dt=a/hh=1/part-0.parquet"
+        ));
+        assert!(!is_hidden_below_partitions(
+            &partition_root,
+            0,
+            "file:/elsewhere/_temporary/part-0.parquet"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_scan_skips_committer_staging_files_of_an_unpartitioned_table() {
+        let table = format_table("memory:/staging_unpartitioned", &[], &[]);
+        write_files(
+            &table,
+            &[
+                "part-0.parquet",
+                "_temporary/0/_temporary/attempt_0/part-1.parquet",
+                "__magic_job_1/tasks/part-2.parquet",
+                ".spark-staging-1/part-3.parquet",
+            ],
+        )
+        .await;
+
+        assert_eq!(planned_files(&table, None).await, vec!["part-0.parquet"]);
+    }
+
+    #[tokio::test]
+    async fn test_scan_skips_committer_staging_files_below_a_partition_directory() {
+        let table = format_table("memory:/staging_partitioned", &["dt"], &[]);
+        write_files(
+            &table,
+            &[
+                "dt=a/part-0.parquet",
+                "dt=a/_temporary/0/_temporary/attempt_0/part-1.parquet",
+                "dt=a/__magic_job_1/tasks/part-2.parquet",
+                "dt=b/part-3.parquet",
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            planned_files(&table, None).await,
+            vec!["dt=a/part-0.parquet", "dt=b/part-3.parquet"]
+        );
+        let only_a = partition_set(&table, &[Some("a")]);
+        assert_eq!(
+            planned_files(&table, Some(only_a)).await,
+            vec!["dt=a/part-0.parquet"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_scan_still_reads_a_value_only_default_partition_directory() {
+        let table = format_table(
+            "memory:/staging_value_only",
+            &["dt"],
+            &[("format-table.partition-path-only-value", "true")],
+        );
+        write_files(
+            &table,
+            &[
+                "__DEFAULT_PARTITION__/part-0.parquet",
+                "__DEFAULT_PARTITION__/_temporary/0/part-1.parquet",
+                "b/part-2.parquet",
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            planned_files(&table, None).await,
+            vec!["__DEFAULT_PARTITION__/part-0.parquet", "b/part-2.parquet"]
+        );
+        let null_partition = partition_set(&table, &[None]);
+        assert_eq!(
+            planned_files(&table, Some(null_partition)).await,
+            vec!["__DEFAULT_PARTITION__/part-0.parquet"]
+        );
+    }
 
     #[test]
     fn test_unsupported_format_lists_the_supported_ones() {

--- a/crates/paimon/src/table/format_table_scan.rs
+++ b/crates/paimon/src/table/format_table_scan.rs
@@ -26,6 +26,7 @@ use crate::spec::{
 use crate::table::partition_filter::PartitionFilter;
 use crate::table::source::{DataSplitBuilder, RowRange};
 use chrono::NaiveDate;
+use futures::{StreamExt, TryStreamExt};
 
 #[derive(Debug, Clone)]
 pub(crate) struct FormatTableScan<'a> {
@@ -89,38 +90,49 @@ impl<'a> FormatTableScan<'a> {
 
         let partition_fields = self.table.schema().partition_fields();
         let table_depth = path_segments(&table_path).len();
-        let mut splits = Vec::new();
-        for scan_root in self.scan_roots(&core_options, &table_path)? {
-            let root_segments = path_segments(&scan_root.path);
-            let partition_levels_below_root = partition_fields
-                .len()
-                .saturating_sub(root_segments.len().saturating_sub(table_depth));
-            let statuses = self
-                .list_status_recursive_if_exists(&scan_root.path)
-                .await?;
-            for status in statuses {
-                if is_hidden_below_partitions(
-                    &root_segments,
-                    partition_levels_below_root,
-                    &status.path,
-                ) {
-                    continue;
+        let scan_roots = self.scan_roots(&core_options, &table_path)?;
+        // A table with many partitions pays one listing per partition, so they run concurrently.
+        // `buffered` keeps the roots in order and stops at the first failure.
+        let table_path = table_path.as_str();
+        let partition_fields = partition_fields.as_slice();
+        let listed: Vec<Vec<crate::DataSplit>> = futures::stream::iter(scan_roots)
+            .map(|scan_root| async move {
+                let root_segments = path_segments(&scan_root.path);
+                let partition_levels_below_root = partition_fields
+                    .len()
+                    .saturating_sub(root_segments.len().saturating_sub(table_depth));
+                let statuses = self
+                    .list_status_recursive_if_exists(&scan_root.path)
+                    .await?;
+                let mut splits = Vec::new();
+                for status in statuses {
+                    if is_hidden_below_partitions(
+                        &root_segments,
+                        partition_levels_below_root,
+                        &status.path,
+                    ) {
+                        continue;
+                    }
+                    if let Some(split) = self
+                        .status_to_split(
+                            status,
+                            table_path,
+                            format_extension,
+                            schema_id,
+                            partition_fields,
+                            scan_root.partition.clone(),
+                        )
+                        .await?
+                    {
+                        splits.push(split);
+                    }
                 }
-                if let Some(split) = self
-                    .status_to_split(
-                        status,
-                        &table_path,
-                        format_extension,
-                        schema_id,
-                        &partition_fields,
-                        scan_root.partition.clone(),
-                    )
-                    .await?
-                {
-                    splits.push(split);
-                }
-            }
-        }
+                Ok::<_, crate::Error>(splits)
+            })
+            .buffered(core_options.format_table_scan_list_parallelism())
+            .try_collect()
+            .await?;
+        let mut splits = listed.into_iter().flatten().collect::<Vec<_>>();
 
         splits.sort_by(|left, right| {
             left.bucket_path().cmp(right.bucket_path()).then_with(|| {
@@ -789,25 +801,27 @@ mod tests {
             .collect()
     }
 
-    /// A filter naming exactly one partition; `None` is the null partition.
-    fn partition_set(table: &Table, values: &[Option<&str>]) -> PartitionFilter {
+    /// A filter naming exactly the given partitions; `None` is a null partition value.
+    fn partition_set(table: &Table, partitions: &[&[Option<&str>]]) -> PartitionFilter {
         let partition_fields = table.schema().partition_fields();
-        let mut builder = BinaryRowBuilder::new(values.len() as i32);
-        for (index, value) in values.iter().enumerate() {
-            match value {
-                Some(value) => builder.write_datum(
-                    index,
-                    &Datum::String(value.to_string()),
-                    partition_fields[index].data_type(),
-                ),
-                None => builder.set_null_at(index),
-            }
-        }
-        PartitionFilter::from_partition_set(
-            HashSet::from([builder.build_serialized()]),
-            &partition_fields,
-        )
-        .unwrap()
+        let partitions = partitions
+            .iter()
+            .map(|values| {
+                let mut builder = BinaryRowBuilder::new(values.len() as i32);
+                for (index, value) in values.iter().enumerate() {
+                    match value {
+                        Some(value) => builder.write_datum(
+                            index,
+                            &Datum::String(value.to_string()),
+                            partition_fields[index].data_type(),
+                        ),
+                        None => builder.set_null_at(index),
+                    }
+                }
+                builder.build_serialized()
+            })
+            .collect::<HashSet<_>>();
+        PartitionFilter::from_partition_set(partitions, &partition_fields).unwrap()
     }
 
     #[test]
@@ -890,7 +904,7 @@ mod tests {
             planned_files(&table, None).await,
             vec!["dt=a/part-0.parquet", "dt=b/part-3.parquet"]
         );
-        let only_a = partition_set(&table, &[Some("a")]);
+        let only_a = partition_set(&table, &[&[Some("a")]]);
         assert_eq!(
             planned_files(&table, Some(only_a)).await,
             vec!["dt=a/part-0.parquet"]
@@ -918,11 +932,60 @@ mod tests {
             planned_files(&table, None).await,
             vec!["__DEFAULT_PARTITION__/part-0.parquet", "b/part-2.parquet"]
         );
-        let null_partition = partition_set(&table, &[None]);
+        let null_partition = partition_set(&table, &[&[None]]);
         assert_eq!(
             planned_files(&table, Some(null_partition)).await,
             vec!["__DEFAULT_PARTITION__/part-0.parquet"]
         );
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_listing_keeps_the_plan_order() {
+        let partitions = ["a", "b", "c", "d", "e", "f", "g", "h"];
+        // Written in reverse, so the plan order owes nothing to the order of the writes.
+        let files = partitions
+            .iter()
+            .rev()
+            .flat_map(|dt| {
+                [
+                    format!("dt={dt}/part-1.parquet"),
+                    format!("dt={dt}/part-0.parquet"),
+                ]
+            })
+            .collect::<Vec<_>>();
+        let file_names = files.iter().map(String::as_str).collect::<Vec<_>>();
+        let expected = partitions
+            .iter()
+            .flat_map(|dt| {
+                [
+                    format!("dt={dt}/part-0.parquet"),
+                    format!("dt={dt}/part-1.parquet"),
+                ]
+            })
+            .collect::<Vec<_>>();
+        let rows = partitions.iter().map(|dt| [Some(*dt)]).collect::<Vec<_>>();
+        let every_partition = rows.iter().map(|row| row.as_slice()).collect::<Vec<_>>();
+
+        for parallelism in ["1", "4"] {
+            let table = format_table(
+                &format!("memory:/listing_order_{parallelism}"),
+                &["dt"],
+                &[("format-table.scan.list-parallelism", parallelism)],
+            );
+            write_files(&table, &file_names).await;
+
+            let filter = partition_set(&table, &every_partition);
+            assert_eq!(
+                planned_files(&table, Some(filter)).await,
+                expected,
+                "one listing per partition, parallelism {parallelism}"
+            );
+            assert_eq!(
+                planned_files(&table, None).await,
+                expected,
+                "one listing of the table, parallelism {parallelism}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Purpose

Split out of #591 so it can be reviewed and merged on its own. It changes how a format table scan lists data files, for every format table, not only catalog-managed ones.

- **Staging files were planned as data.** The scan listed everything below its root and only checked the file's own name. A file a committer stages below a partition directory, such as `dt=a/_temporary/0/_temporary/attempt_0/part-1.parquet` or `dt=a/__magic_job/.../part-2.parquet`, was planned and read even though its job may never commit. The same happened below the root of an unpartitioned table.
- **Partition directories were listed one after another.** A scan planned over many partitions paid one sequential listing per partition.

### Brief change log

- `fix(table): skip committer staging files under format table partitions`: a listed file is skipped once any directory or file name below the partition directories starts with `.` or `_`, the rule apache/paimon#8861 gives the Java reader. Partition directories stay exempt, so a value-only layout still reads `__DEFAULT_PARTITION__`. Paths are compared by segments without the scheme, since a listing may spell `file:/` where the root says `file:///`.
- `fix(table): list format table partitions concurrently`: scan roots are listed through a bounded, ordered stream sized by the new `format-table.scan.list-parallelism` option (default 64, clamped to [1, 1000] like Java). Java reads the option only for catalog-managed partitions; here it bounds every format table scan. Plan order is unchanged and the first listing failure still fails the scan.

### Tests

- `format_table_scan::tests`, on an in-memory warehouse:
  - `test_scan_skips_committer_staging_files_of_an_unpartitioned_table`
  - `test_scan_skips_committer_staging_files_below_a_partition_directory` (full scan and a partition-set scan)
  - `test_scan_still_reads_a_value_only_default_partition_directory` (full scan and the null partition)
  - `test_hidden_names_count_only_below_the_partition_levels` (table, leading-prefix and partition roots, mixed scheme spellings)
  - `test_concurrent_listing_keeps_the_plan_order` (eight partitions, parallelism 1 and 4)
- `core_options::tests::test_format_table_scan_list_parallelism`

The three staging tests fail on `main` without the fix: every staging file shows up in the plan.

Commands run:

```
cargo fmt --all -- --check
cargo clippy --locked --all-targets --workspace --features fulltext,vortex -- -D warnings
cargo test --locked -p paimon --all-targets --features fulltext,vortex
cargo test --locked -p paimon-datafusion --all-targets
```

Locally, 39 `paimon-datafusion` tests fail because they read fixture tables provisioned by `make docker-up` (two also need the lumina native library). The same 39 fail by name on `main` in this environment; everything else passes.

### API and Format

Adds the table option `format-table.scan.list-parallelism` and `CoreOptions::format_table_scan_list_parallelism`. No storage format change.

### Documentation

No documentation change; the option carries its default and bounds in its doc comment.
